### PR TITLE
Add additional tests for SDKv2 to TPF resource migrations

### DIFF
--- a/octopusdeploy_framework/resource_azure_subscription_account_migration_test.go
+++ b/octopusdeploy_framework/resource_azure_subscription_account_migration_test.go
@@ -47,22 +47,108 @@ func TestAzureSubscriptionAccountResource_UpgradeFromSDK_ToPluginFramework(t *te
 }
 
 const azureSubscriptionAccountConfig = `
-resource "octopusdeploy_azure_subscription_account" "azure_account" {
-  name            = "Azure Subscription Account"
-  subscription_id = "00000000-0000-0000-0000-000000000000"
-  azure_environment = "AzureCloud"
-  management_endpoint = "https://management.azure.com"
-  storage_endpoint_suffix = "foofoofoofoofoofoofoofoo"
- }`
+	resource "octopusdeploy_environment" "test_env1" {
+	  name = "Test Environment 1"
+	  description = "Test environment for azure account migration"
+	}
 
-const updatedAzureSubscriptionAccountConfig = ` 
-resource "octopusdeploy_azure_subscription_account" "azure_account" {
-  name            = "Update Azure Subscription Account"
-  subscription_id = "00000000-0000-0000-0000-000000000000"
-  azure_environment = "AzureCloud"
-  management_endpoint = "https://mangement.azure.com"
-  storage_endpoint_suffix = "foofoofoofoofoofoofoofoo"
-}`
+	resource "octopusdeploy_environment" "test_env2" {
+	  name = "Test Environment 2"
+	  description = "Test environment for azure account migration"
+	}
+
+	resource "octopusdeploy_tag_set" "test_tagset" {
+	  name = "test-tagset"
+	  description = "Test tagset"
+	}
+
+	resource "octopusdeploy_tag" "test_tag1" {
+	  name = "tag1"
+	  color = "#ff0000"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_tag" "test_tag2" {
+	  name = "tag2"
+	  color = "#00ff00"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_tenant" "test_tenant1" {
+	  name = "Test Tenant 1"
+	  description = "Test tenant for azure account migration"
+	}
+
+	resource "octopusdeploy_tenant" "test_tenant2" {
+	  name = "Test Tenant 2"
+	  description = "Test tenant for azure account migration"
+	}
+
+	resource "octopusdeploy_azure_subscription_account" "azure_account" {
+	  name                               = "Azure Subscription Account"
+	  description                        = "Test Azure subscription account for migration"
+	  subscription_id                    = "00000000-0000-0000-0000-000000000000"
+	  azure_environment                  = "AzureCloud"
+	  management_endpoint                = "https://management.azure.com/"
+	  storage_endpoint_suffix            = "azure.com"
+	  tenanted_deployment_participation  = "TenantedOrUntenanted"
+	  environments                       = [octopusdeploy_environment.test_env1.id, octopusdeploy_environment.test_env2.id]
+	  tenants                            = [octopusdeploy_tenant.test_tenant1.id]
+	  tenant_tags                        = ["test-tagset/tag1", "test-tagset/tag2"]
+	  depends_on                         = [octopusdeploy_tag.test_tag1, octopusdeploy_tag.test_tag2]
+	}`
+
+const updatedAzureSubscriptionAccountConfig = `
+	resource "octopusdeploy_environment" "test_env1" {
+	  name = "Test Environment 1"
+	  description = "Test environment for azure account migration"
+	}
+
+	resource "octopusdeploy_environment" "test_env2" {
+	  name = "Test Environment 2"
+	  description = "Test environment for azure account migration"
+	}
+
+	resource "octopusdeploy_tag_set" "test_tagset" {
+	  name = "test-tagset"
+	  description = "Test tagset"
+	}
+
+	resource "octopusdeploy_tag" "test_tag1" {
+	  name = "tag1"
+	  color = "#ff0000"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_tag" "test_tag2" {
+	  name = "tag2"
+	  color = "#00ff00"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_tenant" "test_tenant1" {
+	  name = "Test Tenant 1"
+	  description = "Test tenant for azure account migration"
+	}
+
+	resource "octopusdeploy_tenant" "test_tenant2" {
+	  name = "Test Tenant 2"
+	  description = "Test tenant for azure account migration"
+	}
+
+	resource "octopusdeploy_azure_subscription_account" "azure_account" {
+	  name                               = "Updated Azure Subscription Account"
+	  description                        = "Updated test Azure subscription account"
+	  subscription_id                    = "00000000-0000-0000-0000-000000000000"
+	  azure_environment                  = "AzureCloud"
+	  management_endpoint                = "https://management.core.chinacloudapi.cn/"
+	  storage_endpoint_suffix            = "core.chinacloudapi.cn"
+	  tenanted_deployment_participation  = "TenantedOrUntenanted"
+	  environments                       = [octopusdeploy_environment.test_env1.id, octopusdeploy_environment.test_env2.id]
+	  tenants                            = [octopusdeploy_tenant.test_tenant1.id]
+	  tenant_tags                        = ["test-tagset/tag1", "test-tagset/tag2"]
+	  depends_on                         = [octopusdeploy_tag.test_tag1, octopusdeploy_tag.test_tag2]
+	}`
 
 func testAzureSubscriptionAccountDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
@@ -87,8 +173,26 @@ func testAzureSubscriptionAccountUpdated(t *testing.T) resource.TestCheckFunc {
 
 		azureAccount := account.(*accounts.AzureSubscriptionAccount)
 
-		assert.NotEmpty(t, azureAccount.GetID(), "Account ID did not match expected value")
-		assert.Equal(t, azureAccount.Name, "Update Azure Subscription Account", "Account name did not match expected value")
+		env1ID := s.RootModule().Resources["octopusdeploy_environment.test_env1"].Primary.ID
+		env2ID := s.RootModule().Resources["octopusdeploy_environment.test_env2"].Primary.ID
+		tenant1ID := s.RootModule().Resources["octopusdeploy_tenant.test_tenant1"].Primary.ID
+
+		assert.NotEmpty(t, azureAccount.GetID(), "Account ID should not be empty")
+		assert.Equal(t, "Updated Azure Subscription Account", azureAccount.Name, "Account name did not match expected value")
+		assert.Equal(t, "Updated test Azure subscription account", azureAccount.GetDescription(), "Account description did not match expected value")
+		assert.Equal(t, "AzureCloud", azureAccount.AzureEnvironment, "Azure environment did not match expected value")
+		assert.Equal(t, "https://management.core.chinacloudapi.cn/", azureAccount.ManagementEndpoint, "Management endpoint did not match expected value")
+		assert.Equal(t, "core.chinacloudapi.cn", azureAccount.StorageEndpointSuffix, "Storage endpoint suffix did not match expected value")
+		assert.Equal(t, "TenantedOrUntenanted", string(azureAccount.GetTenantedDeploymentMode()), "Tenanted deployment participation did not match expected value")
+
+		expectedEnvironmentIDs := []string{env1ID, env2ID}
+		assert.ElementsMatch(t, expectedEnvironmentIDs, azureAccount.GetEnvironmentIDs(), "Environment IDs should match expected values")
+
+		expectedTenantIDs := []string{tenant1ID}
+		assert.ElementsMatch(t, expectedTenantIDs, azureAccount.GetTenantIDs(), "Tenant IDs should match expected values")
+
+		expectedTenantTags := []string{"test-tagset/tag1", "test-tagset/tag2"}
+		assert.ElementsMatch(t, expectedTenantTags, azureAccount.TenantTags, "Tenant tags should match expected values")
 
 		return nil
 	}

--- a/octopusdeploy_framework/resource_channel_migration_test.go
+++ b/octopusdeploy_framework/resource_channel_migration_test.go
@@ -1,0 +1,176 @@
+package octopusdeploy_framework
+
+import (
+	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestChannelResource_UpgradeFromSDK_ToPluginFramework(t *testing.T) {
+	os.Setenv("TF_CLI_CONFIG_FILE=", "")
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy: testChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"octopusdeploy": {
+						VersionConstraint: "1.3.1",
+						Source:            "OctopusDeploy/octopusdeploy",
+					},
+				},
+				Config: channelConfig,
+			},
+			{
+				ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+				Config:                   channelConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+				Config:                   updatedChannelConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testChannelUpdated(t),
+				),
+			},
+		},
+	})
+}
+
+const channelConfig = `
+	resource "octopusdeploy_lifecycle" "test_lifecycle" {
+	  name = "Test Lifecycle"
+	  description = "Test lifecycle for channel migration"
+	}
+
+	resource "octopusdeploy_lifecycle" "custom_lifecycle" {
+	  name = "Custom Lifecycle"
+	  description = "Custom lifecycle for channel"
+	}
+
+	resource "octopusdeploy_project_group" "test_project_group" {
+	  name = "Test Project Group"
+	  description = "Test project group for channel migration"
+	}
+
+	resource "octopusdeploy_tag_set" "test_tagset" {
+	  name = "test-tagset"
+	  description = "Test tagset for channel"
+	}
+
+	resource "octopusdeploy_tag" "test_tag1" {
+	  name = "tag1"
+	  color = "#ff0000"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_tag" "test_tag2" {
+	  name = "tag2"
+	  color = "#00ff00"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_project" "test_project" {
+	  lifecycle_id     = octopusdeploy_lifecycle.test_lifecycle.id
+	  name             = "Test Project"
+	  description      = "Test project for channel migration"
+	  project_group_id = octopusdeploy_project_group.test_project_group.id
+	}
+
+	resource "octopusdeploy_channel" "test_channel" {
+	  name         = "Test Channel"
+	  description  = "Test channel for migration"
+	  project_id   = octopusdeploy_project.test_project.id
+	  lifecycle_id = octopusdeploy_lifecycle.custom_lifecycle.id
+	  is_default   = false
+	  tenant_tags  = [octopusdeploy_tag.test_tag1.canonical_tag_name, octopusdeploy_tag.test_tag2.canonical_tag_name]
+	}`
+
+const updatedChannelConfig = `
+	resource "octopusdeploy_lifecycle" "test_lifecycle" {
+	  name = "Test Lifecycle"
+	  description = "Test lifecycle for channel migration"
+	}
+
+	resource "octopusdeploy_lifecycle" "custom_lifecycle" {
+	  name = "Custom Lifecycle"
+	  description = "Custom lifecycle for channel"
+	}
+
+	resource "octopusdeploy_project_group" "test_project_group" {
+	  name = "Test Project Group"
+	  description = "Test project group for channel migration"
+	}
+
+	resource "octopusdeploy_tag_set" "test_tagset" {
+	  name = "test-tagset"
+	  description = "Test tagset for channel"
+	}
+
+	resource "octopusdeploy_tag" "test_tag1" {
+	  name = "tag1"
+	  color = "#ff0000"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_tag" "test_tag2" {
+	  name = "tag2"
+	  color = "#00ff00"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_tag" "test_tag3" {
+	  name = "tag3"
+	  color = "#0000ff"
+	  tag_set_id = octopusdeploy_tag_set.test_tagset.id
+	}
+
+	resource "octopusdeploy_project" "test_project" {
+	  lifecycle_id     = octopusdeploy_lifecycle.test_lifecycle.id
+	  name             = "Test Project"
+	  description      = "Test project for channel migration"
+	  project_group_id = octopusdeploy_project_group.test_project_group.id
+	}
+
+	resource "octopusdeploy_channel" "test_channel" {
+	  name         = "Updated Test Channel"
+	  description  = "Updated test channel for migration"
+	  project_id   = octopusdeploy_project.test_project.id
+	  lifecycle_id = octopusdeploy_lifecycle.custom_lifecycle.id
+	  is_default   = false
+	  tenant_tags  = [octopusdeploy_tag.test_tag1.canonical_tag_name, octopusdeploy_tag.test_tag3.canonical_tag_name]
+	}`
+
+func testChannelUpdated(t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		channelId := s.RootModule().Resources["octopusdeploy_channel.test_channel"].Primary.ID
+		channel, err := channels.GetByID(octoClient, octoClient.GetSpaceID(), channelId)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve channel by ID: %s", err)
+		}
+
+		projectID := s.RootModule().Resources["octopusdeploy_project.test_project"].Primary.ID
+		lifecycleID := s.RootModule().Resources["octopusdeploy_lifecycle.custom_lifecycle"].Primary.ID
+
+		assert.NotEmpty(t, channel.GetID(), "Channel ID should not be empty")
+		assert.Equal(t, "Updated Test Channel", channel.Name, "Channel name did not match expected value")
+		assert.Equal(t, "Updated test channel for migration", channel.Description, "Channel description did not match expected value")
+		assert.Equal(t, projectID, channel.ProjectID, "Project ID did not match expected value")
+		assert.Equal(t, lifecycleID, channel.LifecycleID, "Lifecycle ID did not match expected value")
+		assert.True(t, channel.IsDefault, "Channel should be default")
+
+		expectedTenantTags := []string{"test-tagset/tag1", "test-tagset/tag3"}
+		assert.ElementsMatch(t, expectedTenantTags, channel.TenantTags, "Tenant tags should match expected values")
+
+		return nil
+	}
+}


### PR DESCRIPTION
The migration missed fixed by https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/73 served as an important reminder that all migrations should have comprehensive testing to ensure no breaking changes are surfaced to customers.

- Adds migration tests for `octopusdeploy_channel`.
- Updates migration tests for `octopusdeploy_azure_subscription_account` to cover more attributes.