### PR TITLE
Fix Release Creation Strategy mapping on update

### DIFF
--- a/octopusdeploy_framework/resource_project_model.go
+++ b/octopusdeploy_framework/resource_project_model.go
@@ -72,9 +72,9 @@ type versioningStrategyModel struct {
 }
 
 type releaseCreationStrategyModel struct {
-	ChannelID                    types.String `tfsdk:"channel_id"`
-	ReleaseCreationPackageStepID types.String `tfsdk:"release_creation_package_step_id"`
-	ReleaseCreationPackage       types.Object `tfsdk:"release_creation_package"`
+	ChannelID                    types.String                   `tfsdk:"channel_id"`
+	ReleaseCreationPackageStepID types.String                   `tfsdk:"release_creation_package_step_id"`
+	ReleaseCreationPackage       []deploymentActionPackageModel `tfsdk:"release_creation_package"`
 }
 
 type deploymentActionPackageModel struct {


### PR DESCRIPTION
# Background

[SC-115039]

When updating project resources via terraform, the ReleaseCreationPackage is excluded from the request to Octopus. This appears to be a result of trying to pass a single object reference into the ElementsAs method.

# Results

## Sample terraform resource

```
resource "octopusdeploy_project" "example" {
  project_group_id     = "ProjectGroups-1"
  lifecycle_id         = "Lifecycles-1"
  name                 = "local build test 2"
  auto_create_release  = true

  release_creation_strategy {
    release_creation_package_step_id = "64642972-d11f-45d4-8c6f-46064e8ac8b4" # Action ID for the step
    channel_id = "Channels-366"
  
    release_creation_package {
      deployment_action = "Run a Script" # Step name
      package_reference = "8f54473c-2a26-4c6c-a47f-7045622ab234" # Package reference for the action
    }
  }
}
```

## Before

![image](https://github.com/user-attachments/assets/87567e5e-b54c-4130-b8dc-5d225ba2ae06)

## After

![image](https://github.com/user-attachments/assets/415651ca-6e7a-4791-b01a-974e3f11b3f3)

After this fix in terraform, we can still get the following error because the `package_reference` is updated to null in Octopus Server [on this line when the package name is missing](https://github.com/OctopusDeploy/OctopusDeploy/blob/ff72a0fb701f9245560a8bff145c05f7fcf1ad64/source/Octopus.Core/Features/DeploymentProcesses/DeploymentActionPackageNameMapper.cs#L57).

```
 When applying changes to octopusdeploy_project.example, provider
│ "provider[\"octopus.com/com/octopusdeploy\"]" produced an unexpected new
│ value:
│ .release_creation_strategy[0].release_creation_package[0].package_reference:
│ was cty.StringVal("8f54473c-2a26-4c6c-a47f-7045622ab234"), but now
│ cty.StringVal("").
```


