### PR TITLE
add migration guide for deprecating retention_policy block

### DIFF
--- a/docs/guides/migration-guide-v1.3.12.md
+++ b/docs/guides/migration-guide-v1.3.12.md
@@ -50,12 +50,12 @@ Lifecycles data source use:
 
 ### Timeline
 
-Migration will be required no earlier than 19 Oct 2026
+Migration will be required no earlier than 21 Oct 2026
 
 | Date        | What we'll do                                                        | What you need to do                                                      |
 | ----------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| 19 APR 2026 | **Enactment**: Soft-delete the deprecated block (Major release)      | Migrate your Terraform config, or use the escape-hatch, before upgrading |
-| 19 OCT 2026 | **Completion**: Remove the deprecated block entirely (Patch release) | Migrate your Terraform config before upgrading                           |
+| 21 APR 2026 | **Enactment**: Soft-delete the deprecated block (Major release)      | Migrate your Terraform config, or use the escape-hatch, before upgrading |
+| 21 OCT 2026 | **Completion**: Remove the deprecated block entirely (Patch release) | Migrate your Terraform config before upgrading                           |
 
 ### How to migrate
 

--- a/templates/guides/migration-guide-v1.3.12.md.tmpl
+++ b/templates/guides/migration-guide-v1.3.12.md.tmpl
@@ -50,12 +50,12 @@ Lifecycles data source use:
 
 ### Timeline
 
-Migration will be required no earlier than 19 Oct 2026
+Migration will be required no earlier than 21 Oct 2026
 
 | Date        | What we'll do                                                        | What you need to do                                                      |
 | ----------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| 19 APR 2026 | **Enactment**: Soft-delete the deprecated block (Major release)      | Migrate your Terraform config, or use the escape-hatch, before upgrading |
-| 19 OCT 2026 | **Completion**: Remove the deprecated block entirely (Patch release) | Migrate your Terraform config before upgrading                           |
+| 21 APR 2026 | **Enactment**: Soft-delete the deprecated block (Major release)      | Migrate your Terraform config, or use the escape-hatch, before upgrading |
+| 21 OCT 2026 | **Completion**: Remove the deprecated block entirely (Patch release) | Migrate your Terraform config before upgrading                           |
 
 ### How to migrate
 


### PR DESCRIPTION
# Description 
Migration guide for [PR-103](https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/103) - replacing `retention_policy` retention block with `retention_with_strategy` retention block


[[sc-123966]](https://app.shortcut.com/octopusdeploy/story/123966/add-migration-guide-for-deprecating-migration-polocy-block)

## Deprecation Timeline
**Soft delete:** 21 April 2026 ([drafted changes here](https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/102) and [story here](https://app.shortcut.com/octopusdeploy/story/123783/soft-delete-retention-policy-block))
**Removal of `retention_policy` block:** 21 October 2026 ([story here](https://app.shortcut.com/octopusdeploy/story/123514/remove-old-release-strategy-block-usage))
