### PR TITLE
Build and publish binaries on tag

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,23 @@
+workflow "Publish binaries on release" {
+  resolves = ["publish"]
+  on = "push"
+}
+
+action "release-tag" {
+  uses = "actions/bin/filter@master"
+  args = "tag"
+}
+
+action "build" {
+  uses = "sosedoff/actions/golang-build@master"
+  env = {
+    GO111MODULE = "on"
+  }
+  needs = ["release-tag"]
+}
+
+action "publish" {
+  uses = "docker://moonswitch/github-upload-release:master"
+  secrets = ["GITHUB_TOKEN"]
+  needs = ["build"]
+}


### PR DESCRIPTION
When we tag a new version, this will initiate a Github Actions workflow that will build the binaries for each platform and publish them to the Github Release.