### PR TITLE
Add Ability to Manage Ephemeral Environment Fields to Channels

### DIFF
--- a/docs/resources/channel.md
+++ b/docs/resources/channel.md
@@ -30,11 +30,14 @@ resource "octopusdeploy_channel" "example" {
 ### Optional
 
 - `description` (String) The description of this channel.
+- `ephemeral_environment_name_template` (String) The name template for ephemeral environments created from this channel.
 - `is_default` (Boolean) Indicates whether this is the default channel for the associated project.
 - `lifecycle_id` (String) The lifecycle ID associated with this channel.
+- `parent_environment_id` (String) The parent environment ID for ephemeral environments.
 - `rule` (Block List) A list of rules associated with this channel. (see [below for nested schema](#nestedblock--rule))
 - `space_id` (String) The space ID associated with this channel.
 - `tenant_tags` (Set of String) A set of tenant tags associated with this channel.
+- `type` (String) The type of channel. Valid values are `"Lifecycle"` or `"EphemeralEnvironment"`. Defaults to `"Lifecycle"`.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.5
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.84.0
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
@@ -138,7 +138,7 @@ require (
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc // indirect
 	golang.org/x/mod v0.26.0 // indirect
-	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2 h1:fsCyBGYEE0hN2xLfc0/q3FP5GM5udioL0Gx3CyBdrJ4=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.80.2/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.84.0 h1:8CSbBkvlXTCe6breNhhJ6Hl6/ov500a0NaATkNUlus0=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.84.0/go.mod h1:J1UdIilp41MRuFl+5xZm88ywFqJGYCCqxqod+/ZH8ko=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2 h1:960T/UryMsoc2ZOnoLEg7rM9QpxWIdkdB9sR5gsUFAQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2/go.mod h1:kllISYzQ8N3P6+3rScVhyW/KWnPWQbwzm8pFcMInSRM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
@@ -386,8 +386,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
-golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
-golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/octopusdeploy_framework/resource_channel.go
+++ b/octopusdeploy_framework/resource_channel.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"context"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal"
@@ -141,6 +142,9 @@ func expandChannel(ctx context.Context, model schemas.ChannelModel) *channels.Ch
 	channel.Rules = expandChannelRules(model.Rule)
 	channel.SpaceID = model.SpaceId.ValueString()
 	channel.TenantTags = util.ExpandStringSet(model.TenantTags)
+	channel.Type = channels.ChannelType(model.Type.ValueString())
+	channel.ParentEnvironmentID = model.ParentEnvironmentID.ValueString()
+	channel.EphemeralEnvironmentNameTemplate = model.EphemeralEnvironmentNameTemplate.ValueString()
 
 	return channel
 }
@@ -257,6 +261,10 @@ func flattenChannel(ctx context.Context, channel *channels.Channel, model schema
 	}
 
 	model.TenantTags = util.FlattenStringSet(channel.TenantTags, model.TenantTags)
+
+	model.Type = types.StringValue(string(channel.Type))
+	model.ParentEnvironmentID = util.StringOrNull(channel.ParentEnvironmentID)
+	model.EphemeralEnvironmentNameTemplate = util.StringOrNull(channel.EphemeralEnvironmentNameTemplate)
 
 	return model
 }

--- a/octopusdeploy_framework/schemas/channel.go
+++ b/octopusdeploy_framework/schemas/channel.go
@@ -3,6 +3,8 @@ package schemas
 import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -11,14 +13,17 @@ const ChannelResourceDescription = "channel"
 type ChannelSchema struct{}
 
 type ChannelModel struct {
-	Description types.String `tfsdk:"description"`
-	IsDefault   types.Bool   `tfsdk:"is_default"`
-	LifecycleId types.String `tfsdk:"lifecycle_id"`
-	Name        types.String `tfsdk:"name"`
-	ProjectId   types.String `tfsdk:"project_id"`
-	Rule        types.List   `tfsdk:"rule"`
-	SpaceId     types.String `tfsdk:"space_id"`
-	TenantTags  types.Set    `tfsdk:"tenant_tags"`
+	Description                      types.String `tfsdk:"description"`
+	EphemeralEnvironmentNameTemplate types.String `tfsdk:"ephemeral_environment_name_template"`
+	IsDefault                        types.Bool   `tfsdk:"is_default"`
+	LifecycleId                      types.String `tfsdk:"lifecycle_id"`
+	Name                             types.String `tfsdk:"name"`
+	ParentEnvironmentID              types.String `tfsdk:"parent_environment_id"`
+	ProjectId                        types.String `tfsdk:"project_id"`
+	Rule                             types.List   `tfsdk:"rule"`
+	SpaceId                          types.String `tfsdk:"space_id"`
+	TenantTags                       types.Set    `tfsdk:"tenant_tags"`
+	Type                             types.String `tfsdk:"type"`
 
 	ResourceModel
 }
@@ -29,6 +34,10 @@ func (c ChannelSchema) GetResourceSchema() resourceSchema.Schema {
 		Attributes: map[string]resourceSchema.Attribute{
 			"id":          GetIdResourceSchema(),
 			"description": GetDescriptionResourceSchema(ChannelResourceDescription),
+			"ephemeral_environment_name_template": resourceSchema.StringAttribute{
+				Description: "The name template for ephemeral environments created from this channel.",
+				Optional:    true,
+			},
 			"is_default": resourceSchema.BoolAttribute{
 				Description: "Indicates whether this is the default channel for the associated project.",
 				Optional:    true,
@@ -38,6 +47,10 @@ func (c ChannelSchema) GetResourceSchema() resourceSchema.Schema {
 				Optional:    true,
 			},
 			"name": GetNameResourceSchema(true),
+			"parent_environment_id": resourceSchema.StringAttribute{
+				Description: "The parent environment ID for ephemeral environments.",
+				Optional:    true,
+			},
 			"project_id": resourceSchema.StringAttribute{
 				Description: "The project ID associated with this channel.",
 				Required:    true,
@@ -47,6 +60,14 @@ func (c ChannelSchema) GetResourceSchema() resourceSchema.Schema {
 				Description: "A set of tenant tags associated with this channel.",
 				Optional:    true,
 				ElementType: types.StringType,
+			},
+			"type": resourceSchema.StringAttribute{
+				Description: "The type of channel. Valid values are `\"Lifecycle\"` or `\"EphemeralEnvironment\"`. Defaults to `\"Lifecycle\"`.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Blocks: map[string]resourceSchema.Block{


### PR DESCRIPTION
Ephemeral environments introduced 3 new fields to channels. Type, EphemeralEnvironmentNameTemplate and ParentID. This change adds the ability to manage these fields using the terraform provider

[sc-122355]