### PR TITLE
Data resources for Terraform resources

### DIFF
--- a/octopusdeploy/data_aws_account.go
+++ b/octopusdeploy/data_aws_account.go
@@ -1,0 +1,75 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataAwsAccount() *schema.Resource {
+	return &schema.Resource{
+		Read: dataAwsAccountReadByName,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"account_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "AWS",
+			},
+			"environments": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+			},
+			"tenant_tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tenanted_deployment_participation": getTenantedDeploymentSchema(),
+			"secret_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"access_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataAwsAccountReadByName(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	AwsAccountName := d.Get("name")
+	env, err := client.Account.GetByName(AwsAccountName.(string))
+
+	if err == octopusdeploy.ErrItemNotFound {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Aws Account with name %s: %s", AwsAccountName, err.Error())
+	}
+
+	d.SetId(env.ID)
+
+	d.Set("name", env.Name)
+	d.Set("description", env.Description)
+
+	return nil
+}

--- a/octopusdeploy/data_azure_service_principal.go
+++ b/octopusdeploy/data_azure_service_principal.go
@@ -1,0 +1,91 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataAzureServicePrincipal() *schema.Resource {
+	return &schema.Resource{
+		Read: dataAzureServicePrincipalReadByName,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"AzureServicePrincipals": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+			},
+			"tenant_tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tenanted_deployment_participation": getTenantedDeploymentSchema(),
+			"client_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"subscription_number": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"azure_AzureServicePrincipal": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_management_endpoint_base_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"active_directory_endpoint_base_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataAzureServicePrincipalReadByName(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	AzureServicePrincipalName := d.Get("name")
+	env, err := client.Account.GetByName(AzureServicePrincipalName.(string))
+
+	if err == octopusdeploy.ErrItemNotFound {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading AzureServicePrincipal with name %s: %s", AzureServicePrincipalName, err.Error())
+	}
+
+	d.SetId(env.ID)
+
+	d.Set("name", env.Name)
+	d.Set("description", env.Description)
+
+	return nil
+}

--- a/octopusdeploy/data_certificate.go
+++ b/octopusdeploy/data_certificate.go
@@ -1,0 +1,78 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataCertificate() *schema.Resource {
+	return &schema.Resource{
+		Read: dataCertificateReadByName,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"notes": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"certificate_data": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"Certificate_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tenanted_deployment_participation": getTenantedDeploymentSchema(),
+			"tenant_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tenant_tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataCertificateReadByName(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	CertificateName := d.Get("name")
+	env, err := client.Certificate.GetByName(CertificateName.(string))
+
+	if err == octopusdeploy.ErrItemNotFound {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Certificate with name %s: %s", CertificateName, err.Error())
+	}
+
+	d.SetId(env.ID)
+
+	d.Set("name", env.Name)
+
+	return nil
+}

--- a/octopusdeploy/data_channel.go
+++ b/octopusdeploy/data_channel.go
@@ -1,0 +1,80 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataChannel() *schema.Resource {
+	return &schema.Resource{
+		Read: dataChannelReadByName,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"lifecycle_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"version_range": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tag": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"actions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataChannelReadByName(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	ChannelName := d.Get("name")
+	env, err := client.Channel.Get(ChannelName.(string))
+
+	if err == octopusdeploy.ErrItemNotFound {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Channel with name %s: %s", ChannelName, err.Error())
+	}
+
+	d.SetId(env.ID)
+
+	d.Set("name", env.Name)
+	d.Set("description", env.Description)
+
+	return nil
+}

--- a/octopusdeploy/data_nuget.go
+++ b/octopusdeploy/data_nuget.go
@@ -1,0 +1,70 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataNuget() *schema.Resource {
+	return &schema.Resource{
+		Read: dataNugetReadByName,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"feed_uri": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enhanced_mode": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"download_attempts": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  5,
+			},
+			"download_retry_backoff_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  10,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataNugetReadByName(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	NugetName := d.Get("name")
+	env, err := client.Feed.GetByName(NugetName.(string))
+
+	if err == octopusdeploy.ErrItemNotFound {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Nuget with name %s: %s", NugetName, err.Error())
+	}
+
+	d.SetId(env.ID)
+
+	d.Set("name", env.Name)
+
+	return nil
+}

--- a/octopusdeploy/data_tag_set.go
+++ b/octopusdeploy/data_tag_set.go
@@ -1,0 +1,43 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataTagSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataTagSetReadByName,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tag": getTagSchema(),
+		},
+	}
+}
+
+func dataTagSetReadByName(d *schema.ResourceData, m interface{}) error {
+	client := m.(*octopusdeploy.Client)
+
+	TagSetName := d.Get("name")
+	env, err := client.TagSet.GetByName(TagSetName.(string))
+
+	if err == octopusdeploy.ErrItemNotFound {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading TagSet with name %s: %s", TagSetName, err.Error())
+	}
+
+	d.SetId(env.ID)
+
+	d.Set("name", env.Name)
+
+	return nil
+}


### PR DESCRIPTION
# Description

Created all data resources to match all of the Terraform resources that are available. The data resources will give us the ability to `GET` all of the resource information, for example, if we want to print out data on `certificates` or `projects`.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update