### PR TITLE
Chore: Handle unit casing for lifecycle retention policies

### DIFF
--- a/octopusdeploy_framework/resource_lifecycle.go
+++ b/octopusdeploy_framework/resource_lifecycle.go
@@ -150,10 +150,10 @@ func handleUnitCasing(resource *lifecycles.Lifecycle, data *lifecycles.Lifecycle
 	}
 
 	for i, phase := range resource.Phases {
-		if phase.ReleaseRetentionPolicy != nil && len(phase.ReleaseRetentionPolicy.Unit) != 0 {
+		if phase.ReleaseRetentionPolicy != nil && phase.ReleaseRetentionPolicy.Unit != "" {
 			phase.ReleaseRetentionPolicy = updateRetentionPeriodUnit(phase.ReleaseRetentionPolicy, data.Phases[i].ReleaseRetentionPolicy.Unit)
 		}
-		if phase.TentacleRetentionPolicy != nil && len(phase.TentacleRetentionPolicy.Unit) != 0 {
+		if phase.TentacleRetentionPolicy != nil && phase.TentacleRetentionPolicy.Unit != "" {
 			phase.TentacleRetentionPolicy = updateRetentionPeriodUnit(phase.TentacleRetentionPolicy, data.Phases[i].TentacleRetentionPolicy.Unit)
 		}
 	}


### PR DESCRIPTION
This PR fixes a bug where terraform throws an error when there are inconsistencies between the casing of units returned in the API vs the desired state.
[sc-120453]

## After
### Create
<img width="807" height="283" alt="Screenshot 2025-09-09 at 8 13 52 am" src="https://github.com/user-attachments/assets/b55b4713-01a0-4630-a506-1705587c4587" />

### Modify
<img width="1547" height="578" alt="Screenshot 2025-09-09 at 8 14 59 am" src="https://github.com/user-attachments/assets/1f26cb69-0050-4f99-b2c7-91120f1a8b57" />
<img width="1173" height="274" alt="Screenshot 2025-09-09 at 8 15 05 am" src="https://github.com/user-attachments/assets/bb896d6a-dfb6-45f2-8b2d-06a3bacb4888" />
>


## Testing: 
This was the script I used to confirm the behaviour
```
resource "octopusdeploy_lifecycle" "example-lifecycle" {
  name        = "Example Lifecycle"
  description = "This is an example lifecycle for funsies"
  release_retention_policy {
    quantity_to_keep    = 10
    unit                = "ITeMS"
    should_keep_forever = false
  }
  tentacle_retention_policy {
    quantity_to_keep    = 900
    should_keep_forever = false
    unit                = "iTEMS"
  }
  phase {
    name                         = "foo"

    release_retention_policy {
      quantity_to_keep    = 1
      should_keep_forever = false
      unit                = "ITEms"
    }

    tentacle_retention_policy {
      quantity_to_keep    = 30
      should_keep_forever = false
      unit                = "dayS"
    }
  }
}

```
