### PR TITLE
Run Tests on main branch

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,6 +6,9 @@ name: Tests
 'on':
   workflow_dispatch: {}
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   tests:


### PR DESCRIPTION
Add a trigger for push to main branch (A PR merge to main is a `push` action). 

Motivation behind this is that I'd like a history of our tests running on main which should be healthy to ensure we're not seeing any flakey tests. It's hard to look at the test history since it's all PRs which might contain legitimate failed tests. 