### PR TITLE
Add feed type field to feeds datasource

### DIFF
--- a/octopusdeploy_framework/datasource_feeds.go
+++ b/octopusdeploy_framework/datasource_feeds.go
@@ -41,6 +41,7 @@ func (e *feedsDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 
 	query := feeds.FeedsQuery{
 		Name:        data.Name.ValueString(),
+		FeedType:    data.FeedType.ValueString(),
 		IDs:         util.GetIds(data.IDs),
 		PartialName: data.PartialName.ValueString(),
 		Skip:        util.GetNumber(data.Skip),


### PR DESCRIPTION
Adds support for the FeedType property on the feeds datasource.

Core change is from #78 by @GSokol, this change adds tests.

Fixes https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/97