### PR TITLE
Fixed schema for lifecycle

### DIFF
--- a/octopusdeploy/schema_lifecycle.go
+++ b/octopusdeploy/schema_lifecycle.go
@@ -152,7 +152,7 @@ func getLifecycleDataSchema() map[string]*schema.Schema {
 			Required: true,
 			Type:     schema.TypeString,
 		},
-		"phases": {
+		"phase": {
 			Computed: true,
 			Elem:     &schema.Resource{Schema: getPhaseDataSchema()},
 			Type:     schema.TypeList,
@@ -188,7 +188,7 @@ func getLifecycleSchema() map[string]*schema.Schema {
 			Required: true,
 			Type:     schema.TypeString,
 		},
-		"phases": {
+		"phase": {
 			Elem:     &schema.Resource{Schema: getPhaseSchema()},
 			Optional: true,
 			Type:     schema.TypeList,


### PR DESCRIPTION
Parameter `phases` is replaced with `phase` in Lifecycle Schema and Lifecycle Data Schema. The reasons: 
* `expandLifecycle` function expects parameter `phase`.
* Name convention for such parameters is "singular" value (not "plural") in other resources ( e.g.: `step` in `deployment_process` ).