### PR TITLE
Remove redundant auto create release project validation

### DIFF
--- a/octopusdeploy_framework/resource_project_auto_create_release_validation.go
+++ b/octopusdeploy_framework/resource_project_auto_create_release_validation.go
@@ -13,7 +13,7 @@ import (
 
 func (r *projectAutoCreateReleaseResource) validateAutoCreateReleaseConfiguration(ctx context.Context, project *projects.Project, data *schemas.ProjectAutoCreateReleaseResourceModel) error {
 	// Validate deployment process exists
-	if err := r.validateDeploymentProcessExists(ctx, project, data.DeploymentProcessID.ValueString()); err != nil {
+	if err := r.validateDeploymentProcessExists(ctx, project.SpaceID, data.DeploymentProcessID.ValueString()); err != nil {
 		return err
 	}
 
@@ -30,12 +30,12 @@ func (r *projectAutoCreateReleaseResource) validateAutoCreateReleaseConfiguratio
 	return nil
 }
 
-func (r *projectAutoCreateReleaseResource) validateDeploymentProcessExists(ctx context.Context, project *projects.Project, deploymentProcessID string) error {
+func (r *projectAutoCreateReleaseResource) validateDeploymentProcessExists(ctx context.Context, spaceID, deploymentProcessID string) error {
 	if deploymentProcessID == "" {
 		return fmt.Errorf("deployment_process_id is required")
 	}
 
-	_, err := deployments.GetDeploymentProcessByID(r.Client, project.SpaceID, deploymentProcessID)
+	_, err := deployments.GetDeploymentProcessByID(r.Client, spaceID, deploymentProcessID)
 	if err != nil {
 		return fmt.Errorf("deployment process with ID %s does not exist: %w", deploymentProcessID, err)
 	}

--- a/octopusdeploy_framework/resource_project_auto_create_release_validation.go
+++ b/octopusdeploy_framework/resource_project_auto_create_release_validation.go
@@ -3,7 +3,6 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
-
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
@@ -13,8 +12,8 @@ import (
 )
 
 func (r *projectAutoCreateReleaseResource) validateAutoCreateReleaseConfiguration(ctx context.Context, project *projects.Project, data *schemas.ProjectAutoCreateReleaseResourceModel) error {
-	// Validate deployment process belongs to project
-	if err := r.validateDeploymentProcessBelongsToProject(ctx, project, data.DeploymentProcessID.ValueString()); err != nil {
+	// Validate deployment process exists
+	if err := r.validateDeploymentProcessExists(ctx, project, data.DeploymentProcessID.ValueString()); err != nil {
 		return err
 	}
 
@@ -31,17 +30,11 @@ func (r *projectAutoCreateReleaseResource) validateAutoCreateReleaseConfiguratio
 	return nil
 }
 
-func (r *projectAutoCreateReleaseResource) validateDeploymentProcessBelongsToProject(ctx context.Context, project *projects.Project, deploymentProcessID string) error {
+func (r *projectAutoCreateReleaseResource) validateDeploymentProcessExists(ctx context.Context, project *projects.Project, deploymentProcessID string) error {
 	if deploymentProcessID == "" {
 		return fmt.Errorf("deployment_process_id is required")
 	}
 
-	// Check if the deployment process ID matches the project's deployment process ID
-	if project.DeploymentProcessID != deploymentProcessID {
-		return fmt.Errorf("deployment_process_id %s does not belong to project %s (expected: %s)", deploymentProcessID, project.ID, project.DeploymentProcessID)
-	}
-
-	// Additional validation: ensure the deployment process actually exists
 	_, err := deployments.GetDeploymentProcessByID(r.Client, project.SpaceID, deploymentProcessID)
 	if err != nil {
 		return fmt.Errorf("deployment process with ID %s does not exist: %w", deploymentProcessID, err)


### PR DESCRIPTION
[sc-117067]

Follow up to https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/46.

As the project is derived from the process (as opposed to project ID being provided by the user via an attribute) validating that the project process is correct is redundant.