### PR TITLE
Fix channel resource inconsistent attribute value errors

### DIFF
--- a/octopusdeploy_framework/resource_channel.go
+++ b/octopusdeploy_framework/resource_channel.go
@@ -280,7 +280,7 @@ func flattenChannelRule(rule *channels.ChannelRule) types.Object {
 		"action_package": flattenChannelRuleDeploymentActionPackages(rule.ActionPackages),
 		"id":             types.StringValue(rule.ID),
 		"tag":            types.StringValue(rule.Tag),
-		"version_range":  types.StringValue(rule.VersionRange),
+		"version_range":  util.StringOrNull(rule.VersionRange),
 	})
 
 }
@@ -302,7 +302,7 @@ func flattenChannelRuleDeploymentActionPackages(actionPackages []packages.Deploy
 func flattenChannelRuleDeploymentActionPackage(actionPackage *packages.DeploymentActionPackage) types.Object {
 	return types.ObjectValueMust(getChannelRuleDeploymentActionPackageAttrTypes(), map[string]attr.Value{
 		"deployment_action": types.StringValue(actionPackage.DeploymentAction),
-		"package_reference": types.StringValue(actionPackage.PackageReference),
+		"package_reference": util.StringOrNull(actionPackage.PackageReference),
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/76.

#### Background

[sc-119442]

After migrating from a version of the Octopus provider using the SDKv2 implementation of the `octopusdeploy_channel` resource to the new Terraform Plugin Framework implementation (introduced in `1.3.3`), errors of the  form  `x: was null, but now cty.StringVal("")` are being raised for `rule.version_string` and `rule.action_package.package_reference` attributes.

#### Replication

While I couldn't directly replicate this via migrating between versions of our provider, I can artificially replicate it by explicitly setting the `version_string`  attribute to `null` (this approach doesn't work for `package_reference` as the Octopus API throws a `"No package reference matching"` error).

#### Fix

TPF has a stricter treatment of `null` vs. `""` attribute values than SDKv2. Where SDKv2 does not complain if the value of an attribute in the plan is `null` and the provider returns a value of `""` (or vice versa), TPF does, and will surface an error of the form  `x: was null, but now cty.StringVal("")`. This change prevents this error by ensuring that empty string values returned by the Octopus API for `version_string` and `package_reference` attributes are always mapped (or "flattened") to `null` values.

After this change, the replication steps described above no longer produce a `x: was null, but now cty.StringVal("")` error (see examples below). By extension, terraform configurations with existing `null` values for the `version_string` or `package_reference` attributes (either explicitly or by omission) should no longer produce the same error when their provider version is upgraded to use the plugin framework implementation of the `octopusdeploy_channel` resource.

For resources that have been created since the channel resource was migrated (`1.3.3` and later), values in their state file for `version_string` and/or `package_reference` should update quietly in the background from `""` to  `null` the next time the config is applied. To artificially replicate this scenario, I manually set `version_string = ""` in a terraform state file associated with a config which defined a channel rule without a `version_string` (see examples below). (Re)applying the unchanged terraform config reverted the value of `version_string` back to `null` in the state file without raising any errors.

#### Risks

The problem that this approach faces (and which I tried unsuccessfully to solve using a [more complicated fix](https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/tree/wlthomson/fix-channel-unexpected-value-error)), is that configs which explicitly provide an empty string value for `version_string` or `package_reference` will encounter an error of the form:  `x: was cty.StringVal(""), but now null` (note that the previous and new values are reversed from the above error).

In theory, this isn't a problem, as neither `version_string` nor `package_reference` should accept an empty string as a valid value. However, in the case where the Octopus API doesn't raise any validation complaints (which seems to be the case for `version_string`), terraform will raise the `x: was cty.StringVal(""), but now null`  error. If we are confident that `""` is not a valid value for an attribute, despite the API not returning an error, there is also the option of manually raising the validation error in our terraform code (possibly only as a temporary measure while the API is updated).

#### Examples

These examples have been tested on both the latest version of Octopus and the build reported in https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/76 (`2025.2.12920`).

##### Before (`1.3.3`)

Example `octopusdeploy_channel` resource with a `version_range` of `null` (behaviour is the same if explicitly defined or the attribute is omitted).

```
terraform {
  required_providers {
    octopusdeploy = {
      source = "OctopusDeploy/octopusdeploy"
      version = "1.3.3",
    }
  }
}

resource "octopusdeploy_channel" "channel" {
  name         = "Channel"
  project_id   = octopusdeploy_project.project.id
  lifecycle_id = octopusdeploy_lifecycle.lifecycle.id
  space_id = data.octopusdeploy_space.space.id
  is_default = false
  rule {
    tag = "tag"
    action_package {
      deployment_action = octopusdeploy_deployment_process.example.step[0].run_script_action[0].name
      package_reference = "package"
    }
    version_range = null # Set to null here for explicitness, same behaviour if omitted
  }
}
```

Running `terraform plan` and `terraform apply` returns:

```
 Error: Provider produced inconsistent result after apply
│
│ When applying changes to octopusdeploy_channel.channel, provider "provider[\"registry.terraform.io/octopusdeploy/octopusdeploy\"]" produced an unexpected new value: .rule[0].version_range: was null, but now cty.StringVal("").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

If `package_reference` is set to `null`, the API throws the following error:

```
│ Error: Error creating channel
│
│   with octopusdeploy_channel.channel,
│   on main.tf line 92, in resource "octopusdeploy_channel" "channel":
│   92: resource "octopusdeploy_channel" "channel" {
│
│ Octopus API error: There was a problem with your request. [No package reference matching ]
```

##### After (`1.3.3` + branch changes)

Running `terraform plan` and `terraform apply` for the same resource now returns without error.

The entry for `rule[0].version_range` in the `terraform.tfstate` now has a `null` value:

```
"rule": [
  {
    "action_package": [
      {
        "deployment_action": "Hello world (using PowerShell)",
         "package_reference": "package"
      }
    ],
    "id": "dc4e77df-f095-4bec-a954-6d1ba54d439f",
    "tag": "tag",
    "version_range": null
  }
],
```

Manually editing this to `""` and running `terraform plan` and `terraform apply` reverts the value back to `null` without any errors.

