### PR TITLE
Add Kubernetes deployment target support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy v1.3.0
+	github.com/OctopusDeploy/go-octopusdeploy v1.4.0
 	github.com/apparentlymart/go-cidr v1.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.15.53 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/OctopusDeploy/go-octopusdeploy v1.2.1 h1:wfyln0AKOg74dBJM6V2hKHxskXQz
 github.com/OctopusDeploy/go-octopusdeploy v1.2.1/go.mod h1:WyBvcyhFPMULbZwFFWOmt6/irqrfZ/WqCy7ufa8/CGE=
 github.com/OctopusDeploy/go-octopusdeploy v1.3.0 h1:ZekYly62VzsHx7PHSSPI8bOKMNNz1DhlonIeWdPobO8=
 github.com/OctopusDeploy/go-octopusdeploy v1.3.0/go.mod h1:WyBvcyhFPMULbZwFFWOmt6/irqrfZ/WqCy7ufa8/CGE=
+github.com/OctopusDeploy/go-octopusdeploy v1.4.0 h1:uTBRPoGcS3tN40LKQb70xq+m/hpKX1fExfLhGAAxHDk=
+github.com/OctopusDeploy/go-octopusdeploy v1.4.0/go.mod h1:WyBvcyhFPMULbZwFFWOmt6/irqrfZ/WqCy7ufa8/CGE=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-cidr v1.0.0 h1:lGDvXx8Lv9QHjrAVP7jyzleG4F9+FkRhJcEsDFxeb8w=

--- a/octopusdeploy/data_machine.go
+++ b/octopusdeploy/data_machine.go
@@ -117,7 +117,7 @@ func dataMachineReadByName(d *schema.ResourceData, m interface{}) error {
 	client := m.(*octopusdeploy.Client)
 
 	machineName := d.Get("name").(string)
-	machines, err := client.Machine.GetAll()
+	machine, err := client.Machine.GetByName(machineName)
 	if err == octopusdeploy.ErrItemNotFound {
 		return nil
 	}
@@ -125,34 +125,29 @@ func dataMachineReadByName(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("error reading machine with name %s: %s", machineName, err.Error())
 	}
 
-	for _, m := range *machines {
-		if m.Name == machineName {
-			d.SetId(m.ID)
-			d.Set("endpoint_communicationstyle", m.Endpoint.CommunicationStyle)
-			d.Set("endpoint_id", m.Endpoint.ID)
-			d.Set("endpoint_proxyid", m.Endpoint.ProxyID)
-			d.Set("endpoint_tentacleversiondetails_upgradelocked", m.Endpoint.TentacleVersionDetails.UpgradeLocked)
-			d.Set("endpoint_tentacleversiondetails_upgraderequired", m.Endpoint.TentacleVersionDetails.UpgradeRequired)
-			d.Set("endpoint_tentacleversiondetails_upgradesuggested", m.Endpoint.TentacleVersionDetails.UpgradeSuggested)
-			d.Set("endpoint_tentacleversiondetails_version", m.Endpoint.TentacleVersionDetails.Version)
-			d.Set("endpoint_thumbprint", m.Endpoint.Thumbprint)
-			d.Set("endpoint_uri", m.Endpoint.URI)
-			d.Set("environments", m.EnvironmentIDs)
-			d.Set("haslatestcalamari", m.HasLatestCalamari)
-			d.Set("isdisabled", m.IsDisabled)
-			d.Set("isinprocess", m.IsInProcess)
-			d.Set("machinepolicy", m.MachinePolicyID)
-			d.Set("roles", m.Roles)
-			d.Set("status", m.Status)
-			d.Set("statussummary", m.StatusSummary)
-			d.Set("tenanteddeploymentparticipation", m.TenantedDeploymentParticipation)
-			d.Set("tenantids", m.TenantIDs)
-			d.Set("tenanttags", m.TenantTags)
-			//d.Set("thumbprint", m.Thumbprint)
-			//d.Set("uri", m.URI)
-
-		}
-	}
+	d.SetId(machine.ID)
+	d.Set("endpoint_communicationstyle", machine.Endpoint.CommunicationStyle)
+	d.Set("endpoint_id", machine.Endpoint.ID)
+	d.Set("endpoint_proxyid", machine.Endpoint.ProxyID)
+	d.Set("endpoint_tentacleversiondetails_upgradelocked", machine.Endpoint.TentacleVersionDetails.UpgradeLocked)
+	d.Set("endpoint_tentacleversiondetails_upgraderequired", machine.Endpoint.TentacleVersionDetails.UpgradeRequired)
+	d.Set("endpoint_tentacleversiondetails_upgradesuggested", machine.Endpoint.TentacleVersionDetails.UpgradeSuggested)
+	d.Set("endpoint_tentacleversiondetails_version", machine.Endpoint.TentacleVersionDetails.Version)
+	d.Set("endpoint_thumbprint", machine.Endpoint.Thumbprint)
+	d.Set("endpoint_uri", machine.Endpoint.URI)
+	d.Set("environments", machine.EnvironmentIDs)
+	d.Set("haslatestcalamari", machine.HasLatestCalamari)
+	d.Set("isdisabled", machine.IsDisabled)
+	d.Set("isinprocess", machine.IsInProcess)
+	d.Set("machinepolicy", machine.MachinePolicyID)
+	d.Set("roles", machine.Roles)
+	d.Set("status", machine.Status)
+	d.Set("statussummary", machine.StatusSummary)
+	d.Set("tenanteddeploymentparticipation", machine.TenantedDeploymentParticipation)
+	d.Set("tenantids", machine.TenantIDs)
+	d.Set("tenanttags", machine.TenantTags)
+	//d.Set("thumbprint", machine.Thumbprint)
+	//d.Set("uri", machine.URI)
 
 	return nil
 }

--- a/vendor/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy/account.go
+++ b/vendor/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy/account.go
@@ -24,6 +24,7 @@ type Accounts struct {
 
 type Account struct {
 	ID                              string         `json:"Id"`
+	EnvironmentIDs                  []string       `json:"EnvironmentIds"`
 	Name                            string         `json:"Name"`
 	AccountType                     string         `json:"AccountType"`
 	SubscriptionNumber              string         `json:"SubscriptionNumber"`
@@ -32,6 +33,7 @@ type Account struct {
 	Password                        SensitiveValue `json:"Password"`
 	TenantTags                      []string       `json:"TenantTags,omitempty"`
 	TenantedDeploymentParticipation string         `json:"TenantedDeploymentParticipation"`
+	Token                           SensitiveValue `json:"Token,omitempty"`
 }
 
 func (t *Account) Validate() error {

--- a/vendor/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy/channels.go
+++ b/vendor/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy/channels.go
@@ -1,0 +1,160 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/dghubble/sling"
+	"gopkg.in/go-playground/validator.v9"
+)
+
+type ChannelService struct {
+	sling *sling.Sling
+}
+
+func NewChannelService(sling *sling.Sling) *ChannelService {
+	return &ChannelService{
+		sling: sling,
+	}
+}
+
+type Channels struct {
+	Items []Channel `json:"Items"`
+	PagedResults
+}
+
+type Channel struct {
+	Description string        `json:"Description"`
+	ID          string        `json:"Id,omitempty"`
+	IsDefault   bool          `json:"IsDefault"`
+	LifecycleID string        `json:"LifecycleId"`
+	Name        string        `json:"Name"`
+	ProjectID   string        `json:"ProjectId"`
+	Rules       []ChannelRule `json:"Rules,omitempty"`
+	TenantTags  []string      `json:"TenantedDeploymentMode,omitempty"`
+}
+
+type ChannelRule struct {
+	// name of Package step(s) this rule applies to
+	Actions []string `json:"Actions,omitempty"`
+
+	// Id
+	ID string `json:"Id,omitempty"`
+
+	// Pre-release tag
+	Tag string `json:"Tag,omitempty"`
+
+	//Use the NuGet or Maven versioning syntax (depending on the feed type)
+	//to specify the range of versions to include
+	VersionRange string `json:"VersionRange,omitempty"`
+}
+
+func (d *Channels) Validate() error {
+	validate := validator.New()
+
+	err := validate.Struct(d)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *ChannelService) Get(channelID string) (*Channel, error) {
+	path := fmt.Sprintf("channels/%s", channelID)
+	resp, err := apiGet(s.sling, new(Channel), path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Channel), nil
+}
+
+func (s *ChannelService) GetAll() (*[]Channel, error) {
+	var ch []Channel
+
+	path := "channel"
+
+	loadNextPage := true
+
+	for loadNextPage {
+		resp, err := apiGet(s.sling, new(Channels), path)
+
+		if err != nil {
+			return nil, err
+		}
+
+		r := resp.(*Channels)
+
+		for _, item := range r.Items {
+			ch = append(ch, item)
+		}
+
+		path, loadNextPage = LoadNextPage(r.PagedResults)
+	}
+
+	return &ch, nil
+}
+
+// Add adds a new channel
+func (s *ChannelService) Add(channel *Channel) (*Channel, error) {
+	err := ValidateChannelValues(channel)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := apiAdd(s.sling, channel, new(Channel), "channels")
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Channel), nil
+}
+
+// ValidateChannelValues checks the values of a Channel object to see if they are suitable for
+// sending to Octopus Deploy. Used when adding or updating channels.
+func ValidateChannelValues(Channel *Channel) error {
+	return ValidateMultipleProperties([]error{
+		ValidateRequiredPropertyValue("Name", Channel.Name),
+		ValidateRequiredPropertyValue("ProjectID", Channel.ProjectID),
+	})
+}
+
+func NewChannel(name, description, projectID string) *Channel {
+	return &Channel{
+		Name:        name,
+		ProjectID:   projectID,
+		Description: description,
+	}
+}
+
+// Delete deletes an existing channel in Octopus Deploy
+func (s *ChannelService) Delete(channelid string) error {
+	path := fmt.Sprintf("channels/%s", channelid)
+	err := apiDelete(s.sling, path)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Update updates an existing channel in Octopus Deploy
+func (s *ChannelService) Update(channel *Channel) (*Channel, error) {
+	err := ValidateChannelValues(channel)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("channels/%s", channel.ID)
+	resp, err := apiUpdate(s.sling, channel, new(Channel), path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Channel), nil
+}

--- a/vendor/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy/machines.go
+++ b/vendor/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy/machines.go
@@ -42,15 +42,27 @@ type Machine struct {
 	LastModifiedBy                  *string          `json:"LastModifiedBy,omitempty"`
 }
 
+type MachineEndpointAuthentication struct {
+	AccountID          string `json:"AccountId"`
+	ClientCertificate  string `json:"ClientCertificate"`
+	AuthenticationType string `json:"AuthenticationType"`
+}
+
 type MachineEndpoint struct {
-	ID                     string                        `json:"Id"`
-	CommunicationStyle     string                        `json:"CommunicationStyle"`
-	ProxyID                *string                       `json:"ProxyId"`
-	Thumbprint             string                        `json:"Thumbprint"`
-	TentacleVersionDetails MachineTentacleVersionDetails `json:"TentacleVersionDetails"`
-	LastModifiedOn         *string                       `json:"LastModifiedOn,omitempty"`
-	LastModifiedBy         *string                       `json:"LastModifiedBy,omitempty"`
-	URI                    string                        `json:"Uri"` //This is not in the spec doc, but it shows up and needs to be kept in sync
+	ID                     string                         `json:"Id"`
+	CommunicationStyle     string                         `json:"CommunicationStyle"`
+	ProxyID                *string                        `json:"ProxyId"`
+	Thumbprint             string                         `json:"Thumbprint"`
+	TentacleVersionDetails MachineTentacleVersionDetails  `json:"TentacleVersionDetails"`
+	LastModifiedOn         *string                        `json:"LastModifiedOn,omitempty"`
+	LastModifiedBy         *string                        `json:"LastModifiedBy,omitempty"`
+	URI                    string                         `json:"Uri"`                 // This is not in the spec doc, but it shows up and needs to be kept in sync
+	ClusterCertificate     string                         `json:"ClusterCertificate"`  // Kubernetes (not in spec doc)
+	ClusterURL             string                         `json:"ClusterUrl"`          // Kubernetes (not in spec doc)
+	Namespace              string                         `json:"Namespace"`           // Kubernetes (not in spec doc)
+	SkipTLSVerification    string                         `json:"SkipTlsVerification"` // Kubernetes (not in spec doc)
+	DefaultWorkerPoolID    string                         `json:"DefaultWorkerPoolId"`
+	Authentication         *MachineEndpointAuthentication `json:"Authentication"`
 }
 
 type MachineTentacleVersionDetails struct {
@@ -128,6 +140,24 @@ func (s *MachineService) GetAll() (*[]Machine, error) {
 		path, loadNextPage = LoadNextPage(r.PagedResults)
 	}
 	return &p, nil
+}
+
+// GetByName gets an existing machine by its name in Octopus Deploy
+func (s *MachineService) GetByName(machineName string) (*Machine, error) {
+	var found Machine
+	machines, err := s.GetAll()
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, machine := range *machines {
+		if machine.Name == machineName {
+			return &machine, nil
+		}
+	}
+
+	return &found, fmt.Errorf("no machine found with name %s", machineName)
 }
 
 // Add creates a new machine in Octopus Deploy

--- a/vendor/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy/octopusdeploy.go
+++ b/vendor/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy/octopusdeploy.go
@@ -29,6 +29,7 @@ type Client struct {
 	Interruption       *InterruptionsService
 	TagSet             *TagSetService
 	Space              *SpaceService
+	Channel			   *ChannelService
 }
 
 // NewClient returns a new Client.
@@ -55,6 +56,7 @@ func NewClient(httpClient *http.Client, octopusURL, octopusAPIKey string) *Clien
 		Interruption:       NewInterruptionService(base.New()),
 		TagSet:             NewTagSetService(base.New()),
 		Space:              NewSpaceService(base.New()),
+		Channel:            NewChannelService(base.New()),
 	}
 }
 
@@ -79,6 +81,7 @@ func ForSpace(httpClient *http.Client, octopusURL, octopusAPIKey string, space *
 		Lifecycle:          NewLifecycleService(base.New()),
 		LibraryVariableSet: NewLibraryVariableSetService(base.New()),
 		TagSet:             NewTagSetService(base.New()),
+		Channel:            NewChannelService(base.New()),
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/OctopusDeploy/go-octopusdeploy v1.3.0
+# github.com/OctopusDeploy/go-octopusdeploy v1.4.0
 github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy
 # github.com/agext/levenshtein v1.2.1
 github.com/agext/levenshtein


### PR DESCRIPTION
This, along with https://github.com/OctopusDeploy/go-octopusdeploy/pull/17 (which is a dependency for these changes) allows the configuration of Kubernetes deployment targets using terraform.