### PR TITLE
Fix community step templates

### DIFF
--- a/octopusdeploy_framework/datasource_community_step_template.go
+++ b/octopusdeploy_framework/datasource_community_step_template.go
@@ -6,12 +6,9 @@ import (
 	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -22,6 +19,7 @@ type communityStepTemplateDataSource struct {
 func NewCommunityStepTemplateDataSource() datasource.DataSource {
 	return &communityStepTemplateDataSource{}
 }
+
 func (*communityStepTemplateDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = util.GetTypeName("community_step_template")
 }
@@ -34,7 +32,7 @@ func (d *communityStepTemplateDataSource) Configure(_ context.Context, req datas
 	d.Config = DataSourceConfiguration(req, resp)
 }
 
-func (d *stepTemplateDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *communityStepTemplateDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var err error
 	var data schemas.CommunityStepTemplateTypeDataSourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -42,15 +40,19 @@ func (d *stepTemplateDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
+	var ids []string
+	resp.Diagnostics.Append(data.IDs.ElementsAs(ctx, &ids, false)...)
+
 	query := struct {
 		ID      string
+		IDs     []string
 		Website string
 		Name    string
-	}{data.ID.ValueString(), data.Website.ValueString(), data.Name.ValueString()}
+	}{data.ID.ValueString(), ids, data.Website.ValueString(), data.Name.ValueString()}
 
 	util.DatasourceReading(ctx, "community_step_templates", query)
 
-	communityStepTemplates, err := d.Config.Client.CommunityActionTemplates.GetAll()
+	communityStepTemplates, err := d.getCommunityStepTemplate(query.ID, query.IDs)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to query community step templates", err.Error())
@@ -66,21 +68,61 @@ func (d *stepTemplateDataSource) Read(ctx context.Context, req datasource.ReadRe
 		if strings.TrimSpace(query.Website) != "" && communityStepTemplate.Website != query.Website {
 			continue
 		}
-		if strings.TrimSpace(query.Name) != "" && communityStepTemplate.Name != query.Name {
+		if strings.TrimSpace(query.Name) != "" && communityStepTemplate.Name != data.Name.ValueString() {
 			continue
 		}
 		matchingCommunityStepTemplates = append(matchingCommunityStepTemplates, communityStepTemplate)
 	}
 
-	flattenedSteps := []interface{}{}
-	for _, step := range matchingCommunityStepTemplates {
-		flattenedSteps = append(flattenedSteps, schemas.FlattenTenant(step))
-	}
-
-	util.DatasourceResultCount(ctx, "community_step_templates", len(flattenedSteps))
+	util.DatasourceResultCount(ctx, "community_step_templates", len(matchingCommunityStepTemplates))
 
 	data.ID = types.StringValue("Tenants " + time.Now().UTC().String())
-	data.Steps, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.TenantObjectType()}, flattenedSteps)
+	data.Steps = make([]schemas.CommunityStepTemplateTypeResourceModel, 0, len(matchingCommunityStepTemplates))
+	for _, project := range matchingCommunityStepTemplates {
+		data.Steps = append(data.Steps, flattenStep(project))
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (d *communityStepTemplateDataSource) getCommunityStepTemplate(id string, ids []string) ([]*actions.CommunityActionTemplate, error) {
+	queryIds := []string{}
+
+	if len(ids) > 0 {
+		queryIds = ids
+	}
+
+	if strings.TrimSpace(id) != "" {
+		queryIds = append(queryIds, id)
+	}
+
+	// Optimise the query by only requesting the IDs that are needed.
+	// This does filtering server side.
+	if len(queryIds) != 0 {
+		return d.Config.Client.CommunityActionTemplates.GetByIDs(queryIds)
+	}
+
+	// Otherwise we have to filter client side.
+	return d.Config.Client.CommunityActionTemplates.GetAll()
+}
+
+func flattenStep(step *actions.CommunityActionTemplate) schemas.CommunityStepTemplateTypeResourceModel {
+	resourceModel := schemas.CommunityStepTemplateTypeResourceModel{
+		Type:          types.StringValue(step.Type),
+		Author:        types.StringValue(step.Author),
+		Name:          types.StringValue(step.Name),
+		Description:   types.StringValue(step.Description),
+		Packages:      types.List{},
+		Website:       types.StringValue(step.Website),
+		HistoryUrl:    types.StringValue(step.HistoryURL),
+		Parameters:    types.List{},
+		Properties:    types.Map{},
+		StepPackageId: types.StringValue(step.ActionType),
+		Version:       types.Int32Value(step.Version),
+		ResourceModel: schemas.ResourceModel{
+			ID: types.StringValue(step.ID),
+		},
+	}
+
+	return resourceModel
 }

--- a/octopusdeploy_framework/datasource_community_step_template.go
+++ b/octopusdeploy_framework/datasource_community_step_template.go
@@ -6,10 +6,12 @@ import (
 	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 type communityStepTemplateDataSource struct {
@@ -99,4 +101,15 @@ func (d *communityStepTemplateDataSource) getCommunityStepTemplate(id string) ([
 
 	// Otherwise we have to filter client side.
 	return d.Config.Client.CommunityActionTemplates.GetAll()
+}
+
+func mapCommunityStepTemplateToDatasourceModel(data *schemas.CommunityStepTemplateTypeDataSourceModel, at *actions.CommunityActionTemplate) diag.Diagnostics {
+	resp := diag.Diagnostics{}
+
+	data.ID = types.StringValue(at.ID)
+	data.SpaceID = types.StringValue(at.SpaceID)
+	stepTemplate, dg := convertStepTemplateAttributes(at)
+	resp.Append(dg...)
+	data.StepTemplate = stepTemplate
+	return resp
 }

--- a/octopusdeploy_framework/datasource_community_step_template.go
+++ b/octopusdeploy_framework/datasource_community_step_template.go
@@ -1,0 +1,86 @@
+package octopusdeploy_framework
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type communityStepTemplateDataSource struct {
+	*Config
+}
+
+func NewCommunityStepTemplateDataSource() datasource.DataSource {
+	return &communityStepTemplateDataSource{}
+}
+func (*communityStepTemplateDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = util.GetTypeName("community_step_template")
+}
+
+func (*communityStepTemplateDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schemas.CommunityStepTemplateSchema{}.GetDatasourceSchema()
+}
+
+func (d *communityStepTemplateDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	d.Config = DataSourceConfiguration(req, resp)
+}
+
+func (d *stepTemplateDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var err error
+	var data schemas.CommunityStepTemplateTypeDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	query := struct {
+		ID      string
+		Website string
+		Name    string
+	}{data.ID.ValueString(), data.Website.ValueString(), data.Name.ValueString()}
+
+	util.DatasourceReading(ctx, "community_step_templates", query)
+
+	communityStepTemplates, err := d.Config.Client.CommunityActionTemplates.GetAll()
+
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to query community step templates", err.Error())
+		return
+	}
+
+	matchingCommunityStepTemplates := []*actions.CommunityActionTemplate{}
+
+	for _, communityStepTemplate := range communityStepTemplates {
+		if strings.TrimSpace(query.ID) != "" && communityStepTemplate.ID != query.ID {
+			continue
+		}
+		if strings.TrimSpace(query.Website) != "" && communityStepTemplate.Website != query.Website {
+			continue
+		}
+		if strings.TrimSpace(query.Name) != "" && communityStepTemplate.Name != query.Name {
+			continue
+		}
+		matchingCommunityStepTemplates = append(matchingCommunityStepTemplates, communityStepTemplate)
+	}
+
+	flattenedSteps := []interface{}{}
+	for _, step := range matchingCommunityStepTemplates {
+		flattenedSteps = append(flattenedSteps, schemas.FlattenTenant(step))
+	}
+
+	util.DatasourceResultCount(ctx, "community_step_templates", len(flattenedSteps))
+
+	data.ID = types.StringValue("Tenants " + time.Now().UTC().String())
+	data.Steps, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.TenantObjectType()}, flattenedSteps)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/octopusdeploy_framework/datasource_community_step_template.go
+++ b/octopusdeploy_framework/datasource_community_step_template.go
@@ -85,7 +85,7 @@ func (d *communityStepTemplateDataSource) Read(ctx context.Context, req datasour
 	}
 
 	data.ID = types.StringValue("CommunityActionTemplates " + time.Now().UTC().String())
-	steps, stepsDiag := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.CommunityStepTemplateTypeObjectType()}, matchingCommunityStepTemplates)
+	steps, stepsDiag := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.CommunityStepTemplateTypeObjectType()}, communityStepTemplateResourceModels)
 	resp.Diagnostics.Append(stepsDiag...)
 	data.Steps = steps
 

--- a/octopusdeploy_framework/datasource_community_step_template.go
+++ b/octopusdeploy_framework/datasource_community_step_template.go
@@ -77,7 +77,9 @@ func (d *communityStepTemplateDataSource) Read(ctx context.Context, req datasour
 	util.DatasourceResultCount(ctx, "community_step_templates", len(matchingCommunityStepTemplates))
 
 	data.ID = types.StringValue("CommunityActionTemplates " + time.Now().UTC().String())
-	data.Steps, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.CommunityStepTemplateTypeObjectType()}, matchingCommunityStepTemplates)
+	steps, stepsDiag := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.CommunityStepTemplateTypeObjectType()}, matchingCommunityStepTemplates)
+	resp.Diagnostics.Append(stepsDiag...)
+	data.Steps = steps
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/octopusdeploy_framework/datasource_community_step_template.go
+++ b/octopusdeploy_framework/datasource_community_step_template.go
@@ -6,12 +6,10 @@ import (
 	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 type communityStepTemplateDataSource struct {
@@ -78,6 +76,14 @@ func (d *communityStepTemplateDataSource) Read(ctx context.Context, req datasour
 
 	util.DatasourceResultCount(ctx, "community_step_templates", len(matchingCommunityStepTemplates))
 
+	communityStepTemplateResourceModels := []schemas.CommunityStepTemplateTypeResourceModel{}
+	for _, communityStepTemplate := range matchingCommunityStepTemplates {
+		stepTemplate := schemas.CommunityStepTemplateTypeResourceModel{}
+		stepTemplateDiag := mapCommunityStepTemplateToCommunityResourceModel(ctx, &stepTemplate, communityStepTemplate)
+		resp.Diagnostics.Append(stepTemplateDiag...)
+		communityStepTemplateResourceModels = append(communityStepTemplateResourceModels, stepTemplate)
+	}
+
 	data.ID = types.StringValue("CommunityActionTemplates " + time.Now().UTC().String())
 	steps, stepsDiag := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.CommunityStepTemplateTypeObjectType()}, matchingCommunityStepTemplates)
 	resp.Diagnostics.Append(stepsDiag...)
@@ -101,15 +107,4 @@ func (d *communityStepTemplateDataSource) getCommunityStepTemplate(id string) ([
 
 	// Otherwise we have to filter client side.
 	return d.Config.Client.CommunityActionTemplates.GetAll()
-}
-
-func mapCommunityStepTemplateToDatasourceModel(data *schemas.CommunityStepTemplateTypeDataSourceModel, at *actions.CommunityActionTemplate) diag.Diagnostics {
-	resp := diag.Diagnostics{}
-
-	data.ID = types.StringValue(at.ID)
-	data.SpaceID = types.StringValue(at.SpaceID)
-	stepTemplate, dg := convertStepTemplateAttributes(at)
-	resp.Append(dg...)
-	data.StepTemplate = stepTemplate
-	return resp
 }

--- a/octopusdeploy_framework/datasource_step_template.go
+++ b/octopusdeploy_framework/datasource_step_template.go
@@ -2,6 +2,8 @@ package octopusdeploy_framework
 
 import (
 	"context"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
@@ -123,4 +125,38 @@ func convertStepTemplateAttributes(at *actiontemplates.ActionTemplate) (types.Ob
 	})
 	diags.Append(dg...)
 	return stepTemplate, diags
+}
+
+func mapCommunityStepTemplateToCommunityResourceModel(ctx context.Context, data *schemas.CommunityStepTemplateTypeResourceModel, at *actions.CommunityActionTemplate) diag.Diagnostics {
+	resp := diag.Diagnostics{}
+
+	data.ID = types.StringValue(at.ID)
+	data.Name = types.StringValue(at.Name)
+	data.Version = types.Int32Value(at.Version)
+	data.Description = types.StringValue(at.Description)
+	data.Website = types.StringValue(at.Website)
+	data.HistoryUrl = types.StringValue(at.HistoryURL)
+	data.Type = types.StringValue(at.ActionType)
+	data.Author = types.StringValue(at.Author)
+
+	// Parameters
+	sParams, dg := convertStepTemplateToParameterAttributes(ctx, at.Parameters, data.Parameters)
+	resp.Append(dg...)
+	data.Parameters = sParams
+
+	// Properties
+	stringProps := make(map[string]attr.Value, len(at.Properties))
+	for keys, value := range at.Properties {
+		stringProps[keys] = types.StringValue(value.Value)
+	}
+	props, dg := types.MapValue(types.StringType, stringProps)
+	resp.Append(dg...)
+	data.Properties = props
+
+	// Packages
+	pkgs, dg := convertStepTemplateToPackageAttributes(at.Packages)
+	resp.Append(dg...)
+	data.Packages = pkgs
+
+	return resp
 }

--- a/octopusdeploy_framework/framework_provider.go
+++ b/octopusdeploy_framework/framework_provider.go
@@ -2,13 +2,14 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"os"
+
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"os"
 )
 
 type octopusDeployFrameworkProvider struct {
@@ -74,6 +75,7 @@ func (p *octopusDeployFrameworkProvider) DataSources(ctx context.Context) []func
 		NewLifecyclesDataSource,
 		NewEnvironmentsDataSource,
 		NewStepTemplateDataSource,
+		NewCommunityStepTemplateDataSource,
 		NewGitCredentialsDataSource,
 		NewFeedsDataSource,
 		NewLibraryVariableSetDataSource,
@@ -107,6 +109,7 @@ func (p *octopusDeployFrameworkProvider) Resources(ctx context.Context) []func()
 		NewLifecycleResource,
 		NewEnvironmentResource,
 		NewStepTemplateResource,
+		NewCommunityStepTemplateResource,
 		NewGitCredentialResource,
 		NewHelmFeedResource,
 		NewArtifactoryGenericFeedResource,

--- a/octopusdeploy_framework/resource_community_step_template.go
+++ b/octopusdeploy_framework/resource_community_step_template.go
@@ -1,0 +1,127 @@
+package octopusdeploy_framework
+
+import (
+	"context"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+type communityStepTemplateTypeResource struct {
+	*Config
+}
+
+var (
+	_ resource.ResourceWithImportState    = &communityStepTemplateTypeResource{}
+	_ resource.ResourceWithValidateConfig = &communityStepTemplateTypeResource{}
+)
+
+func NewCommunityStepTemplateResource() resource.Resource {
+	return &communityStepTemplateTypeResource{}
+}
+
+func (r *communityStepTemplateTypeResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = util.GetTypeName("community_step_template")
+}
+
+func (r *communityStepTemplateTypeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schemas.CommunityStepTemplateSchema{}.GetResourceSchema()
+}
+
+func (r *communityStepTemplateTypeResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.Config = ResourceConfiguration(req, resp)
+}
+
+func (*communityStepTemplateTypeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *communityStepTemplateTypeResource) ValidateConfig(ctx context.Context, request resource.ValidateConfigRequest, response *resource.ValidateConfigResponse) {
+	var data schemas.StepTemplateTypeResourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *communityStepTemplateTypeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data schemas.StepTemplateTypeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newActionTemplate, dg := mapStepTemplateResourceModelToActionTemplate(ctx, data)
+	resp.Diagnostics.Append(dg...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The end users work with action templates, not community step templates.
+	// The difference with a community step template is that it is installed rather than created.
+	// But the end result of an installed community step template is a regular (if read only) action template in the current space.
+	communityStepTemplate := actions.NewCommunityActionTemplate(newActionTemplate.Name, newActionTemplate.ActionType)
+	communityStepTemplate.ID = newActionTemplate.CommunityActionTemplateID
+
+	// Installing a community step template essentially creates a read only step template in the current space.
+	communityStepTemplate, err := r.Config.Client.CommunityActionTemplates.Install(*communityStepTemplate)
+
+	if err != nil {
+		resp.Diagnostics.AddError("unable to install community step template", err.Error())
+		return
+	}
+
+	// read the details of the newly installed step template
+	actionTemplate, err := actiontemplates.GetByID(r.Config.Client, data.SpaceID.ValueString(), communityStepTemplate.ID)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to read the installed community step template", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(mapStepTemplateToResourceModel(ctx, &data, actionTemplate)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *communityStepTemplateTypeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data schemas.StepTemplateTypeResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Unlike the Create function, we read a community step template just like a regular action template.
+	// This is because the community step template is installed in the current space and is accessed via the action templates API.
+	actionTemplate, err := actiontemplates.GetByID(r.Config.Client, data.SpaceID.ValueString(), data.ID.ValueString())
+	if err != nil {
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "action template"); err != nil {
+			resp.Diagnostics.AddError("unable to load environment", err.Error())
+		}
+		return
+	}
+
+	resp.Diagnostics.Append(mapStepTemplateToResourceModel(ctx, &data, actionTemplate)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *communityStepTemplateTypeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Step templates based on community step templates are read only.
+}
+
+func (r *communityStepTemplateTypeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data schemas.StepTemplateTypeResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := actiontemplates.DeleteByID(r.Config.Client, data.SpaceID.ValueString(), data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("unable to delete step template", err.Error())
+		return
+	}
+}

--- a/octopusdeploy_framework/resource_community_step_template.go
+++ b/octopusdeploy_framework/resource_community_step_template.go
@@ -114,6 +114,7 @@ func (r *communityStepTemplateTypeResource) Update(ctx context.Context, req reso
 	// Step templates based on community step templates are read only.
 }
 
+// Delete is used to uninstall the community step template by deleting the action template that was created when the community step template was installed.
 func (r *communityStepTemplateTypeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data schemas.StepTemplateFromCommunityStepTemplateTypeResourceModel
 
@@ -128,6 +129,8 @@ func (r *communityStepTemplateTypeResource) Delete(ctx context.Context, req reso
 	}
 }
 
+// The act of creating a community step template is actually installing a step template into the space.
+// The thing we return to the user is a regular action template, which is what they will use in their deployments.
 func mapCommunityStepTemplateToResourceModel(ctx context.Context, data *schemas.StepTemplateFromCommunityStepTemplateTypeResourceModel, at *actiontemplates.ActionTemplate) diag.Diagnostics {
 	resp := diag.Diagnostics{}
 

--- a/octopusdeploy_framework/resource_community_step_template.go
+++ b/octopusdeploy_framework/resource_community_step_template.go
@@ -160,3 +160,37 @@ func mapCommunityStepTemplateToResourceModel(ctx context.Context, data *schemas.
 
 	return resp
 }
+
+func mapCommunityStepTemplateToCommunityResourceModel(ctx context.Context, data *schemas.CommunityStepTemplateTypeResourceModel, at *actions.CommunityActionTemplate) diag.Diagnostics {
+	resp := diag.Diagnostics{}
+
+	data.ID = types.StringValue(at.ID)
+	data.Name = types.StringValue(at.Name)
+	data.Version = types.Int32Value(at.Version)
+	data.Description = types.StringValue(at.Description)
+	data.Website = types.StringValue(at.Website)
+	data.HistoryUrl = types.StringValue(at.HistoryURL)
+	data.Type = types.StringValue(at.ActionType)
+	data.Author = types.StringValue(at.Author)
+
+	// Parameters
+	sParams, dg := convertStepTemplateToParameterAttributes(ctx, at.Parameters, data.Parameters)
+	resp.Append(dg...)
+	data.Parameters = sParams
+
+	// Properties
+	stringProps := make(map[string]attr.Value, len(at.Properties))
+	for keys, value := range at.Properties {
+		stringProps[keys] = types.StringValue(value.Value)
+	}
+	props, dg := types.MapValue(types.StringType, stringProps)
+	resp.Append(dg...)
+	data.Properties = props
+
+	// Packages
+	pkgs, dg := convertStepTemplateToPackageAttributes(at.Packages)
+	resp.Append(dg...)
+	data.Packages = pkgs
+
+	return resp
+}

--- a/octopusdeploy_framework/resource_community_step_template.go
+++ b/octopusdeploy_framework/resource_community_step_template.go
@@ -160,37 +160,3 @@ func mapCommunityStepTemplateToResourceModel(ctx context.Context, data *schemas.
 
 	return resp
 }
-
-func mapCommunityStepTemplateToCommunityResourceModel(ctx context.Context, data *schemas.CommunityStepTemplateTypeResourceModel, at *actions.CommunityActionTemplate) diag.Diagnostics {
-	resp := diag.Diagnostics{}
-
-	data.ID = types.StringValue(at.ID)
-	data.Name = types.StringValue(at.Name)
-	data.Version = types.Int32Value(at.Version)
-	data.Description = types.StringValue(at.Description)
-	data.Website = types.StringValue(at.Website)
-	data.HistoryUrl = types.StringValue(at.HistoryURL)
-	data.Type = types.StringValue(at.ActionType)
-	data.Author = types.StringValue(at.Author)
-
-	// Parameters
-	sParams, dg := convertStepTemplateToParameterAttributes(ctx, at.Parameters, data.Parameters)
-	resp.Append(dg...)
-	data.Parameters = sParams
-
-	// Properties
-	stringProps := make(map[string]attr.Value, len(at.Properties))
-	for keys, value := range at.Properties {
-		stringProps[keys] = types.StringValue(value.Value)
-	}
-	props, dg := types.MapValue(types.StringType, stringProps)
-	resp.Append(dg...)
-	data.Properties = props
-
-	// Packages
-	pkgs, dg := convertStepTemplateToPackageAttributes(at.Packages)
-	resp.Append(dg...)
-	data.Packages = pkgs
-
-	return resp
-}

--- a/octopusdeploy_framework/resource_community_step_template_test.go
+++ b/octopusdeploy_framework/resource_community_step_template_test.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
@@ -17,7 +18,7 @@ func TestAccOctopusCommunityStepTemplateBasic(t *testing.T) {
 	website2 := "https://library.octopus.com/step-templates/6042d737-5902-0729-ae57-8b6650a299da"
 
 	resource.Test(t, resource.TestCase{
-		CheckDestroy:             func(s *terraform.State) error { return testCommunityStepTemplateDestroy(s, localName) },
+		CheckDestroy:             func(s *terraform.State) error { return testCommunityStepTemplateDestroy(s) },
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
@@ -26,6 +27,10 @@ func TestAccOctopusCommunityStepTemplateBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(prefix, "id"),
 					resource.TestCheckResourceAttrSet(prefix, "community_action_template_id"),
+					resource.TestCheckResourceAttrWith(prefix, "community_action_template_id", func(value string) error {
+						fmt.Fprintf(os.Stderr, "Community Action Template ID: %s\n", value)
+						return nil
+					}),
 				),
 			},
 			{
@@ -54,7 +59,7 @@ func testCommunityStepTemplate(website string, name string) string {
 	)
 }
 
-func testCommunityStepTemplateDestroy(s *terraform.State, localName string) error {
+func testCommunityStepTemplateDestroy(s *terraform.State) error {
 	if octoClient == nil {
 		return fmt.Errorf("octoClient is nil")
 	}

--- a/octopusdeploy_framework/resource_community_step_template_test.go
+++ b/octopusdeploy_framework/resource_community_step_template_test.go
@@ -1,0 +1,123 @@
+package octopusdeploy_framework
+
+import (
+	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"testing"
+)
+
+func TestAccOctopusStepTemplateBasic(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	prefix := "octopusdeploy_step_template." + localName
+	data := stepTemplateTestData{
+		localName:     localName,
+		prefix:        prefix,
+		actionType:    "Octopus.Script",
+		name:          acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
+		description:   acctest.RandStringFromCharSet(20, acctest.CharSetAlpha),
+		stepPackageID: "Octopus.Script",
+		packages: []stepTemplatePackageTestData{
+			{
+				packageID:          "force",
+				acquisitonLocation: "Server",
+				feedID:             "feeds-builtin",
+				name:               "mypackage",
+				properties: stepTemplatePackagePropsTestData{
+					extract:       "True",
+					purpose:       "",
+					selectionMode: "immediate",
+				},
+			},
+		},
+		parameters: []stepTemplateParamTestData{
+			{
+				defaultValue: "Hello World",
+				displaySettings: map[string]string{
+					"Octopus.ControlType": "SingleLineText",
+				},
+				helpText: acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
+				label:    acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
+				name:     acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
+				id:       "621e1584-cdf3-4b67-9204-fc82430c908c",
+			},
+			{
+				defaultValue: "Hello Earth",
+				displaySettings: map[string]string{
+					"Octopus.ControlType": "SingleLineText",
+				},
+				helpText: acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
+				label:    acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
+				name:     acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
+				id:       "cd731d21-669a-42e1-81af-048681fd5c69",
+			},
+		},
+		properties: map[string]string{
+			"Octopus.Action.Script.ScriptBody":   "echo 'Hello World'",
+			"Octopus.Action.Script.ScriptSource": "Inline",
+			"Octopus.Action.Script.Syntax":       "Bash",
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             func(s *terraform.State) error { return testStepTemplateDestroy(s, localName) },
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testStepTemplateRunScriptBasic(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(prefix, "name", data.name),
+				),
+			},
+			{
+				Config: testStepTemplateRunScriptUpdate(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(prefix, "name", data.name+"-updated"),
+				),
+			},
+		},
+	})
+}
+
+func testStepTemplateRunScriptBasic(data stepTemplateTestData) string {
+	return fmt.Sprintf(`
+		resource "octopusdeploy_community_step_template" "template" {
+			community_action_template_id="CommunityActionTemplates-11"
+		}
+`,
+	)
+}
+
+func testStepTemplateRunScriptUpdate(data stepTemplateTestData) string {
+	data.name = data.name + "-updated"
+
+	return testStepTemplateRunScriptBasic(data)
+}
+
+func testStepTemplateDestroy(s *terraform.State, localName string) error {
+	var actionTemplateID string
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "octopusdeploy_step_template" {
+			continue
+		}
+
+		actionTemplateID = rs.Primary.ID
+		break
+	}
+	if actionTemplateID == "" {
+		return fmt.Errorf("no octopusdeploy_step_template resource found")
+	}
+
+	actionTemplate, err := actiontemplates.GetByID(octoClient, octoClient.GetSpaceID(), actionTemplateID)
+	if err == nil {
+		if actionTemplate != nil {
+			return fmt.Errorf("step template (%s) still exists", actionTemplate.Name)
+		}
+	}
+
+	return nil
+}

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -29,7 +29,6 @@ const (
 // CommunityStepTemplateTypeDataSourceModel represents the data source defined in the Terraform configuration.
 type CommunityStepTemplateTypeDataSourceModel struct {
 	ID      types.String `tfsdk:"id"`
-	SpaceID types.String `tfsdk:"space_id"`
 	Website types.String `tfsdk:"website"`
 	Name    types.String `tfsdk:"name"`
 	Steps   types.List   `tfsdk:"steps"`
@@ -38,15 +37,14 @@ type CommunityStepTemplateTypeDataSourceModel struct {
 // CommunityStepTemplateTypeObjectType returns the type mapping used to define the Steps attribute in the CommunityStepTemplateTypeDataSourceModel.
 func CommunityStepTemplateTypeObjectType() map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":              types.StringType,
-		"author":          types.StringType,
-		"action_type":     types.StringType,
-		"name":            types.StringType,
-		"description":     types.StringType,
-		"website":         types.StringType,
-		"history_url":     types.StringType,
-		"version":         types.Int32Type,
-		"step_package_id": types.StringType,
+		"id":          types.StringType,
+		"author":      types.StringType,
+		"type":        types.StringType,
+		"name":        types.StringType,
+		"description": types.StringType,
+		"website":     types.StringType,
+		"history_url": types.StringType,
+		"version":     types.Int32Type,
 		"parameters": types.ListType{
 			ElemType: types.ObjectType{AttrTypes: ParametersObjectType()},
 		},
@@ -55,6 +53,21 @@ func CommunityStepTemplateTypeObjectType() map[string]attr.Type {
 			ElemType: types.ObjectType{AttrTypes: PackagesObjectType()},
 		},
 	}
+}
+
+type CommunityStepTemplateTypeResourceModel struct {
+	Type        types.String `tfsdk:"type"`
+	Name        types.String `tfsdk:"name"`
+	Author      types.String `tfsdk:"author"`
+	Description types.String `tfsdk:"description"`
+	Website     types.String `tfsdk:"website"`
+	HistoryUrl  types.String `tfsdk:"history_url"`
+	Version     types.Int32  `tfsdk:"version"`
+	Packages    types.List   `tfsdk:"packages"`
+	Parameters  types.List   `tfsdk:"parameters"`
+	Properties  types.Map    `tfsdk:"properties"`
+
+	ResourceModel
 }
 
 // ParametersObjectType returns the type mapping used to define the parameters attribute in the CommunityStepTemplateTypeObjectType function
@@ -117,11 +130,6 @@ func (s CommunityStepTemplateSchema) GetDatasourceSchema() ds.Schema {
 				Description: "Unique identifier of the community step template",
 				Optional:    true,
 			},
-			"space_id": ds.StringAttribute{
-				Description: "SpaceID of the Community Step Template",
-				Optional:    true,
-				Computed:    true,
-			},
 			"name": ds.StringAttribute{
 				Description: "Name of the Community Step Template",
 				Optional:    true,
@@ -150,8 +158,8 @@ func (s CommunityStepTemplateSchema) GetDataSourceStepsAttributes() map[string]d
 			Description: "The author of this " + CommunityStepTemplateResourceDescription + ".",
 			Computed:    true,
 		},
-		"action_type": ds.StringAttribute{
-			Description: "The action type of this " + CommunityStepTemplateResourceDescription + ".",
+		"type": ds.StringAttribute{
+			Description: "The type of this " + CommunityStepTemplateResourceDescription + ".",
 			Computed:    true,
 		},
 		"website": ds.StringAttribute{
@@ -160,10 +168,6 @@ func (s CommunityStepTemplateSchema) GetDataSourceStepsAttributes() map[string]d
 		},
 		"history_url": ds.StringAttribute{
 			Description: "The history url of this " + CommunityStepTemplateResourceDescription + ".",
-			Computed:    true,
-		},
-		"step_package_id": ds.StringAttribute{
-			Description: "The step package ID url of this " + CommunityStepTemplateResourceDescription + ".",
 			Computed:    true,
 		},
 		"version": ds.Int32Attribute{

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -58,7 +58,6 @@ type StepTemplateFromCommunityStepTemplateTypeResourceModel struct {
 	Packages                  types.List   `tfsdk:"packages"`
 	Parameters                types.List   `tfsdk:"parameters"`
 	Properties                types.Map    `tfsdk:"properties"`
-	StepPackageId             types.String `tfsdk:"step_package_id"`
 	Version                   types.Int32  `tfsdk:"version"`
 
 	ResourceModel
@@ -94,22 +93,15 @@ func (s CommunityStepTemplateSchema) GetResourceSchema() rs.Schema {
 				Description: "The name of the community step template.",
 				Optional:    false,
 				Computed:    true,
-				Default:     stringdefault.StaticString(""),
 			},
 			"description": rs.StringAttribute{
 				Description: "The description of this " + CommunityStepTemplateResourceDescription + ".",
 				Optional:    false,
 				Computed:    true,
-				Default:     stringdefault.StaticString(""),
 			},
 			"space_id": GetSpaceIdResourceSchema(CommunityStepTemplateResourceDescription),
 			"version": rs.Int32Attribute{
 				Description: "The version of the step template",
-				Optional:    false,
-				Computed:    true,
-			},
-			"step_package_id": rs.StringAttribute{
-				Description: "The ID of the step package",
 				Optional:    false,
 				Computed:    true,
 			},

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -230,6 +230,7 @@ func (s CommunityStepTemplateSchema) GetResourceSchema() rs.Schema {
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"packages":   GetReadOnlyStepTemplatePackageResourceSchema(),

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	ds "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	rs "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -93,27 +96,42 @@ func (s CommunityStepTemplateSchema) GetResourceSchema() rs.Schema {
 				Description: "The name of the community step template.",
 				Optional:    false,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"description": rs.StringAttribute{
 				Description: "The description of this " + CommunityStepTemplateResourceDescription + ".",
 				Optional:    false,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"space_id": GetSpaceIdResourceSchema(CommunityStepTemplateResourceDescription),
 			"version": rs.Int32Attribute{
 				Description: "The version of the step template",
 				Optional:    false,
 				Computed:    true,
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+				},
 			},
 			"action_type": rs.StringAttribute{
 				Description: "The action type of the step template",
 				Optional:    false,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"community_action_template_id": rs.StringAttribute{
 				Description: "The ID of the community action template",
 				Optional:    false,
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"packages":   GetReadOnlyStepTemplatePackageResourceSchema(),
 			"parameters": GetReadOnlyStepTemplateParameters(),
@@ -122,6 +140,9 @@ func (s CommunityStepTemplateSchema) GetResourceSchema() rs.Schema {
 				Required:    false,
 				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
@@ -133,6 +154,9 @@ func GetReadOnlyStepTemplateParameters() rs.ListNestedAttribute {
 		Required:    false,
 		Optional:    false,
 		Computed:    true,
+		PlanModifiers: []planmodifier.List{
+			listplanmodifier.UseStateForUnknown(),
+		},
 		NestedObject: rs.NestedAttributeObject{
 			Attributes: map[string]rs.Attribute{
 				"default_value": util.ResourceString().
@@ -194,6 +218,9 @@ func GetReadOnlyStepTemplatePackageResourceSchema() rs.ListNestedAttribute {
 		Description: "Package information for the community step template",
 		Optional:    false,
 		Computed:    true,
+		PlanModifiers: []planmodifier.List{
+			listplanmodifier.UseStateForUnknown(),
+		},
 		NestedObject: rs.NestedAttributeObject{
 			Attributes: map[string]rs.Attribute{
 				"acquisition_location": rs.StringAttribute{
@@ -201,19 +228,25 @@ func GetReadOnlyStepTemplatePackageResourceSchema() rs.ListNestedAttribute {
 					Default:     stringdefault.StaticString("Server"),
 					Optional:    false,
 					Computed:    true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"feed_id": util.ResourceString().
 					Description("ID of the feed.").
 					Computed().
+					PlanModifiers(stringplanmodifier.UseStateForUnknown()).
 					Build(),
 				"id": GetIdResourceSchema(),
 				"name": util.ResourceString().
 					Description("Package name.").
 					Computed().
+					PlanModifiers(stringplanmodifier.UseStateForUnknown()).
 					Build(),
 				"package_id": util.ResourceString().
 					Description("The ID of the package to use.").
 					Computed().
+					PlanModifiers(stringplanmodifier.UseStateForUnknown()).
 					Build(),
 				"properties": rs.SingleNestedAttribute{
 					Description: "Properties for the package.",
@@ -225,23 +258,35 @@ func GetReadOnlyStepTemplatePackageResourceSchema() rs.ListNestedAttribute {
 							Default:     stringdefault.StaticString("True"),
 							Optional:    false,
 							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"package_parameter_name": rs.StringAttribute{
 							Description: "The name of the package parameter",
 							Default:     stringdefault.StaticString(""),
 							Optional:    false,
 							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"purpose": rs.StringAttribute{
 							Description: "The purpose of this property.",
 							Default:     stringdefault.StaticString(""),
 							Optional:    false,
 							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"selection_mode": rs.StringAttribute{
 							Description: "The selection mode.",
 							Optional:    false,
 							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -150,6 +150,10 @@ func (s CommunityStepTemplateSchema) GetDataSourceStepsAttributes() map[string]d
 			Description: "The author of this " + CommunityStepTemplateResourceDescription + ".",
 			Computed:    true,
 		},
+		"action_type": ds.StringAttribute{
+			Description: "The action type of this " + CommunityStepTemplateResourceDescription + ".",
+			Computed:    true,
+		},
 		"website": ds.StringAttribute{
 			Description: "The website of this " + CommunityStepTemplateResourceDescription + ".",
 			Computed:    true,

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -14,17 +14,17 @@ const (
 )
 
 type CommunityStepTemplateTypeDataSourceModel struct {
-	ID      types.String `tfsdk:"id"`
-	Website types.String `tfsdk:"website"`
-	Name    types.String `tfsdk:"name"`
-	Steps   types.List   `tfsdk:"steps"`
+	ID      types.String                             `tfsdk:"id"`
+	IDs     types.List                               `tfsdk:"ids"`
+	Website types.String                             `tfsdk:"website"`
+	Name    types.String                             `tfsdk:"name"`
+	Steps   []CommunityStepTemplateTypeResourceModel `tfsdk:"steps"`
 }
 
 // CommunityStepTemplateTypeResourceModel represents the resource model for a community step template.
 // It is a little different to most other resources because a community step template is read only and
 // installed rather than created.
 type CommunityStepTemplateTypeResourceModel struct {
-	SpaceID       types.String `tfsdk:"space_id"`
 	Type          types.String `tfsdk:"type"`
 	Author        types.String `tfsdk:"author"`
 	Name          types.String `tfsdk:"name"`

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -1,0 +1,110 @@
+package schemas
+
+import (
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	ds "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	rs "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	CommunityStepTemplateResourceType          = "community step template"
+	CommunityStepTemplateResourceDescription   = "community_step_template"
+	CommunityStepTemplateDatasourceDescription = "community_step_template"
+)
+
+type CommunityStepTemplateTypeDataSourceModel struct {
+	ID      types.String `tfsdk:"id"`
+	Website types.String `tfsdk:"website"`
+	Name    types.String `tfsdk:"name"`
+	Steps   types.List   `tfsdk:"steps"`
+}
+
+// CommunityStepTemplateTypeResourceModel represents the resource model for a community step template.
+// It is a little different to most other resources because a community step template is read only and
+// installed rather than created.
+type CommunityStepTemplateTypeResourceModel struct {
+	SpaceID       types.String `tfsdk:"space_id"`
+	Type          types.String `tfsdk:"type"`
+	Author        types.String `tfsdk:"author"`
+	Name          types.String `tfsdk:"name"`
+	Description   types.String `tfsdk:"description"`
+	Packages      types.List   `tfsdk:"packages"`
+	Website       types.String `tfsdk:"website"`
+	HistoryUrl    types.String `tfsdk:"history_url"`
+	Parameters    types.List   `tfsdk:"parameters"`
+	Properties    types.Map    `tfsdk:"properties"`
+	StepPackageId types.String `tfsdk:"step_package_id"`
+	Version       types.Int32  `tfsdk:"version"`
+
+	ResourceModel
+}
+
+type CommunityStepTemplateSchema struct{}
+
+var _ EntitySchema = CommunityStepTemplateSchema{}
+
+func (s CommunityStepTemplateSchema) GetDatasourceSchema() ds.Schema {
+	return ds.Schema{
+		Description: util.GetDataSourceDescription(CommunityStepTemplateDatasourceDescription),
+		Attributes: map[string]ds.Attribute{
+			"id": ds.StringAttribute{
+				Description: "Unique identifier of the community step template",
+				Required:    true,
+			},
+			"space_id": ds.StringAttribute{
+				Description: "SpaceID of the Community Step Template",
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (s CommunityStepTemplateSchema) GetResourceSchema() rs.Schema {
+	return rs.Schema{
+		Description: util.GetResourceSchemaDescription(CommunityStepTemplateResourceDescription),
+		Attributes: map[string]rs.Attribute{
+			"space_id":    GetSpaceIdResourceSchema(CommunityStepTemplateResourceDescription),
+			"id":          GetIdResourceSchema(),
+			"name":        GetNameResourceSchema(true),
+			"description": GetDescriptionResourceSchema(CommunityStepTemplateResourceDescription),
+			"type": rs.StringAttribute{
+				Description: "The type of the community step template",
+				Computed:    true,
+				Optional:    false,
+			},
+			"author": rs.StringAttribute{
+				Description: "The author of the community step template",
+				Computed:    true,
+				Optional:    false,
+			},
+			"website": rs.StringAttribute{
+				Description: "The website link to the community step template",
+				Computed:    true,
+				Optional:    false,
+			},
+			"history_url": rs.StringAttribute{
+				Description: "The website link to the history community step template",
+				Computed:    true,
+				Optional:    false,
+			},
+			"version": rs.Int32Attribute{
+				Description: "The version of the step template",
+				Optional:    false,
+				Computed:    true,
+			},
+			"step_package_id": rs.StringAttribute{
+				Description: "The ID of the step package",
+				Required:    true,
+			},
+			"packages":   GetStepTemplatePackageResourceSchema(CommunityStepTemplateResourceType),
+			"parameters": GetStepTemplateParameterResourceSchema(CommunityStepTemplateResourceType),
+			"properties": rs.MapAttribute{
+				Description: "Properties for the community step template",
+				Required:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -31,7 +31,7 @@ type CommunityStepTemplateTypeDataSourceModel struct {
 	ID      types.String `tfsdk:"id"`
 	Website types.String `tfsdk:"website"`
 	Name    types.String `tfsdk:"name"`
-	Steps   types.List   `tfsdk:"steps"`
+	Steps   types.List   `tfsdk:"steps"` // Steps used the type CommunityStepTemplateTypeObjectType()
 }
 
 // CommunityStepTemplateTypeObjectType returns the type mapping used to define the Steps attribute in the CommunityStepTemplateTypeDataSourceModel.
@@ -53,21 +53,6 @@ func CommunityStepTemplateTypeObjectType() map[string]attr.Type {
 			ElemType: types.ObjectType{AttrTypes: PackagesObjectType()},
 		},
 	}
-}
-
-type CommunityStepTemplateTypeResourceModel struct {
-	Type        types.String `tfsdk:"type"`
-	Name        types.String `tfsdk:"name"`
-	Author      types.String `tfsdk:"author"`
-	Description types.String `tfsdk:"description"`
-	Website     types.String `tfsdk:"website"`
-	HistoryUrl  types.String `tfsdk:"history_url"`
-	Version     types.Int32  `tfsdk:"version"`
-	Packages    types.List   `tfsdk:"packages"`
-	Parameters  types.List   `tfsdk:"parameters"`
-	Properties  types.Map    `tfsdk:"properties"`
-
-	ResourceModel
 }
 
 // ParametersObjectType returns the type mapping used to define the parameters attribute in the CommunityStepTemplateTypeObjectType function
@@ -100,6 +85,23 @@ func PackagesObjectType() map[string]attr.Type {
 			},
 		},
 	}
+}
+
+// CommunityStepTemplateTypeResourceModel is the resource model for the community step template type. This only returned
+// by the data source.
+type CommunityStepTemplateTypeResourceModel struct {
+	Type        types.String `tfsdk:"type"`
+	Name        types.String `tfsdk:"name"`
+	Author      types.String `tfsdk:"author"`
+	Description types.String `tfsdk:"description"`
+	Website     types.String `tfsdk:"website"`
+	HistoryUrl  types.String `tfsdk:"history_url"`
+	Version     types.Int32  `tfsdk:"version"`
+	Packages    types.List   `tfsdk:"packages"`
+	Parameters  types.List   `tfsdk:"parameters"`
+	Properties  types.Map    `tfsdk:"properties"`
+
+	ResourceModel
 }
 
 // StepTemplateFromCommunityStepTemplateTypeResourceModel represents a step template generated from a community step template.

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -49,6 +49,21 @@ type CommunityStepTemplateTypeResourceModel struct {
 	ResourceModel
 }
 
+type StepTemplateFromCommunityStepTemplateTypeResourceModel struct {
+	ActionType                types.String `tfsdk:"action_type"`
+	SpaceID                   types.String `tfsdk:"space_id"`
+	CommunityActionTemplateId types.String `tfsdk:"community_action_template_id"`
+	Name                      types.String `tfsdk:"name"`
+	Description               types.String `tfsdk:"description"`
+	Packages                  types.List   `tfsdk:"packages"`
+	Parameters                types.List   `tfsdk:"parameters"`
+	Properties                types.Map    `tfsdk:"properties"`
+	StepPackageId             types.String `tfsdk:"step_package_id"`
+	Version                   types.Int32  `tfsdk:"version"`
+
+	ResourceModel
+}
+
 type CommunityStepTemplateSchema struct{}
 
 var _ EntitySchema = CommunityStepTemplateSchema{}
@@ -106,7 +121,7 @@ func (s CommunityStepTemplateSchema) GetResourceSchema() rs.Schema {
 			"community_action_template_id": rs.StringAttribute{
 				Description: "The ID of the community action template",
 				Optional:    false,
-				Computed:    true,
+				Required:    true,
 			},
 			"packages":   GetReadOnlyStepTemplatePackageResourceSchema(),
 			"parameters": GetReadOnlyStepTemplateParameters(),

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -40,6 +40,7 @@ func CommunityStepTemplateTypeObjectType() map[string]attr.Type {
 	return map[string]attr.Type{
 		"id":              types.StringType,
 		"author":          types.StringType,
+		"action_type":     types.StringType,
 		"name":            types.StringType,
 		"description":     types.StringType,
 		"website":         types.StringType,

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -159,7 +159,7 @@ func (s CommunityStepTemplateSchema) GetDataSourceStepsAttributes() map[string]d
 			Computed:    true,
 		},
 		"type": ds.StringAttribute{
-			Description: "The type of this " + CommunityStepTemplateResourceDescription + ".",
+			Description: "The action type of this " + CommunityStepTemplateResourceDescription + ".",
 			Computed:    true,
 		},
 		"website": ds.StringAttribute{
@@ -345,10 +345,37 @@ func GetReadOnlyStepTemplatePackageResourceSchema() rs.ListNestedAttribute {
 					Computed().
 					PlanModifiers(stringplanmodifier.UseStateForUnknown()).
 					Build(),
-				"properties": rs.MapAttribute{
-					Description: "The display settings for the parameter.",
-					Optional:    true,
-					ElementType: types.StringType,
+				"properties": rs.SingleNestedAttribute{
+					Description: "Properties for the package.",
+					Required:    true,
+					Attributes: map[string]rs.Attribute{
+						"extract": rs.StringAttribute{
+							Description: "If the package should extract.",
+							Default:     stringdefault.StaticString("True"),
+							Optional:    true,
+							Computed:    true,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile("^(True|False)$"), "Extract must be True or False"),
+							},
+						},
+						"package_parameter_name": rs.StringAttribute{
+							Description: "The name of the package parameter",
+							Default:     stringdefault.StaticString(""),
+							Optional:    true,
+							Computed:    true,
+						},
+						"purpose": rs.StringAttribute{
+							Description: "The purpose of this property.",
+							Default:     stringdefault.StaticString(""),
+							Optional:    true,
+							Required:    false,
+							Computed:    true,
+						},
+						"selection_mode": rs.StringAttribute{
+							Description: "The selection mode.",
+							Required:    true,
+						},
+					},
 				},
 			},
 		},

--- a/octopusdeploy_framework/schemas/step_template.go
+++ b/octopusdeploy_framework/schemas/step_template.go
@@ -1,23 +1,17 @@
 package schemas
 
 import (
-	"fmt"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
-	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	ds "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	rs "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"regexp"
 )
 
 const (
+	StepTemplateResourceType          = "step template"
 	StepTemplateResourceDescription   = "step_template"
 	StepTemplateDatasourceDescription = "step_template"
 )
@@ -125,135 +119,13 @@ func (s StepTemplateSchema) GetResourceSchema() rs.Schema {
 				Computed:    true,
 				Default:     stringdefault.StaticString(""),
 			},
-			"packages":         GetStepTemplatePackageResourceSchema(),
+			"packages":         GetStepTemplatePackageResourceSchema(StepTemplateResourceType),
 			"git_dependencies": GetStepTemplateGitDependencySchema(),
-			"parameters":       GetStepTemplateParameterResourceSchema(),
+			"parameters":       GetStepTemplateParameterResourceSchema(StepTemplateResourceType),
 			"properties": rs.MapAttribute{
 				Description: "Properties for the step template",
 				Required:    true,
 				ElementType: types.StringType,
-			},
-		},
-	}
-}
-
-func GetStepTemplateParameterResourceSchema() rs.ListNestedAttribute {
-	return rs.ListNestedAttribute{
-		Description: "List of parameters that can be used in Step Template.",
-		Required:    true,
-		NestedObject: rs.NestedAttributeObject{
-			Attributes: map[string]rs.Attribute{
-				"default_value": util.ResourceString().
-					Description("A default value for the parameter, if applicable. This can be a hard-coded value or a variable reference.").
-					Optional().
-					Computed().
-					Default(stringdefault.StaticString("")).
-					PlanModifiers(stringplanmodifier.UseStateForUnknown()).
-					Build(),
-				"default_sensitive_value": util.ResourceString().
-					Description("Use this attribute to set a sensitive default value for the parameter when display settings are set to 'Sensitive'").
-					Optional().
-					Sensitive().
-					Build(),
-				"display_settings": rs.MapAttribute{
-					Description: "The display settings for the parameter.",
-					Optional:    true,
-					ElementType: types.StringType,
-				},
-				"help_text": rs.StringAttribute{
-					Description: "The help presented alongside the parameter input.",
-					Optional:    true,
-					Computed:    true,
-					Default:     stringdefault.StaticString(""),
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.UseStateForUnknown(),
-					},
-				},
-				"id": rs.StringAttribute{
-					Description: "The id for the property.",
-					Required:    true,
-					Validators: []validator.String{
-						stringvalidator.RegexMatches(regexp.MustCompile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"), fmt.Sprintf("must be a valid UUID, unique within this list. Here is one you could use: %s.\nExpect uuid", uuid.New())),
-					},
-				},
-				"label": rs.StringAttribute{
-					Description: "The label shown beside the parameter when presented in the deployment process. Example: `Server name`.",
-					Optional:    true,
-					Computed:    true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.UseStateForUnknown(),
-					},
-				},
-				"name": rs.StringAttribute{
-					Description: "The name of the variable set by the parameter. The name can contain letters, digits, dashes and periods. Example: `ServerName`",
-					Required:    true,
-					Validators: []validator.String{
-						stringvalidator.LengthAtLeast(1),
-					},
-				},
-			},
-		},
-	}
-}
-
-func GetStepTemplatePackageResourceSchema() rs.ListNestedAttribute {
-	return rs.ListNestedAttribute{
-		Description: "Package information for the step template",
-		Required:    true,
-		NestedObject: rs.NestedAttributeObject{
-			Attributes: map[string]rs.Attribute{
-				"acquisition_location": rs.StringAttribute{
-					Description: "Acquisition location for the package.",
-					Default:     stringdefault.StaticString("Server"),
-					Optional:    true,
-					Computed:    true,
-				},
-				"feed_id": util.ResourceString().
-					Description("ID of the feed.").
-					Required().
-					Build(),
-				"id": GetIdResourceSchema(),
-				"name": util.ResourceString().
-					Description("Package name.").
-					Required().
-					Build(),
-				"package_id": util.ResourceString().
-					Description("The ID of the package to use.").
-					Optional().
-					Computed().
-					Build(),
-				"properties": rs.SingleNestedAttribute{
-					Description: "Properties for the package.",
-					Required:    true,
-					Attributes: map[string]rs.Attribute{
-						"extract": rs.StringAttribute{
-							Description: "If the package should extract.",
-							Default:     stringdefault.StaticString("True"),
-							Optional:    true,
-							Computed:    true,
-							Validators: []validator.String{
-								stringvalidator.RegexMatches(regexp.MustCompile("^(True|False)$"), "Extract must be True or False"),
-							},
-						},
-						"package_parameter_name": rs.StringAttribute{
-							Description: "The name of the package parameter",
-							Default:     stringdefault.StaticString(""),
-							Optional:    true,
-							Computed:    true,
-						},
-						"purpose": rs.StringAttribute{
-							Description: "The purpose of this property.",
-							Default:     stringdefault.StaticString(""),
-							Optional:    true,
-							Required:    false,
-							Computed:    true,
-						},
-						"selection_mode": rs.StringAttribute{
-							Description: "The selection mode.",
-							Required:    true,
-						},
-					},
-				},
 			},
 		},
 	}


### PR DESCRIPTION
The current `octopusdeploy_step_template` resource does not properly install step templates based on a community step template. 

This PR adds a new resource called `octopusdeploy_community_step_template`, which installs a step template linked to a community step template. It also adds a new data source called `octopusdeploy_community_step_template`  which queries community step templates by name, ID, or website.

The typical usage of these resources would be this:

```
data "octopusdeploy_community_step_template" "statuscake_maintenance_window" {
    website="https://library.octopus.com/step-templates/87cbaa94-4477-4474-a9c3-7943b5668d30"
}

resource "octopusdeploy_community_step_template" "statuscake_maintenance_window" {
  community_action_template_id=data.octopusdeploy_community_step_template.statuscake_maintenance_window.steps[0].id
}
```

Fixes https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/57