### PR TITLE
Return tags in tag set data source

### DIFF
--- a/docs/data-sources/tag_sets.md
+++ b/docs/data-sources/tag_sets.md
@@ -38,5 +38,18 @@ Read-Only:
 - `name` (String) The name of this resource.
 - `sort_order` (Number) The sort order associated with this resource.
 - `space_id` (String) The space ID associated with this resource.
+- `tags` (Attributes List) The tags associated with this tag set. (see [below for nested schema](#nestedatt--tag_sets--tags))
+
+<a id="nestedatt--tag_sets--tags"></a>
+### Nested Schema for `tag_sets.tags`
+
+Read-Only:
+
+- `canonical_tag_name` (String) The canonical name of this tag.
+- `color` (String) The color associated with this tag.
+- `description` (String) The description of this tag.
+- `id` (String) The unique ID for this tag.
+- `name` (String) The name of this tag.
+- `sort_order` (Number) The sort order associated with this tag.
 
 

--- a/octopusdeploy_framework/datasource_tag_sets.go
+++ b/octopusdeploy_framework/datasource_tag_sets.go
@@ -3,13 +3,14 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tagsets"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"time"
 )
 
 var _ datasource.DataSource = &tagSetsDataSource{}
@@ -74,12 +75,27 @@ func flattenTagSets(ctx context.Context, tagSets []*tagsets.TagSet) types.List {
 
 	tfList := make([]attr.Value, len(tagSets))
 	for i, tagSet := range tagSets {
+
+		tags := make([]attr.Value, len(tagSet.Tags))
+
+		for j, tag := range tagSet.Tags {
+			tags[j] = types.ObjectValueMust(schemas.GetTagAttrTypes(), map[string]attr.Value{
+				"id":                 types.StringValue(tag.ID),
+				"canonical_tag_name": types.StringValue(tag.CanonicalTagName),
+				"name":               types.StringValue(tag.Name),
+				"description":        types.StringValue(tag.Description),
+				"color":              types.StringValue(tag.Color),
+				"sort_order":         types.Int64Value(int64(tag.SortOrder)),
+			})
+		}
+
 		tfList[i] = types.ObjectValueMust(schemas.GetTagSetAttrTypes(), map[string]attr.Value{
 			"id":          types.StringValue(tagSet.ID),
 			"name":        types.StringValue(tagSet.Name),
 			"description": types.StringValue(tagSet.Description),
 			"sort_order":  types.Int64Value(int64(tagSet.SortOrder)),
 			"space_id":    types.StringValue(tagSet.SpaceID),
+			"tags":        types.ListValueMust(types.ObjectType{AttrTypes: schemas.GetTagAttrTypes()}, tags),
 		})
 	}
 

--- a/octopusdeploy_framework/schemas/tag_set.go
+++ b/octopusdeploy_framework/schemas/tag_set.go
@@ -99,6 +99,38 @@ func (t TagSetSchema) GetDatasourceSchema() datasourceSchema.Schema {
 							Computed().
 							Description("The space ID associated with this resource.").
 							Build(),
+						"tags": datasourceSchema.ListNestedAttribute{
+							Computed:    true,
+							Description: "The tags associated with this tag set.",
+							NestedObject: datasourceSchema.NestedAttributeObject{
+								Attributes: map[string]datasourceSchema.Attribute{
+									"id": util.DataSourceString().
+										Computed().
+										Description("The unique ID for this tag.").
+										Build(),
+									"canonical_tag_name": util.DataSourceString().
+										Computed().
+										Description("The canonical name of this tag.").
+										Build(),
+									"name": util.DataSourceString().
+										Computed().
+										Description("The name of this tag.").
+										Build(),
+									"description": util.DataSourceString().
+										Computed().
+										Description("The description of this tag.").
+										Build(),
+									"color": util.DataSourceString().
+										Computed().
+										Description("The color associated with this tag.").
+										Build(),
+									"sort_order": util.DataSourceInt64().
+										Computed().
+										Description("The sort order associated with this tag.").
+										Build(),
+								},
+							},
+						},
 					},
 				},
 			},
@@ -113,6 +145,18 @@ func GetTagSetAttrTypes() map[string]attr.Type {
 		"name":        types.StringType,
 		"description": types.StringType,
 		"sort_order":  types.Int64Type,
+		"tags":        types.ListType{ElemType: types.ObjectType{AttrTypes: GetTagAttrTypes()}},
+	}
+}
+
+func GetTagAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                 types.StringType,
+		"canonical_tag_name": types.StringType,
+		"name":               types.StringType,
+		"description":        types.StringType,
+		"color":              types.StringType,
+		"sort_order":         types.Int64Type,
 	}
 }
 


### PR DESCRIPTION
This PR returns the tags associated with a tag set in a `octopusdeploy_tag_sets` data source. This allows users to query for the existence of tag sets and tags.