### PR TITLE
feat: Add ability to set GitHub app as source for git dependency resources

### DIFF
--- a/docs/resources/process_child_step.md
+++ b/docs/resources/process_child_step.md
@@ -133,6 +133,7 @@ Optional:
 
 - `file_path_filters` (Set of String) List of file path filters used to narrow down the directory where files are to be sourced from. Supports glob patten syntax.
 - `git_credential_id` (String) ID of an existing Git credential.
+- `github_connection_id` (String) ID of an existing GitHub App connection. Used when git_credential_type is GitHub
 
 
 <a id="nestedatt--packages"></a>

--- a/docs/resources/process_step.md
+++ b/docs/resources/process_step.md
@@ -164,6 +164,7 @@ Optional:
 
 - `file_path_filters` (Set of String) List of file path filters used to narrow down the directory where files are to be sourced from. Supports glob patten syntax.
 - `git_credential_id` (String) ID of an existing Git credential.
+- `github_connection_id` (String) ID of an existing GitHub App connection. Used when git_credential_type is GitHub
 
 
 <a id="nestedatt--packages"></a>

--- a/docs/resources/process_templated_child_step.md
+++ b/docs/resources/process_templated_child_step.md
@@ -184,6 +184,7 @@ Optional:
 
 - `file_path_filters` (Set of String) List of file path filters used to narrow down the directory where files are to be sourced from. Supports glob patten syntax.
 - `git_credential_id` (String) ID of an existing Git credential.
+- `github_connection_id` (String) ID of an existing GitHub App connection. Used when git_credential_type is GitHub
 
 
 <a id="nestedatt--packages"></a>

--- a/docs/resources/process_templated_step.md
+++ b/docs/resources/process_templated_step.md
@@ -165,6 +165,7 @@ Optional:
 
 - `file_path_filters` (Set of String) List of file path filters used to narrow down the directory where files are to be sourced from. Supports glob patten syntax.
 - `git_credential_id` (String) ID of an existing Git credential.
+- `github_connection_id` (String) ID of an existing GitHub App connection. Used when git_credential_type is GitHub
 
 
 <a id="nestedatt--packages"></a>

--- a/octopusdeploy_framework/resource_process_child_step_mapping_test.go
+++ b/octopusdeploy_framework/resource_process_child_step_mapping_test.go
@@ -2,6 +2,8 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"testing"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
@@ -12,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestAccMapProcessChildStepFromStateWithAllAttributes(t *testing.T) {
@@ -67,7 +68,8 @@ func TestAccMapProcessChildStepFromStateWithAllAttributes(t *testing.T) {
 					"file_path_filters": types.SetValueMust(types.StringType, []attr.Value{
 						types.StringValue("directory-a"),
 					}),
-					"git_credential_id": types.StringValue("GitCredentials-1"),
+					"git_credential_id":    types.StringValue("GitCredentials-1"),
+					"github_connection_id": types.StringValue(""),
 				},
 			),
 		}),
@@ -180,12 +182,13 @@ func TestAccMapProcessChildStepToStateWithAllAttributes(t *testing.T) {
 		AcquisitionLocation: "Server",
 	}
 	gitDependency := &gitdependencies.GitDependency{
-		Name:              "this-dependency",
-		RepositoryUri:     "git://test.repository.co.nz",
-		DefaultBranch:     "default",
-		GitCredentialType: "NotSpecified",
-		FilePathFilters:   []string{"directory-b"},
-		GitCredentialId:   "GitCredential-2",
+		Name:               "this-dependency",
+		RepositoryUri:      "git://test.repository.co.nz",
+		DefaultBranch:      "default",
+		GitCredentialType:  "NotSpecified",
+		FilePathFilters:    []string{"directory-b"},
+		GitCredentialId:    "GitCredential-2",
+		GitHubConnectionId: "",
 	}
 
 	action := deployments.NewDeploymentAction("Step One", "Octopus.Script")
@@ -285,10 +288,11 @@ func TestAccMapProcessChildStepToStateWithAllAttributes(t *testing.T) {
 			gitDependency.Name: types.ObjectValueMust(
 				schemas.ProcessStepGitDependencyAttributeTypes(),
 				map[string]attr.Value{
-					"repository_uri":      types.StringValue(gitDependency.RepositoryUri),
-					"default_branch":      types.StringValue(gitDependency.DefaultBranch),
-					"git_credential_type": types.StringValue(gitDependency.GitCredentialType),
-					"git_credential_id":   types.StringValue(gitDependency.GitCredentialId),
+					"repository_uri":       types.StringValue(gitDependency.RepositoryUri),
+					"default_branch":       types.StringValue(gitDependency.DefaultBranch),
+					"git_credential_type":  types.StringValue(gitDependency.GitCredentialType),
+					"git_credential_id":    types.StringValue(gitDependency.GitCredentialId),
+					"github_connection_id": types.StringValue(gitDependency.GitHubConnectionId),
 					"file_path_filters": types.SetValueMust(types.StringType, []attr.Value{
 						types.StringValue("directory-b"),
 					}),
@@ -443,10 +447,11 @@ func TestAccMapProcessChildStepToStateWithAllAttributesForRunbooks(t *testing.T)
 			gitDependency.Name: types.ObjectValueMust(
 				schemas.ProcessStepGitDependencyAttributeTypes(),
 				map[string]attr.Value{
-					"repository_uri":      types.StringValue(gitDependency.RepositoryUri),
-					"default_branch":      types.StringValue(gitDependency.DefaultBranch),
-					"git_credential_type": types.StringValue(gitDependency.GitCredentialType),
-					"git_credential_id":   types.StringValue(gitDependency.GitCredentialId),
+					"repository_uri":       types.StringValue(gitDependency.RepositoryUri),
+					"default_branch":       types.StringValue(gitDependency.DefaultBranch),
+					"git_credential_type":  types.StringValue(gitDependency.GitCredentialType),
+					"git_credential_id":    types.StringValue(gitDependency.GitCredentialId),
+					"github_connection_id": types.StringValue(gitDependency.GitHubConnectionId),
 					"file_path_filters": types.SetValueMust(types.StringType, []attr.Value{
 						types.StringValue("directory-b"),
 					}),

--- a/octopusdeploy_framework/resource_process_step.go
+++ b/octopusdeploy_framework/resource_process_step.go
@@ -351,11 +351,12 @@ func mapProcessStepActionGitDependenciesFromState(ctx context.Context, dependenc
 		}
 
 		gitDependency := &gitdependencies.GitDependency{
-			Name:              key,
-			RepositoryUri:     dependencyState.RepositoryUri.ValueString(),
-			DefaultBranch:     dependencyState.DefaultBranch.ValueString(),
-			GitCredentialType: dependencyState.GitCredentialType.ValueString(),
-			GitCredentialId:   dependencyState.GitCredentialID.ValueString(),
+			Name:               key,
+			RepositoryUri:      dependencyState.RepositoryUri.ValueString(),
+			DefaultBranch:      dependencyState.DefaultBranch.ValueString(),
+			GitCredentialType:  dependencyState.GitCredentialType.ValueString(),
+			GitCredentialId:    dependencyState.GitCredentialID.ValueString(),
+			GitHubConnectionId: dependencyState.GitHubConnectionID.ValueString(),
 		}
 
 		if dependencyState.FilePathFilters.IsNull() {
@@ -541,11 +542,12 @@ func mapGitDependenciesToState(dependencies []*gitdependencies.GitDependency) ty
 		stateDependency := types.ObjectValueMust(
 			schemas.ProcessStepGitDependencyAttributeTypes(),
 			map[string]attr.Value{
-				"repository_uri":      types.StringValue(dependency.RepositoryUri),
-				"default_branch":      types.StringValue(dependency.DefaultBranch),
-				"git_credential_type": types.StringValue(dependency.GitCredentialType),
-				"file_path_filters":   types.SetValueMust(types.StringType, util.ToValueSlice(dependency.FilePathFilters)),
-				"git_credential_id":   types.StringValue(dependency.GitCredentialId),
+				"repository_uri":       types.StringValue(dependency.RepositoryUri),
+				"default_branch":       types.StringValue(dependency.DefaultBranch),
+				"git_credential_type":  types.StringValue(dependency.GitCredentialType),
+				"file_path_filters":    types.SetValueMust(types.StringType, util.ToValueSlice(dependency.FilePathFilters)),
+				"git_credential_id":    types.StringValue(dependency.GitCredentialId),
+				"github_connection_id": types.StringValue(dependency.GitHubConnectionId),
 			},
 		)
 

--- a/octopusdeploy_framework/resource_process_step_mapping_test.go
+++ b/octopusdeploy_framework/resource_process_step_mapping_test.go
@@ -73,7 +73,8 @@ func TestAccMapProcessStepFromStateWithAllAttributes(t *testing.T) {
 					"file_path_filters": types.SetValueMust(types.StringType, []attr.Value{
 						types.StringValue("directory-a"),
 					}),
-					"git_credential_id": types.StringValue("GitCredentials-1"),
+					"git_credential_id":    types.StringValue("GitCredentials-1"),
+					"github_connection_id": types.StringValue("GitHubConnections-1"),
 				},
 			),
 		}),
@@ -133,12 +134,13 @@ func TestAccMapProcessStepFromStateWithAllAttributes(t *testing.T) {
 				},
 				GitDependencies: []*gitdependencies.GitDependency{
 					{
-						Name:              "script-folder",
-						RepositoryUri:     "git://test.repository.fi",
-						DefaultBranch:     "main",
-						GitCredentialType: "UsernamePassword",
-						FilePathFilters:   []string{"directory-a"},
-						GitCredentialId:   "GitCredentials-1",
+						Name:               "script-folder",
+						RepositoryUri:      "git://test.repository.fi",
+						DefaultBranch:      "main",
+						GitCredentialType:  "UsernamePassword",
+						FilePathFilters:    []string{"directory-a"},
+						GitCredentialId:    "GitCredentials-1",
+						GitHubConnectionId: "GitHubConnections-1",
 					},
 				},
 				Packages: []*packages.PackageReference{
@@ -257,12 +259,13 @@ func TestAccMapProcessStepToStateWithAllAttributes(t *testing.T) {
 		AcquisitionLocation: "Server",
 	}
 	gitDependency := &gitdependencies.GitDependency{
-		Name:              "this-dependency",
-		RepositoryUri:     "git://test.repository.co.nz",
-		DefaultBranch:     "default",
-		GitCredentialType: "NotSpecified",
-		FilePathFilters:   []string{"directory-b"},
-		GitCredentialId:   "GitCredential-2",
+		Name:               "this-dependency",
+		RepositoryUri:      "git://test.repository.co.nz",
+		DefaultBranch:      "default",
+		GitCredentialType:  "NotSpecified",
+		FilePathFilters:    []string{"directory-b"},
+		GitCredentialId:    "GitCredential-2",
+		GitHubConnectionId: "GitHubConnections-2",
 	}
 
 	action := deployments.NewDeploymentAction("Step One", "Octopus.Script")
@@ -369,10 +372,11 @@ func TestAccMapProcessStepToStateWithAllAttributes(t *testing.T) {
 			gitDependency.Name: types.ObjectValueMust(
 				schemas.ProcessStepGitDependencyAttributeTypes(),
 				map[string]attr.Value{
-					"repository_uri":      types.StringValue(gitDependency.RepositoryUri),
-					"default_branch":      types.StringValue(gitDependency.DefaultBranch),
-					"git_credential_type": types.StringValue(gitDependency.GitCredentialType),
-					"git_credential_id":   types.StringValue(gitDependency.GitCredentialId),
+					"repository_uri":       types.StringValue(gitDependency.RepositoryUri),
+					"default_branch":       types.StringValue(gitDependency.DefaultBranch),
+					"git_credential_type":  types.StringValue(gitDependency.GitCredentialType),
+					"git_credential_id":    types.StringValue(gitDependency.GitCredentialId),
+					"github_connection_id": types.StringValue(gitDependency.GitHubConnectionId),
 					"file_path_filters": types.SetValueMust(types.StringType, []attr.Value{
 						types.StringValue("directory-b"),
 					}),
@@ -422,12 +426,13 @@ func TestAccMapProcessStepToStateWithAllAttributesForRunbook(t *testing.T) {
 		AcquisitionLocation: "Server",
 	}
 	gitDependency := &gitdependencies.GitDependency{
-		Name:              "this-dependency",
-		RepositoryUri:     "git://test.repository.co.nz",
-		DefaultBranch:     "default",
-		GitCredentialType: "NotSpecified",
-		FilePathFilters:   []string{"directory-b"},
-		GitCredentialId:   "GitCredential-2",
+		Name:               "this-dependency",
+		RepositoryUri:      "git://test.repository.co.nz",
+		DefaultBranch:      "default",
+		GitCredentialType:  "NotSpecified",
+		FilePathFilters:    []string{"directory-b"},
+		GitCredentialId:    "GitCredential-2",
+		GitHubConnectionId: "GitHubConnections-2",
 	}
 
 	action := deployments.NewDeploymentAction("Step One", "Octopus.Script")
@@ -535,10 +540,11 @@ func TestAccMapProcessStepToStateWithAllAttributesForRunbook(t *testing.T) {
 			gitDependency.Name: types.ObjectValueMust(
 				schemas.ProcessStepGitDependencyAttributeTypes(),
 				map[string]attr.Value{
-					"repository_uri":      types.StringValue(gitDependency.RepositoryUri),
-					"default_branch":      types.StringValue(gitDependency.DefaultBranch),
-					"git_credential_type": types.StringValue(gitDependency.GitCredentialType),
-					"git_credential_id":   types.StringValue(gitDependency.GitCredentialId),
+					"repository_uri":       types.StringValue(gitDependency.RepositoryUri),
+					"default_branch":       types.StringValue(gitDependency.DefaultBranch),
+					"git_credential_type":  types.StringValue(gitDependency.GitCredentialType),
+					"git_credential_id":    types.StringValue(gitDependency.GitCredentialId),
+					"github_connection_id": types.StringValue(gitDependency.GitHubConnectionId),
 					"file_path_filters": types.SetValueMust(types.StringType, []attr.Value{
 						types.StringValue("directory-b"),
 					}),

--- a/octopusdeploy_framework/schemas/process_step.go
+++ b/octopusdeploy_framework/schemas/process_step.go
@@ -289,11 +289,12 @@ func resourceActionPackageReferenceAttributes() map[string]resourceSchema.Attrib
 }
 
 type ProcessStepGitDependencyResourceModel struct {
-	RepositoryUri     types.String `tfsdk:"repository_uri"`
-	DefaultBranch     types.String `tfsdk:"default_branch"`
-	GitCredentialType types.String `tfsdk:"git_credential_type"`
-	FilePathFilters   types.Set    `tfsdk:"file_path_filters"`
-	GitCredentialID   types.String `tfsdk:"git_credential_id"`
+	RepositoryUri      types.String `tfsdk:"repository_uri"`
+	DefaultBranch      types.String `tfsdk:"default_branch"`
+	GitCredentialType  types.String `tfsdk:"git_credential_type"`
+	FilePathFilters    types.Set    `tfsdk:"file_path_filters"`
+	GitCredentialID    types.String `tfsdk:"git_credential_id"`
+	GitHubConnectionID types.String `tfsdk:"github_connection_id"`
 }
 
 func ProcessStepGitDependencyObjectType() types.ObjectType {
@@ -304,11 +305,12 @@ func ProcessStepGitDependencyObjectType() types.ObjectType {
 
 func ProcessStepGitDependencyAttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"repository_uri":      types.StringType,
-		"default_branch":      types.StringType,
-		"git_credential_type": types.StringType,
-		"file_path_filters":   types.SetType{ElemType: types.StringType},
-		"git_credential_id":   types.StringType,
+		"repository_uri":       types.StringType,
+		"default_branch":       types.StringType,
+		"git_credential_type":  types.StringType,
+		"file_path_filters":    types.SetType{ElemType: types.StringType},
+		"git_credential_id":    types.StringType,
+		"github_connection_id": types.StringType,
 	}
 }
 
@@ -348,6 +350,10 @@ func resourceActionGitDependencyNestedAttribute() resourceSchema.NestedAttribute
 				Optional().
 				Computed().
 				Default("").
+				Build(),
+			"github_connection_id": util.ResourceString().
+				Description("ID of an existing GitHub App connection. Used when git_credential_type is GitHub").
+				Optional().
 				Build(),
 		},
 	}


### PR DESCRIPTION
# Background

[sc-125235]

Sources for git dependencies can now also be set to use a previously configured GitHub web app connection.

<img width="660" height="921" alt="Screenshot 2025-12-17 075735" src="https://github.com/user-attachments/assets/cdced46d-a036-4622-b14c-a42e08efbe43" />

<img width="1001" height="975" alt="Screenshot 2025-12-17 080118" src="https://github.com/user-attachments/assets/7dd2bf1b-2a59-4577-9551-5270d351343f" />

