### PR TITLE
fix: update oidc auth to state consistently

### DIFF
--- a/octopusdeploy_framework/resource_azure_container_registry.go
+++ b/octopusdeploy_framework/resource_azure_container_registry.go
@@ -3,6 +3,7 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
@@ -160,6 +161,8 @@ func createContainerRegistryFeedResourceFromAzureData(data *schemas.AzureContain
 			Audience:    data.OidcAuthentication.Audience.ValueString(),
 			SubjectKeys: util.ExpandStringList(data.OidcAuthentication.SubjectKey),
 		}
+	} else {
+		oidc = nil
 	}
 
 	feed, err := feeds.NewAzureContainerRegistry(
@@ -211,13 +214,15 @@ func updateDataFromAzureContainerRegistryFeed(data *schemas.AzureContainerRegist
 
 	data.ID = types.StringValue(feed.ID)
 
-	if feed.OidcAuthentication != nil {
+	if feed.OidcAuthentication != nil && (feed.OidcAuthentication.Audience != "" || len(feed.OidcAuthentication.SubjectKeys) > 0 || feed.OidcAuthentication.TenantId != "" || feed.OidcAuthentication.ClientId != "") {
 		data.OidcAuthentication = &schemas.AzureContainerRegistryOidcAuthenticationResourceModel{
 			ClientId:   types.StringValue(feed.OidcAuthentication.ClientId),
 			TenantId:   types.StringValue(feed.OidcAuthentication.TenantId),
 			Audience:   types.StringValue(feed.OidcAuthentication.Audience),
 			SubjectKey: util.FlattenStringList(feed.OidcAuthentication.SubjectKeys),
 		}
+	} else {
+		data.OidcAuthentication = nil
 	}
 }
 

--- a/octopusdeploy_framework/resource_google_container_registry.go
+++ b/octopusdeploy_framework/resource_google_container_registry.go
@@ -3,6 +3,7 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
@@ -159,6 +160,8 @@ func createContainerRegistryFeedResourceFromGoogleData(data *schemas.GoogleConta
 			Audience:    data.OidcAuthentication.Audience.ValueString(),
 			SubjectKeys: util.ExpandStringList(data.OidcAuthentication.SubjectKey),
 		}
+	} else {
+		oidc = nil
 	}
 
 	feed, err := feeds.NewGoogleContainerRegistry(data.Name.ValueString(), data.Username.ValueString(), core.NewSensitiveValue(data.Password.ValueString()), oidc)
@@ -206,11 +209,13 @@ func updateGoogleDataFromDockerContainerRegistryFeed(data *schemas.GoogleContain
 
 	data.ID = types.StringValue(feed.ID)
 
-	if feed.OidcAuthentication != nil {
+	if feed.OidcAuthentication != nil && (feed.OidcAuthentication.Audience != "" || len(feed.OidcAuthentication.SubjectKeys) > 0) {
 		data.OidcAuthentication = &schemas.GoogleContainerRegistryOidcAuthenticationResourceModel{
 			Audience:   types.StringValue(feed.OidcAuthentication.Audience),
 			SubjectKey: util.FlattenStringList(feed.OidcAuthentication.SubjectKeys),
 		}
+	} else {
+		data.OidcAuthentication = nil
 	}
 }
 


### PR DESCRIPTION
Fixes: #169 
[sc-135132]

Before 
```
Error: Provider produced inconsistent result after apply
│
│ When applying changes to octopusdeploy_google_container_registry.gcr, provider "provider[\"octopus.com/com/octopusdeploy\"]" produced an
│ unexpected new value: .oidc_authentication: was null, but now cty.ObjectVal(map[string]cty.Value{"audience":cty.StringVal(""),
│ "subject_keys":cty.ListValEmpty(cty.String)}).
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

After:
```
octopusdeploy_azure_container_registry.acr: Creating...
octopusdeploy_google_container_registry.gcr_with_oidc: Creating...
octopusdeploy_google_container_registry.gcr: Creating...
octopusdeploy_azure_container_registry.acr_with_oidc: Creating...
octopusdeploy_google_container_registry.gcr: Creation complete after 0s [id=Feeds-2365]
octopusdeploy_google_container_registry.gcr_with_oidc: Creation complete after 0s [id=Feeds-2363]
octopusdeploy_azure_container_registry.acr_with_oidc: Creation complete after 0s [id=Feeds-2364]
octopusdeploy_azure_container_registry.acr: Creation complete after 0s [id=Feeds-2366]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
```