### PR TITLE
Fix naming of binaries on release

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -9,7 +9,7 @@ action "release-tag" {
 }
 
 action "build" {
-  uses = "sosedoff/actions/golang-build@master"
+  uses = "./actions/builder"
   env = {
     GO111MODULE = "on"
   }

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ terraform-provider-octopusdeploy.exe
 main.tf
 build/
 artifacts/
+.release/
 
 node_modules/
 .env

--- a/actions/builder/Dockerfile
+++ b/actions/builder/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.11
+
+LABEL "name"="Go Builder"
+LABEL "version"="0.2.0"
+
+LABEL "com.github.actions.name"="Go Builder"
+LABEL "com.github.actions.description"="Cross-complile Go programs"
+LABEL "com.github.actions.icon"="package"
+LABEL "com.github.actions.color"="#E0EBF5"
+
+RUN \
+  apt-get update && \
+  apt-get install -y ca-certificates openssl zip && \
+  update-ca-certificates && \
+  rm -rf /var/lib/apt
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/builder/README.md
+++ b/actions/builder/README.md
@@ -1,0 +1,60 @@
+# Go Builder
+
+This action is adapted from https://github.com/sosedoff/actions/tree/master/golang-build
+
+Github Action to cross-compile Go project binaries for multiple platforms in a single run.
+
+Uses `golang:1.11` Docker image with `CGO_ENABLED=0` flag.
+
+## Usage
+
+Basic usage:
+
+```
+action "build" {
+  uses = "./actions/build"
+}
+```
+
+Basic workflow configuration will compile binaries for the following platforms:
+
+- linux: 386/amd64
+- darwin: 386/amd64
+- windows: 386/amd64 
+
+Alternatively you can provide a list of target architectures in `arg`:
+
+```
+action "build" {
+  uses = "./actions/build"
+  args = "linux/amd64 darwin/amd64"
+}
+```
+
+Example output:
+
+```
+----> Setting up Go repository
+----> Building project for: darwin/amd64
+  adding: test-go-action_darwin_amd64 (deflated 50%)
+----> Building project for: darwin/386
+  adding: test-go-action_darwin_386 (deflated 45%)
+----> Building project for: linux/amd64
+  adding: test-go-action_linux_amd64 (deflated 50%)
+----> Building project for: linux/386
+  adding: test-go-action_linux_386 (deflated 45%)
+----> Building project for: windows/amd64
+  adding: test-go-action_windows_amd64 (deflated 50%)
+----> Building project for: windows/386
+  adding: test-go-action_windows_386 (deflated 46%)
+----> Build is complete. List of files at /github/workspace/.release:
+total 16436
+drwxr-xr-x 2 root root    4096 Feb  5 00:03 .
+drwxr-xr-x 5 root root    4096 Feb  5 00:02 ..
+-rw-r--r-- 1 root root  978566 Feb  5 00:02 test-go-action_darwin_386.zip
+-rw-r--r-- 1 root root 1008819 Feb  5 00:02 test-go-action_darwin_amd64.zip
+-rw-r--r-- 1 root root  918555 Feb  5 00:02 test-go-action_linux_386.zip
+-rw-r--r-- 1 root root  952985 Feb  5 00:02 test-go-action_linux_amd64.zip
+-rw-r--r-- 1 root root  930942 Feb  5 00:03 test-go-action_windows_386.zip
+-rw-r--r-- 1 root root  972286 Feb  5 00:02 test-go-action_windows_amd64.zip
+```

--- a/actions/builder/entrypoint.sh
+++ b/actions/builder/entrypoint.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -e
+
+if [[ -z "$GITHUB_WORKSPACE" ]]; then
+  echo "Set the GITHUB_WORKSPACE env variable."
+  exit 1
+fi
+
+if [[ -z "$GITHUB_REPOSITORY" ]]; then
+  echo "Set the GITHUB_REPOSITORY env variable."
+  exit 1
+fi
+
+if [[ -z "$GITHUB_REF" ]]; then
+    echo "Set the GITHUB_REF env variable."
+    exit 1
+fi
+
+# Regex and validate-version function adapted from https://github.com/fsaintjacques/semver-tool/blob/master/src/semver
+SEMVER_REGEX="^[v]?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+function validate-version {
+  local version=$1
+  if [[ "$version" =~ $SEMVER_REGEX ]]; then
+    # if a second argument is passed, store the result in var named by $2
+    if [ "$#" -eq "2" ]; then
+      local major=${BASH_REMATCH[1]}
+      local minor=${BASH_REMATCH[2]}
+      local patch=${BASH_REMATCH[3]}
+      local prere=${BASH_REMATCH[4]}
+      local build=${BASH_REMATCH[5]}
+      eval "$2=(\"$major\" \"$minor\" \"$patch\" \"$prere\" \"$build\")"
+    else
+      echo "$version"
+    fi
+  else
+    echo -e "version '$version' does not match the semver scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'. Ensure this action is being run for a tag and not a branch." >&2
+    exit 1
+  fi
+}
+
+root_path="/go/src/github.com/$GITHUB_REPOSITORY"
+release_path="$GITHUB_WORKSPACE/.release"
+repo_name="$(echo $GITHUB_REPOSITORY | cut -d '/' -f2)"
+targets=${@-"darwin/amd64 darwin/386 linux/amd64 linux/386 windows/amd64 windows/386"}
+version="${GITHUB_REF##*/}"
+
+validate-version $version
+
+echo "----> Setting up Go repository"
+mkdir -p $release_path
+mkdir -p $root_path
+cp -a $GITHUB_WORKSPACE/* $root_path/
+cd $root_path
+
+for target in $targets; do
+  os="$(echo $target | cut -d '/' -f1)"
+  arch="$(echo $target | cut -d '/' -f2)"
+  output="${release_path}/${repo_name}_${os}_${arch}_${version}"
+  binary_name="${output}"
+
+  if [[ "$os" == "windows" ]]; then
+    binary_name="$binary_name.exe"
+  fi
+
+  echo "----> Building project for: $target"
+  GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $binary_name
+  zip -j $output.zip $binary_name > /dev/null
+  rm -rf $binary_name
+done
+
+echo "----> Build is complete. List of files at $release_path:"
+cd $release_path
+ls -al


### PR DESCRIPTION
This adds the version number to the binaries to allow for Terraform provider version restrictions:

```
provider "octopusdeploy" {
  version = "~> 0.1.0"
  ...
}
```

This also ensures windows binaries have the `.exe` extension