### PR TITLE
Bug fix for updating X509 certs

### DIFF
--- a/octopusdeploy/resource_certificate.go
+++ b/octopusdeploy/resource_certificate.go
@@ -173,7 +173,7 @@ func resourceCertificateUpdate(d *schema.ResourceData, m interface{}) error {
 
 	client := m.(*octopusdeploy.Client)
 
-	updatedCertificate, err := client.Certificate.Replace(certificate)
+	updatedCertificate, err := client.Certificate.Update(certificate)
 
 	if err != nil {
 		return fmt.Errorf("error updating certificate id %s: %s", d.Id(), err.Error())


### PR DESCRIPTION
## Bug
There was a bug (found here: https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/63) that would not allow users to update the X509 certs after creating them via Terraform

## Reason
The issue was the `resourceCertificateUpdate` function in the Terraform provider itself (`resource_certificate.go` ) was pointing to the `Replace` method instead of the `Update` method

## The Fix
I updated the call from `resourceCertificateUpdate` function to instead use the Update method and the update to the cert is successful with no more 500 errors.

Screenshots are in the `topic-terraformprovdr` Slack channel.