### PR TITLE
Expose action ID on steps

### DIFF
--- a/octopusdeploy_framework/resource_process_step.go
+++ b/octopusdeploy_framework/resource_process_step.go
@@ -3,6 +3,8 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
@@ -17,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"strings"
 )
 
 var _ resource.ResourceWithImportState = &processStepResource{}
@@ -505,6 +506,7 @@ func mapProcessStepToState(process processWrapper, step *deployments.DeploymentS
 }
 
 func mapProcessStepActionToState(action *deployments.DeploymentAction, state *schemas.ProcessStepResourceModel) diag.Diagnostics {
+	state.ActionID = types.StringValue(action.GetID())
 	state.Type = types.StringValue(action.ActionType)
 	state.Slug = types.StringValue(action.Slug)
 	state.IsRequired = types.BoolValue(action.IsRequired)

--- a/octopusdeploy_framework/resource_process_step_test.go
+++ b/octopusdeploy_framework/resource_process_step_test.go
@@ -2,11 +2,12 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"testing"
 )
 
 func TestAccOctopusDeployProcessStepRunScript(t *testing.T) {
@@ -69,6 +70,7 @@ func testCheckResourceProcessStepRunScriptAttributes(step string, script string)
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttrSet(qualifiedName, "id"),
 		resource.TestCheckResourceAttr(qualifiedName, "name", step),
+		resource.TestCheckResourceAttrSet(qualifiedName, "action_id"),
 		resource.TestCheckResourceAttr(qualifiedName, "type", "Octopus.Script"),
 		resource.TestCheckResourceAttr(qualifiedName, "properties.Octopus.Action.TargetRoles", "role-one"),
 		resource.TestCheckResourceAttr(qualifiedName, "execution_properties.Octopus.Action.RunOnServer", "True"),

--- a/octopusdeploy_framework/schemas/process_step.go
+++ b/octopusdeploy_framework/schemas/process_step.go
@@ -58,6 +58,11 @@ func (p ProcessStepSchema) GetResourceSchema() resourceSchema.Schema {
 				DefaultEmpty().
 				Build(),
 
+			"action_id": util.ResourceString().
+				Description("The ID of the first action created in the step.").
+				Computed().
+				PlanModifiers(stringplanmodifier.UseStateForUnknown()).
+				Build(),
 			"type": util.ResourceString().
 				Description("Execution type of the step.").
 				Required().
@@ -150,6 +155,7 @@ type ProcessStepResourceModel struct {
 	Condition          types.String `tfsdk:"condition"`
 	Properties         types.Map    `tfsdk:"properties"`
 
+	ActionID             types.String                              `tfsdk:"action_id"`
 	Type                 types.String                              `tfsdk:"type"`
 	Slug                 types.String                              `tfsdk:"slug"`
 	IsDisabled           types.Bool                                `tfsdk:"is_disabled"`


### PR DESCRIPTION
The action ID is required in some circumstances, such as scoping a variable to an action. This PR exposes the action ID created by a `octopusdeploy_process_step` so variables can be scoped to the action.

Fixes https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/60