### PR TITLE
chore: Fix CI not using pre-pull docker image

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -137,7 +137,7 @@ jobs:
           OCTOTESTSKIPINIT: true
           GOMAXPROCS: 4
           OCTOTESTVERSION: latest
-          OCTOTESTIMAGEURL: octopusdeploy/octopusdeploy
+          OCTOTESTIMAGEURL: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
           OCTOTESTRETRYCOUNT: 0
       - name: Upload test artifacts
         if: always()


### PR DESCRIPTION
As part of #139, we've updated the CI image that is pulled before running the tests. However, we did not update the actual image used.