### PR TITLE
Allow empty name for deferred packages in step template

### DIFF
--- a/docs/resources/step_template.md
+++ b/docs/resources/step_template.md
@@ -42,7 +42,7 @@ This resource manages step_templates in Octopus Deploy.
 Required:
 
 - `feed_id` (String) ID of the feed.
-- `name` (String) The name of this resource.
+- `name` (String) Package name.
 - `properties` (Attributes) Properties for the package. (see [below for nested schema](#nestedatt--packages--properties))
 
 Optional:

--- a/octopusdeploy_framework/schemas/process_step_reserved_execution_properties_validator.go
+++ b/octopusdeploy_framework/schemas/process_step_reserved_execution_properties_validator.go
@@ -9,6 +9,10 @@ import (
 
 type reservedExecutionPropertiesValidator struct{}
 
+func warnAboutReservedExecutionProperties() validator.Map {
+	return &reservedExecutionPropertiesValidator{}
+}
+
 func (v reservedExecutionPropertiesValidator) Description(ctx context.Context) string {
 	return "execution properties must not contain reserved properties"
 }
@@ -39,10 +43,6 @@ func (v reservedExecutionPropertiesValidator) ValidateMap(ctx context.Context, r
 			)
 		}
 	}
-}
-
-func warnAboutReservedExecutionProperties() validator.Map {
-	return &reservedExecutionPropertiesValidator{}
 }
 
 type reservedExecutionPropertyWarning struct {

--- a/octopusdeploy_framework/schemas/step_template.go
+++ b/octopusdeploy_framework/schemas/step_template.go
@@ -204,18 +204,20 @@ func GetStepTemplatePackageResourceSchema() rs.ListNestedAttribute {
 					Optional:    true,
 					Computed:    true,
 				},
-				"feed_id": rs.StringAttribute{
-					Description: "ID of the feed.",
-					Required:    true,
-				},
-				"id":   GetIdResourceSchema(),
-				"name": GetNameResourceSchema(true),
-				"package_id": rs.StringAttribute{
-					Description: "The ID of the package to use.",
-					Optional:    true,
-					Required:    false,
-					Computed:    true,
-				},
+				"feed_id": util.ResourceString().
+					Description("ID of the feed (can be empty for deferred package).").
+					Required().
+					Build(),
+				"id": GetIdResourceSchema(),
+				"name": util.ResourceString().
+					Description("Package name (can be empty for deferred package).").
+					Required().
+					Build(),
+				"package_id": util.ResourceString().
+					Description("The ID of the package to use.").
+					Optional().
+					Computed().
+					Build(),
 				"properties": rs.SingleNestedAttribute{
 					Description: "Properties for the package.",
 					Required:    true,

--- a/octopusdeploy_framework/schemas/step_template.go
+++ b/octopusdeploy_framework/schemas/step_template.go
@@ -205,12 +205,12 @@ func GetStepTemplatePackageResourceSchema() rs.ListNestedAttribute {
 					Computed:    true,
 				},
 				"feed_id": util.ResourceString().
-					Description("ID of the feed (can be empty for deferred package).").
+					Description("ID of the feed.").
 					Required().
 					Build(),
 				"id": GetIdResourceSchema(),
 				"name": util.ResourceString().
-					Description("Package name (can be empty for deferred package).").
+					Description("Package name.").
 					Required().
 					Build(),
 				"package_id": util.ResourceString().


### PR DESCRIPTION
Step templates have ability to defer package requirement and use package provided by the consumer via parameter. This allows to create step template without directly referenced package.

Terraform however has a validation for package name not allowed to be empty

This PR removes this validation

Fixes: https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/8