### PR TITLE
Fix the octopusdeploy_project_versioning_strategy resource

### DIFF
--- a/octopusdeploy_framework/resource_project_versioning_strategy.go
+++ b/octopusdeploy_framework/resource_project_versioning_strategy.go
@@ -2,11 +2,12 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"log"
+	"net/http"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"log"
-	"net/http"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
@@ -212,7 +213,10 @@ func mapStateToProjectVersioningStrategy(ctx context.Context, state *schemas.Pro
 func mapProjectVersioningStrategyToState(versioningStrategy *projects.VersioningStrategy, state *schemas.ProjectVersioningStrategyModel) {
 	if versioningStrategy.DonorPackageStepID != nil {
 		state.DonorPackageStepID = types.StringValue(*versioningStrategy.DonorPackageStepID)
+	} else {
+		state.DonorPackageStepID = types.StringNull()
 	}
+
 	// Template and Donor Package are mutually exclusive options. We won't always have DonorPackage information.
 	state.Template = types.StringValue(versioningStrategy.Template)
 
@@ -224,5 +228,7 @@ func mapProjectVersioningStrategyToState(versioningStrategy *projects.Versioning
 				"package_reference": types.StringValue(versioningStrategy.DonorPackage.PackageReference),
 			},
 		)
+	} else {
+		state.DonorPackage = types.ObjectNull(schemas.ProjectVersioningStrategyDonorPackageAttributeTypes())
 	}
 }

--- a/octopusdeploy_framework/resource_project_versioning_strategy_test.go
+++ b/octopusdeploy_framework/resource_project_versioning_strategy_test.go
@@ -1,0 +1,75 @@
+package octopusdeploy_framework
+
+import (
+	"fmt"
+	"testing"
+
+	internaltest "github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/test"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestProjectVersioningStrategyWithUpdate(t *testing.T) {
+	lifecycleLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	lifecycleName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectGroupLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectGroupName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	versioningStrategyPrefix := "octopusdeploy_project_versioning_strategy." + localName
+	template := "#{Octopus.Version.LastMajor}.#{Octopus.Version.LastMinor}.#{Octopus.Version.LastPatch}.#{Octopus.Version.NextRevision}"
+	template2 := "#{Octopus.Date.Year}.#{Octopus.Date.Month}.#{Octopus.Date.Day}.i"
+
+	description := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccProjectCheckDestroy,
+			testAccLifecycleCheckDestroy,
+		),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists(),
+					resource.TestCheckResourceAttr(versioningStrategyPrefix, "template", template),
+				),
+				Config: testProjectVersioningStrategy(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description, template),
+			},
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists(),
+					resource.TestCheckResourceAttr(versioningStrategyPrefix, "template", template2),
+				),
+				Config: testProjectVersioningStrategy(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description, template2),
+			},
+		},
+	})
+}
+
+func testProjectVersioningStrategy(lifecycleLocalName string, lifecycleName string, projectGroupLocalName string, projectGroupName string, localName string, name string, description string, template string) string {
+	projectGroup := internaltest.NewProjectGroupTestOptions()
+	projectGroup.LocalName = projectGroupLocalName
+	projectGroup.Resource.Name = projectGroupName
+
+	return fmt.Sprintf(testAccLifecycle(lifecycleLocalName, lifecycleName)+"\n"+
+		internaltest.ProjectGroupConfiguration(projectGroup)+"\n"+
+		`resource "octopusdeploy_project" "%s" {
+			description      = "%s"
+			lifecycle_id     = octopusdeploy_lifecycle.%s.id
+			name             = "%s"
+			project_group_id = octopusdeploy_project_group.%s.id
+
+			connectivity_policy {
+				allow_deployments_to_no_targets = true
+				skip_machine_behavior           = "None"
+			}
+
+		}
+
+		resource "octopusdeploy_project_versioning_strategy" "%s" {
+		  project_id = "${octopusdeploy_project.%s.id}"
+		  template   = "%s"
+		}`, localName, description, lifecycleLocalName, name, projectGroupLocalName, localName, localName, template)
+}

--- a/octopusdeploy_framework/resource_project_versioning_strategy_test.go
+++ b/octopusdeploy_framework/resource_project_versioning_strategy_test.go
@@ -55,12 +55,7 @@ func TestProjectVersioningStrategyWithUpdate(t *testing.T) {
 			{
 				Check: resource.ComposeTestCheckFunc(
 					testAccProjectCheckExists(),
-					resource.TestCheckResourceAttrWith(versioningStrategyPrefix, "donor_package_step_id", func(value string) error {
-						if value == "" {
-							return fmt.Errorf("donor_package_step_id should not be empty")
-						}
-						return nil
-					}),
+					resource.TestCheckResourceAttrSet(versioningStrategyPrefix, "donor_package_step_id"),
 				),
 				Config: testProjectVersioningStrategyFromStep(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description),
 			},

--- a/octopusdeploy_framework/resource_project_versioning_strategy_test.go
+++ b/octopusdeploy_framework/resource_project_versioning_strategy_test.go
@@ -44,6 +44,14 @@ func TestProjectVersioningStrategyWithUpdate(t *testing.T) {
 				),
 				Config: testProjectVersioningStrategy(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description, template2),
 			},
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists(),
+					resource.TestCheckResourceAttr(versioningStrategyPrefix, "donor_package.deployment_action", "Hello World"),
+					resource.TestCheckResourceAttr(versioningStrategyPrefix, "donor_package.package_reference", ""),
+				),
+				Config: testProjectVersioningStrategyFromPackage(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description),
+			},
 		},
 	})
 }
@@ -65,11 +73,130 @@ func testProjectVersioningStrategy(lifecycleLocalName string, lifecycleName stri
 				allow_deployments_to_no_targets = true
 				skip_machine_behavior           = "None"
 			}
+		}
 
+		resource "octopusdeploy_process" "%s" {
+		  project_id  = octopusdeploy_project.%s.id
+		}
+
+		resource "octopusdeploy_process_step" "%s" {
+		  process_id  = octopusdeploy_process.%s.id
+		  name = "%s"
+		  properties = {
+			"Octopus.Action.TargetRoles" = "role-one"
+		  }
+		  type = "Octopus.TentaclePackage"
+		  primary_package = {
+			package_id: "my.package"
+			feed_id: "built-in"
+		  }
+		  execution_properties = {
+			"Octopus.Action.RunOnServer" = "True"    
+		  }
+		}
+
+		resource octopusdeploy_process_steps_order "%s" {
+		  process_id = octopusdeploy_process.%s.id
+		  steps = [
+			octopusdeploy_process_step.%s.id
+		  ]
 		}
 
 		resource "octopusdeploy_project_versioning_strategy" "%s" {
 		  project_id = "${octopusdeploy_project.%s.id}"
 		  template   = "%s"
-		}`, localName, description, lifecycleLocalName, name, projectGroupLocalName, localName, localName, template)
+		}`,
+		localName,
+		description,
+		lifecycleLocalName,
+		name,
+		projectGroupLocalName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		template)
+}
+
+func testProjectVersioningStrategyFromPackage(lifecycleLocalName string, lifecycleName string, projectGroupLocalName string, projectGroupName string, localName string, name string, description string) string {
+	projectGroup := internaltest.NewProjectGroupTestOptions()
+	projectGroup.LocalName = projectGroupLocalName
+	projectGroup.Resource.Name = projectGroupName
+
+	configuration := fmt.Sprintf(testAccLifecycle(lifecycleLocalName, lifecycleName)+"\n"+
+		internaltest.ProjectGroupConfiguration(projectGroup)+"\n"+
+		`resource "octopusdeploy_project" "%s" {
+			description      = "%s"
+			lifecycle_id     = octopusdeploy_lifecycle.%s.id
+			name             = "%s"
+			project_group_id = octopusdeploy_project_group.%s.id
+
+			connectivity_policy {
+				allow_deployments_to_no_targets = true
+				skip_machine_behavior           = "None"
+			}
+		}
+
+		resource "octopusdeploy_process" "%s" {
+		  project_id  = octopusdeploy_project.%s.id
+		}
+
+		resource "octopusdeploy_process_step" "%s" {
+		  process_id  = octopusdeploy_process.%s.id
+		  name = "Hello World"
+		  properties = {
+			"Octopus.Action.TargetRoles" = "role-one"
+		  }
+		  type = "Octopus.TentaclePackage"
+		  primary_package = {
+			package_id: "Package"
+			feed_id: "built-in"
+		  }
+		  execution_properties = {
+			"Octopus.Action.RunOnServer" = "True"    
+		  }
+		}
+
+		resource octopusdeploy_process_steps_order "%s" {
+		  process_id = octopusdeploy_process.%s.id
+		  steps = [
+			octopusdeploy_process_step.%s.id
+		  ]
+		}
+
+		resource "octopusdeploy_project_versioning_strategy" "%s" {
+		  project_id = "${octopusdeploy_project.%s.id}"
+		  donor_package = {
+			deployment_action = "Hello World"
+			package_reference = ""
+		  }
+          depends_on = [
+			octopusdeploy_process_step.%s,
+			octopusdeploy_process.%s
+		  ]
+		}`,
+		localName,
+		description,
+		lifecycleLocalName,
+		name,
+		projectGroupLocalName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName)
+
+	return configuration
 }

--- a/octopusdeploy_framework/resource_project_versioning_strategy_test.go
+++ b/octopusdeploy_framework/resource_project_versioning_strategy_test.go
@@ -52,6 +52,18 @@ func TestProjectVersioningStrategyWithUpdate(t *testing.T) {
 				),
 				Config: testProjectVersioningStrategyFromPackage(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description),
 			},
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists(),
+					resource.TestCheckResourceAttrWith(versioningStrategyPrefix, "donor_package_step_id", func(value string) error {
+						if value == "" {
+							return fmt.Errorf("donor_package_step_id should not be empty")
+						}
+						return nil
+					}),
+				),
+				Config: testProjectVersioningStrategyFromStep(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description),
+			},
 		},
 	})
 }
@@ -186,6 +198,108 @@ func testProjectVersioningStrategyFromPackage(lifecycleLocalName string, lifecyc
 		lifecycleLocalName,
 		name,
 		projectGroupLocalName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName)
+
+	return configuration
+}
+
+func testProjectVersioningStrategyFromStep(lifecycleLocalName string, lifecycleName string, projectGroupLocalName string, projectGroupName string, localName string, name string, description string) string {
+	projectGroup := internaltest.NewProjectGroupTestOptions()
+	projectGroup.LocalName = projectGroupLocalName
+	projectGroup.Resource.Name = projectGroupName
+
+	configuration := fmt.Sprintf(testAccLifecycle(lifecycleLocalName, lifecycleName)+"\n"+
+		internaltest.ProjectGroupConfiguration(projectGroup)+"\n"+
+		`resource "octopusdeploy_project" "%s" {
+			description      = "%s"
+			lifecycle_id     = octopusdeploy_lifecycle.%s.id
+			name             = "%s"
+			project_group_id = octopusdeploy_project_group.%s.id
+
+			connectivity_policy {
+				allow_deployments_to_no_targets = true
+				skip_machine_behavior           = "None"
+			}
+		}
+
+		resource "octopusdeploy_process" "%s" {
+		  project_id  = octopusdeploy_project.%s.id
+		}
+
+		resource "octopusdeploy_process_step" "%s" {
+		  process_id  = octopusdeploy_process.%s.id
+		  name = "Hello World"
+		  properties = {
+			"Octopus.Action.TargetRoles" = "role-one"
+		  }
+		  type = "Octopus.TentaclePackage"
+		  primary_package = {
+			package_id: "Package"
+			feed_id: "built-in"
+		  }
+		  execution_properties = {
+			"Octopus.Action.RunOnServer" = "True"    
+		  }
+		}
+
+		resource octopusdeploy_process_steps_order "%s" {
+		  process_id = octopusdeploy_process.%s.id
+		  steps = [
+			octopusdeploy_process_step.%s.id
+		  ]
+		}
+
+		resource "octopusdeploy_process_child_step" "%s" {
+		  process_id  = octopusdeploy_process.%s.id
+		  parent_id = octopusdeploy_process_step.%s.id
+		  name = "Hello World Child"
+		  type = "Octopus.TentaclePackage"
+		  primary_package = {
+			package_id: "Package"
+			feed_id: "built-in"
+		  }
+		  execution_properties = {
+			"Octopus.Action.RunOnServer" = "True"    
+		  }
+		}
+
+		resource "octopusdeploy_process_child_steps_order" "%s" {
+		  process_id = octopusdeploy_process.%s.id
+		  parent_id = octopusdeploy_process_step.%s.id
+		  children = [
+			octopusdeploy_process_child_step.%s.id,
+		  ]
+		}
+
+		resource "octopusdeploy_project_versioning_strategy" "%s" {
+		  project_id = "${octopusdeploy_project.%s.id}"
+		  donor_package_step_id = octopusdeploy_process_child_step.%s.id
+          depends_on = [
+			octopusdeploy_process.%s
+		  ]
+		}`,
+		localName,
+		description,
+		lifecycleLocalName,
+		name,
+		projectGroupLocalName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
+		localName,
 		localName,
 		localName,
 		localName,


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/55

This change ensures that `DonorPackageStepID` and `DonorPackage` have a known value if they are null.

It also adds tests for the `octopusdeploy_project_versioning_strategy` resource.