### PR TITLE
Add check-migration-tests job to github workflow

### DIFF
--- a/.github/workflows/require-migration-tests.yml
+++ b/.github/workflows/require-migration-tests.yml
@@ -1,4 +1,4 @@
-name: Require Tests for SDKv2 to TFP Resource Migrations
+name: Require Tests for SDKv2 to TPF Migrations
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-migration-tests:
-    name: Check Migration Tests Required
+    name: Require Tests for SDKv2 to TPF Migrations
     runs-on: ubuntu-latest
 
     steps:

--- a/ci-scripts/helpers/check_migration_tests.sh
+++ b/ci-scripts/helpers/check_migration_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Check for missing migration tests when SDKv2 resources are replaced with TFP resources
+# Check for missing migration tests when SDKv2 resources are replaced with TPF resources
 # Usage: check_migration_tests.sh <base_ref>
 
 set -e
@@ -10,18 +10,18 @@ CURRENT_REF=${GITHUB_REF:-HEAD}
 
 echo "Checking for migration tests between $BASE_REF and $CURRENT_REF"
 
-# Get deleted SDKv2 and new TFP resources
+# Get deleted SDKv2 and new TPF resources
 deleted_sdkv2=$(git diff --name-status $BASE_REF..$CURRENT_REF | grep '^D.*octopusdeploy/resource_.*\.go$' | grep -v '_test\.go$' || true)
-new_tfp=$(git diff --name-status $BASE_REF..$CURRENT_REF | grep '^A.*octopusdeploy_framework/resource_.*\.go$' | grep -v '_test\.go$' | grep -v '_migration_test\.go$' || true)
+new_tpf=$(git diff --name-status $BASE_REF..$CURRENT_REF | grep '^A.*octopusdeploy_framework/resource_.*\.go$' | grep -v '_test\.go$' | grep -v '_migration_test\.go$' || true)
 
-if [ ! -z "$deleted_sdkv2" ] && [ ! -z "$new_tfp" ]; then
+if [ ! -z "$deleted_sdkv2" ] && [ ! -z "$new_tpf" ]; then
   missing_tests=""
   
   # Extract resource names and check for matches
   for deleted_file in $deleted_sdkv2; do
     deleted_resource=$(echo "$deleted_file" | sed 's/.*resource_\(.*\)\.go$/\1/')
     
-    for new_file in $new_tfp; do
+    for new_file in $new_tpf; do
       new_resource=$(echo "$new_file" | sed 's/.*resource_\(.*\)\.go$/\1/')
       
       if [ "$deleted_resource" = "$new_resource" ]; then
@@ -36,7 +36,7 @@ if [ ! -z "$deleted_sdkv2" ] && [ ! -z "$new_tfp" ]; then
   done
   
   if [ ! -z "$missing_tests" ]; then
-    echo "::error::Migration tests required when replacing SDKV2 resources with TFP resources."
+    echo "::error::Migration tests required when replacing SDKV2 resources with TPF resources."
     echo "Missing migration tests for:$missing_tests"
     echo "Required files:"
     for resource in $missing_tests; do


### PR DESCRIPTION
Background:

It's important that we build trust with consumers of our TF provider. While we can't guarantee no breakages, we can take effects to drive the risk of unplanned breakages as close to zero as possible. 

Migrations from SDKv2 to TFP can be trickty, and automated testing is an important safety net to avoid unexpected breakages when migrating a resource. While we can generally rely on engineers to write tests to accompany their changes, migrating terraform resources is a fairly niche domain which takes a few gos to get comfortable with. The more we signpost best practices, the more we insulate our users from having their config broken, and  our engineers from the unpleasant experience of breaking things.

Details:

This adds a script which detects if a resource has been deleted from the `octopusdeploy` resource directory and a new one with the same name added to the `octopusdeploy_framework` directory and ensures an accompanying migration test exists.

Testing:

- Returns `1` (error) if a resource migration has occurred but no test exists.
- Returns `0` (success) if no resource migration has occurred.
- Returns `0` (success) if a resource migration has occurred and a matching test can be found.