### PR TITLE
Add data_certificate as a data source in provider

### DIFF
--- a/octopusdeploy/data_certificate.go
+++ b/octopusdeploy/data_certificate.go
@@ -22,7 +22,7 @@ func dataCertificate() *schema.Resource {
 			},
 			"certificate_data": {
 				Type:      schema.TypeString,
-				Required:  true,
+				Optional:  true,
 				Sensitive: true,
 			},
 			"password": {
@@ -30,12 +30,16 @@ func dataCertificate() *schema.Resource {
 				Optional:  true,
 				Sensitive: true,
 			},
-			"Certificate_ids": {
+			"certificate_ids": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"serial_number": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"tenanted_deployment_participation": getTenantedDeploymentSchema(),
 			"tenant_ids": {
@@ -52,6 +56,10 @@ func dataCertificate() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"thumbprint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -60,7 +68,7 @@ func dataCertificateReadByName(d *schema.ResourceData, m interface{}) error {
 	client := m.(*octopusdeploy.Client)
 
 	CertificateName := d.Get("name")
-	env, err := client.Certificate.GetByName(CertificateName.(string))
+	cert, err := client.Certificate.GetByName(CertificateName.(string))
 
 	if err == octopusdeploy.ErrItemNotFound {
 		return nil
@@ -70,9 +78,11 @@ func dataCertificateReadByName(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("error reading Certificate with name %s: %s", CertificateName, err.Error())
 	}
 
-	d.SetId(env.ID)
+	d.SetId(cert.ID)
 
-	d.Set("name", env.Name)
+	d.Set("name", cert.Name)
+	d.Set("serial_number", cert.SerialNumber)
+	d.Set("thumbprint", cert.Thumbprint)
 
 	return nil
 }

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -20,6 +20,7 @@ func Provider() terraform.ResourceProvider {
 			"octopusdeploy_lifecycle":            dataLifecycle(),
 			"octopusdeploy_feed":                 dataFeed(),
 			"octopusdeploy_account":              dataAccount(),
+			"octopusdeploy_certificate":          dataCertificate(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"octopusdeploy_project":                           resourceProject(),
@@ -40,7 +41,7 @@ func Provider() terraform.ResourceProvider {
 			"octopusdeploy_azure_service_principal":           resourceAzureServicePrincipal(),
 			"octopusdeploy_usernamepassword_account":          resourceUsernamePassword(),
 			"octopusdeploy_sshkey_account":                    resourceSSHKey(),
-			"octopusdeploy_aws_account":           			       resourceAmazonWebServicesAccount(),
+			"octopusdeploy_aws_account":                       resourceAmazonWebServicesAccount(),
 		},
 		Schema: map[string]*schema.Schema{
 			"address": {


### PR DESCRIPTION
In the process of testing out the provider, I noticed that there is a data source for certificates, but it wasn't available when I tried to use it. This commit adds it to the provider.go

Once I added the certificate data source, Terraform complained about the `certificate_ids` property having an upper-case letter. I fixed the casing and added `serial_number` and `thumbprint`. Since I didn't want to go too far without opening a PR, I only added `serial_number` and `thumbprint` to the `dataCertificateReadByName` function.

Hopefully this helps! If there are any changes I need to make, let me know. I'm still relatively new to Go and working on Terraform Providers.

I also noticed there are several other data sources that aren't included in provider.go. I wasn't sure if that was intentional or not and I didn't want to make this PR any bigger. Thanks!