### PR TITLE
Fix typo

### DIFF
--- a/website/docs/d/lifecycle.html.markdown
+++ b/website/docs/d/lifecycle.html.markdown
@@ -23,6 +23,6 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-* `id` - ID of the environment.
+* `id` - ID of the lifecycle.
 
 * `description` - A description of the lifecycle.


### PR DESCRIPTION
The `id` attribute for this data source returns a lifecycle id not an environment id.