### PR TITLE
Allow community step templates to be installed in non-default space

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.5
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.1
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2-0.20250907212724-ac9f3fc3bae8
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.5
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2-0.20250907212724-ac9f3fc3bae8
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.1-0.20250827084210-7d8ac74bef
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.1-0.20250827084210-7d8ac74befd2/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.1 h1:bGTgwLMy3qoXejDeCaZZfuQEsyB+bIieKb8d2aKmt/w=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.1/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2-0.20250907212724-ac9f3fc3bae8 h1:rNgg/1mlKFPB9s5RnRE5bx+6s6q4tVFjgL+qjL+k4MM=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2-0.20250907212724-ac9f3fc3bae8/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.1 h1:rQjwRQ9Q3EV0FDxRRMMc3X0vto9u3nCNAqe8Tk6p4Yk=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.1/go.mod h1:MpwQ4jw7ugTju/whAqtxf5vFxVPV0jBvHp8X4TKBhE8=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.1 h1:bGTgwLMy3qoXejDeCaZZfuQE
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.1/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2-0.20250907212724-ac9f3fc3bae8 h1:rNgg/1mlKFPB9s5RnRE5bx+6s6q4tVFjgL+qjL+k4MM=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2-0.20250907212724-ac9f3fc3bae8/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2 h1:fsCyBGYEE0hN2xLfc0/q3FP5GM5udioL0Gx3CyBdrJ4=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.1 h1:rQjwRQ9Q3EV0FDxRRMMc3X0vto9u3nCNAqe8Tk6p4Yk=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.1/go.mod h1:MpwQ4jw7ugTju/whAqtxf5vFxVPV0jBvHp8X4TKBhE8=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=

--- a/octopusdeploy_framework/resource_community_step_template.go
+++ b/octopusdeploy_framework/resource_community_step_template.go
@@ -70,8 +70,14 @@ func (r *communityStepTemplateTypeResource) Create(ctx context.Context, req reso
 			ID: data.CommunityActionTemplateId.ValueString(),
 		},
 	}
+
+	spaceId := data.SpaceID.ValueString()
+	if spaceId == "" {
+		spaceId = r.Config.Client.GetSpaceID()
+	}
+
 	// Installing a community step template essentially creates a read only step template in the current space.
-	communityStepTemplate, err := r.Config.Client.CommunityActionTemplates.InstallToSpace(newCommunityStepTemplate, data.SpaceID.ValueString())
+	communityStepTemplate, err := r.Config.Client.CommunityActionTemplates.InstallToSpace(newCommunityStepTemplate, spaceId)
 
 	if err != nil {
 		resp.Diagnostics.AddError("unable to install community step template", err.Error())
@@ -79,7 +85,7 @@ func (r *communityStepTemplateTypeResource) Create(ctx context.Context, req reso
 	}
 
 	// read the details of the newly installed step template
-	actionTemplate, err := actiontemplates.GetByID(r.Config.Client, data.SpaceID.ValueString(), communityStepTemplate.ID)
+	actionTemplate, err := actiontemplates.GetByID(r.Config.Client, spaceId, communityStepTemplate.ID)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to read the installed community step template", err.Error())
 		return

--- a/octopusdeploy_framework/resource_community_step_template.go
+++ b/octopusdeploy_framework/resource_community_step_template.go
@@ -71,7 +71,7 @@ func (r *communityStepTemplateTypeResource) Create(ctx context.Context, req reso
 		},
 	}
 	// Installing a community step template essentially creates a read only step template in the current space.
-	communityStepTemplate, err := r.Config.Client.CommunityActionTemplates.Install(newCommunityStepTemplate)
+	communityStepTemplate, err := r.Config.Client.CommunityActionTemplates.InstallToSpace(newCommunityStepTemplate, data.SpaceID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError("unable to install community step template", err.Error())


### PR DESCRIPTION
This PR uses the new functionality introduced in https://github.com/OctopusDeploy/go-octopusdeploy/pull/357 to install a community step template to a non-default space.

Here is an example:

```
terraform {
  required_providers {
    octopusdeploy = { 
        source = "OctopusDeploy/octopusdeploy"
        version = "1.3.6" 
        # Use this source when debugging        
        #source = "octopus.com/com/octopusdeploy"
        
    }
  }
}

provider "octopusdeploy" {
  address  = "${var.octopus_server}"
  api_key  = "${var.octopus_apikey}"
  space_id = "${var.octopus_space_id}"
}

variable "octopus_server" {
  type        = string
  nullable    = false
  sensitive   = false
  description = "The URL of the Octopus server e.g. https://myinstance.octopus.app."
}
variable "octopus_apikey" {
  type        = string
  nullable    = false
  sensitive   = true
  description = "The API key used to access the Octopus server. See https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key for details on creating an API key."
}
variable "octopus_space_id" {
  type        = string
  nullable    = false
  sensitive   = false
  description = "The space ID to populate"
}


data "octopusdeploy_community_step_template" "statuscake_maintenance_window" {
    website="https://library.octopus.com/step-templates/b362bd69-4a69-42c1-bcb5-2a134549ef3f"
}

resource "octopusdeploy_community_step_template" "statuscake_maintenance_window" {
  community_action_template_id=data.octopusdeploy_community_step_template.statuscake_maintenance_window.steps[0].id
}
```