### PR TITLE
Update workflow job names for status checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    name: Validate Docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -103,7 +103,7 @@ jobs:
 
   tests-combine-summaries:
     if: always()
-    name: Combine Test Reports
+    name: Ensure Tests Pass
     needs: [ tests ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prevent-new-sdk-additions.yml
+++ b/.github/workflows/prevent-new-sdk-additions.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   detect-new-sdk-files:
+    name: Prevent New SDK Files
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Our current workflows don't have unique names, and there are multiple workflows that all contain a job named `build`. 

In order to target the correct status checks for our branch protections, we need unique names for these jobs. This PR disambiguates between `build` (the actual go build), `Validate Docs` and `Prevent New SDK Files`, which were all previously called `build`.

Also changes the `Combine Test Reports` job to be `Ensure Tests Pass`, giving it clearer intent and meaning when viewed in the status checks view.