### PR TITLE
fix: ignore variable scope ordering

### DIFF
--- a/octopusdeploy_framework/schemas/planmodifiers/order_insensitive_list.go
+++ b/octopusdeploy_framework/schemas/planmodifiers/order_insensitive_list.go
@@ -1,0 +1,52 @@
+// Package planmodifiers contains custom plan modifiers for the Terraform provider.
+package planmodifiers
+
+import (
+	"context"
+
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// OrderInsensitiveList returns a plan modifier that ignores the order of elements in a list.
+// This fixes issues where APIs return scope values in a different order than submitted,
+// causing unwanted Terraform plan differences.
+func OrderInsensitiveList() planmodifier.List {
+	return orderInsensitiveListModifier{}
+}
+
+type orderInsensitiveListModifier struct{}
+
+func (m orderInsensitiveListModifier) Description(_ context.Context) string {
+	return "Ignores order differences between planned and actual list values"
+}
+
+func (m orderInsensitiveListModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m orderInsensitiveListModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	// If the plan value is null or unknown, no changes needed
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// If the state value is null, this is a create operation, no changes needed
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// If the state value is unknown, no changes needed
+	if req.StateValue.IsUnknown() {
+		return
+	}
+
+	// Convert both lists to string slices for comparison
+	planStrings := util.ExpandStringList(req.PlanValue)
+	stateStrings := util.ExpandStringList(req.StateValue)
+
+	// If the sorted content matches, keep the current state value to prevent drift
+	if util.StringSlicesEqual(planStrings, stateStrings) {
+		resp.PlanValue = req.StateValue
+	}
+}

--- a/octopusdeploy_framework/schemas/variable_scope.go
+++ b/octopusdeploy_framework/schemas/variable_scope.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas/planmodifiers"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -125,6 +127,9 @@ func getVariableScopeFieldResourceSchema(scopeDescription string) resourceSchema
 		Description: fmt.Sprintf("A list of %s that are scoped to this variable value.", strings.ReplaceAll(scopeDescription, "_", " ")),
 		Optional:    true,
 		ElementType: basetypes.StringType{},
+		PlanModifiers: []planmodifier.List{
+			planmodifiers.OrderInsensitiveList(),
+		},
 	}
 }
 

--- a/octopusdeploy_framework/schemas/variable_scope_test.go
+++ b/octopusdeploy_framework/schemas/variable_scope_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -101,4 +102,28 @@ func TestFlattenVariableScope(t *testing.T) {
 	actionScope := flattenedVariableScope.Elements()[0].(types.Object).Attributes()["actions"].(types.List)
 	t.Logf("Action scope: %#v", actionScope)
 	assert.Len(t, actionScope.Elements(), 1)
+}
+
+func TestVariableScopeOrderInsensitive(t *testing.T) {
+	originalScope := variables.VariableScope{
+		Environments: []string{"Environments-62", "Environments-61", "Environments-63"},
+	}
+
+	reorderedScope := variables.VariableScope{
+		Environments: []string{"Environments-61", "Environments-63", "Environments-62"},
+	}
+
+	originalTerraform := MapFromVariableScope(originalScope)
+	reorderedTerraform := MapFromVariableScope(reorderedScope)
+
+	// These are not equal because the order is different, but they are equivalent
+	assert.NotEqual(t, originalTerraform, reorderedTerraform)
+
+	originalEnvs := originalTerraform.(types.Object).Attributes()["environments"].(types.List)
+	reorderedEnvs := reorderedTerraform.(types.Object).Attributes()["environments"].(types.List)
+
+	originalStrings := util.ExpandStringList(originalEnvs)
+	reorderedStrings := util.ExpandStringList(reorderedEnvs)
+
+	assert.ElementsMatch(t, originalStrings, reorderedStrings)
 }


### PR DESCRIPTION
[SC-133698]

Changes in the Octopus API have resulted in the modify variable set endpoint returning scopes as a list ordered by ID. The issue was raised for environment scopes, but applies to all scope types. Previously this list was ordered in the same sequence as was submitted in the update request. When using terraform, customers might not always order their scopes by ID which results in drift for variables managed by terraform.

Fixes: https://github.com/OctopusDeploy/Issues/issues/9851

Sample variable set and project variable resources:
```
resource "octopusdeploy_variable" "varsetexample" {
  name        = "test-varset-environment-order"
  owner_id = "LibraryVariableSets-22"
  type        = "String"
  value       = "test-value"

  scope {
    environments = [
      "Environments-82"
      "Environments-83",
      "Environments-81"
    ]
    # Uncomment these to test other scope types:
    # machines = ["Machines-123", "Machines-456", "Machines-789"]
    # roles = ["web-server", "api-server", "database"]
  }
}

resource "octopusdeploy_variable" "projectexample" {
  name        = "test-project-environment-order"
  owner_id = "Projects-121"
  type        = "String"
  value       = "test-value"

  scope {
    environments = [
      "Environments-82",
      "Environments-81",
      "Environments-83"
    ]
  }
}
```

## Before
The initial `terraform apply` was successful and showed no problems.
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # octopusdeploy_variable.varsetexample will be created
  + resource "octopusdeploy_variable" "varsetexample" {
      + description  = "Testing environment scope order fix"
      + id           = (known after apply)
      + is_editable  = true
      + is_sensitive = false
      + name         = "test-varset-environment-order"
      + owner_id     = "LibraryVariableSets-22"
      + space_id     = (known after apply)
      + type         = "String"
      + value        = "test-value"

      + scope {
          + environments = [
              + "Environments-82",
              + "Environments-83",
              + "Environments-81",
            ]
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

octopusdeploy_variable.varsetexample: Creating...
octopusdeploy_variable.varsetexample: Creation complete after 1s [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Subsequent `terraform apply` showed a change in scope order
```
octopusdeploy_variable.varsetexample: Refreshing state... [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # octopusdeploy_variable.varsetexample will be updated in-place
  ~ resource "octopusdeploy_variable" "varsetexample" {
        id           = "e0e6e294-ff20-4a19-bfd0-8d62a5f27905"
        name         = "test-varset-environment-order"
        # (7 unchanged attributes hidden)

      ~ scope {
          ~ environments = [
              - "Environments-81",
                "Environments-82",
                "Environments-83",
              + "Environments-81",
            ]
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## After
Re-running `terraform plan` or `terraform apply` detects no changes (both project and variable set variables)
```
octopusdeploy_variable.varsetexample: Refreshing state... [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

## Testing
Actual changes to the scope (other than ordering) are still detected by the provider as normal.
### Removing a scope:
```
octopusdeploy_variable.varsetexample: Refreshing state... [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # octopusdeploy_variable.varsetexample will be updated in-place
  ~ resource "octopusdeploy_variable" "varsetexample" {
        id           = "e0e6e294-ff20-4a19-bfd0-8d62a5f27905"
        name         = "test-varset-environment-order"
        # (7 unchanged attributes hidden)

      ~ scope {
          ~ environments = [
              - "Environments-81",
                "Environments-82",
                # (1 unchanged element hidden)
            ]
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### Adding a scope
```
octopusdeploy_variable.varsetexample: Refreshing state... [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # octopusdeploy_variable.varsetexample will be updated in-place
  ~ resource "octopusdeploy_variable" "varsetexample" {
        id           = "e0e6e294-ff20-4a19-bfd0-8d62a5f27905"
        name         = "test-varset-environment-order"
        # (7 unchanged attributes hidden)

      ~ scope {
          ~ environments = [
                # (1 unchanged element hidden)
                "Environments-83",
              + "Environments-81",
            ]
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

octopusdeploy_variable.varsetexample: Modifying... [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]
octopusdeploy_variable.varsetexample: Modifications complete after 1s [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Adding other scope types
```
octopusdeploy_variable.varsetexample: Refreshing state... [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # octopusdeploy_variable.varsetexample will be updated in-place
  ~ resource "octopusdeploy_variable" "varsetexample" {
        id           = "e0e6e294-ff20-4a19-bfd0-8d62a5f27905"
        name         = "test-varset-environment-order"
        # (7 unchanged attributes hidden)

      ~ scope {
          + machines     = [
              + "Machines-123",
              + "Machines-456",
              + "Machines-789",
            ]
          + roles        = [
              + "web-server",
              + "api-server",
              + "database",
            ]
            # (1 unchanged attribute hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

octopusdeploy_variable.varsetexample: Modifying... [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]
octopusdeploy_variable.varsetexample: Modifications complete after 0s [id=e0e6e294-ff20-4a19-bfd0-8d62a5f27905]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```