### PR TITLE
Add custom field definitions to channel

### DIFF
--- a/docs/resources/channel.md
+++ b/docs/resources/channel.md
@@ -29,6 +29,7 @@ resource "octopusdeploy_channel" "example" {
 
 ### Optional
 
+- `custom_field_definitions` (Attributes List) A list of custom field definitions for this channel. Maximum of 10. (see [below for nested schema](#nestedatt--custom_field_definitions))
 - `description` (String) The description of this channel.
 - `ephemeral_environment_name_template` (String) The name template for ephemeral environments created from this channel.
 - `is_default` (Boolean) Indicates whether this is the default channel for the associated project.
@@ -42,6 +43,15 @@ resource "octopusdeploy_channel" "example" {
 ### Read-Only
 
 - `id` (String) The unique ID for this resource.
+
+<a id="nestedatt--custom_field_definitions"></a>
+### Nested Schema for `custom_field_definitions`
+
+Required:
+
+- `description` (String) The description of the custom field.
+- `field_name` (String) The name of the custom field.
+
 
 <a id="nestedblock--rule"></a>
 ### Nested Schema for `rule`

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.105.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.105.1-0.20260410024644-845b3652cb8c
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.103.0 h1:yGQxxqm3lXgEFITtdhXC7FQ
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.103.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.105.0 h1:KfQngSy4tnjRfHJldIcxxE+DKeiMsJHu/1PTub/kKc8=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.105.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.105.1-0.20260410024644-845b3652cb8c h1:6102d7f5d46u8pNkwSDQOrZSh8ACSRYOBmnOFTa7anc=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.105.1-0.20260410024644-845b3652cb8c/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2 h1:960T/UryMsoc2ZOnoLEg7rM9QpxWIdkdB9sR5gsUFAQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2/go.mod h1:kllISYzQ8N3P6+3rScVhyW/KWnPWQbwzm8pFcMInSRM=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=

--- a/octopusdeploy_framework/resource_channel.go
+++ b/octopusdeploy_framework/resource_channel.go
@@ -337,11 +337,10 @@ func getChannelRuleDeploymentActionPackageAttrTypes() map[string]attr.Type {
 }
 
 func expandChannelCustomFieldDefinitions(defs types.List) *[]channels.ChannelCustomFieldDefinition {
-	if defs.IsNull() {
-		return nil // omitted from JSON → server leaves field unchanged
+	result := make([]channels.ChannelCustomFieldDefinition, 0)
+	if defs.IsNull() || defs.IsUnknown() {
+		return &result // sends [] → clears when omitted from config
 	}
-
-	result := make([]channels.ChannelCustomFieldDefinition, 0, len(defs.Elements()))
 	for _, elem := range defs.Elements() {
 		obj := elem.(types.Object)
 		attrs := obj.Attributes()
@@ -355,19 +354,15 @@ func expandChannelCustomFieldDefinitions(defs types.List) *[]channels.ChannelCus
 		}
 		result = append(result, def)
 	}
-	return &result // empty slice → sends [] to API (clears); populated → sets definitions
+	return &result
 }
 
 func flattenChannelCustomFieldDefinitions(defs *[]channels.ChannelCustomFieldDefinition, current types.List) types.List {
 	attrTypes := getChannelCustomFieldDefinitionAttrTypes()
-	if defs == nil {
-		// API omitted the field — preserve whatever the plan specified
+	if defs == nil || len(*defs) == 0 {
 		if current.IsNull() {
 			return types.ListNull(types.ObjectType{AttrTypes: attrTypes})
 		}
-		return types.ListValueMust(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{})
-	}
-	if len(*defs) == 0 {
 		return types.ListValueMust(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{})
 	}
 

--- a/octopusdeploy_framework/resource_channel.go
+++ b/octopusdeploy_framework/resource_channel.go
@@ -253,7 +253,7 @@ func flattenChannel(ctx context.Context, channel *channels.Channel, model schema
 	model.Name = types.StringValue(channel.Name)
 	model.ProjectId = types.StringValue(channel.ProjectID)
 
-	model.CustomFieldDefinitions = flattenChannelCustomFieldDefinitions(channel.CustomFieldDefinitions)
+	model.CustomFieldDefinitions = flattenChannelCustomFieldDefinitions(channel.CustomFieldDefinitions, model.CustomFieldDefinitions)
 	model.Rule = flattenChannelRules(channel.Rules, model.Rule)
 
 	if channel.SpaceID == "" && model.SpaceId.IsNull() {
@@ -336,9 +336,9 @@ func getChannelRuleDeploymentActionPackageAttrTypes() map[string]attr.Type {
 	}
 }
 
-func expandChannelCustomFieldDefinitions(defs types.List) []channels.ChannelCustomFieldDefinition {
-	if defs.IsNull() || defs.IsUnknown() || len(defs.Elements()) == 0 {
-		return []channels.ChannelCustomFieldDefinition{}
+func expandChannelCustomFieldDefinitions(defs types.List) *[]channels.ChannelCustomFieldDefinition {
+	if defs.IsNull() {
+		return nil // omitted from JSON → server leaves field unchanged
 	}
 
 	result := make([]channels.ChannelCustomFieldDefinition, 0, len(defs.Elements()))
@@ -355,22 +355,30 @@ func expandChannelCustomFieldDefinitions(defs types.List) []channels.ChannelCust
 		}
 		result = append(result, def)
 	}
-	return result
+	return &result // empty slice → sends [] to API (clears); populated → sets definitions
 }
 
-func flattenChannelCustomFieldDefinitions(defs []channels.ChannelCustomFieldDefinition) types.List {
-	if len(defs) == 0 {
-		return types.ListNull(types.ObjectType{AttrTypes: getChannelCustomFieldDefinitionAttrTypes()})
+func flattenChannelCustomFieldDefinitions(defs *[]channels.ChannelCustomFieldDefinition, current types.List) types.List {
+	attrTypes := getChannelCustomFieldDefinitionAttrTypes()
+	if defs == nil {
+		// API omitted the field — preserve whatever the plan specified
+		if current.IsNull() {
+			return types.ListNull(types.ObjectType{AttrTypes: attrTypes})
+		}
+		return types.ListValueMust(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{})
+	}
+	if len(*defs) == 0 {
+		return types.ListValueMust(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{})
 	}
 
-	elems := make([]attr.Value, 0, len(defs))
-	for _, def := range defs {
-		elems = append(elems, types.ObjectValueMust(getChannelCustomFieldDefinitionAttrTypes(), map[string]attr.Value{
+	elems := make([]attr.Value, 0, len(*defs))
+	for _, def := range *defs {
+		elems = append(elems, types.ObjectValueMust(attrTypes, map[string]attr.Value{
 			"field_name":  types.StringValue(def.FieldName),
 			"description": types.StringValue(def.Description),
 		}))
 	}
-	return types.ListValueMust(types.ObjectType{AttrTypes: getChannelCustomFieldDefinitionAttrTypes()}, elems)
+	return types.ListValueMust(types.ObjectType{AttrTypes: attrTypes}, elems)
 }
 
 func getChannelCustomFieldDefinitionAttrTypes() map[string]attr.Type {

--- a/octopusdeploy_framework/resource_channel.go
+++ b/octopusdeploy_framework/resource_channel.go
@@ -139,6 +139,7 @@ func expandChannel(ctx context.Context, model schemas.ChannelModel) *channels.Ch
 	channel.Description = model.Description.ValueString()
 	channel.IsDefault = model.IsDefault.ValueBool()
 	channel.LifecycleID = model.LifecycleId.ValueString()
+	channel.CustomFieldDefinitions = expandChannelCustomFieldDefinitions(model.CustomFieldDefinitions)
 	channel.Rules = expandChannelRules(model.Rule)
 	channel.SpaceID = model.SpaceId.ValueString()
 	channel.TenantTags = util.ExpandStringSet(model.TenantTags)
@@ -252,6 +253,7 @@ func flattenChannel(ctx context.Context, channel *channels.Channel, model schema
 	model.Name = types.StringValue(channel.Name)
 	model.ProjectId = types.StringValue(channel.ProjectID)
 
+	model.CustomFieldDefinitions = flattenChannelCustomFieldDefinitions(channel.CustomFieldDefinitions)
 	model.Rule = flattenChannelRules(channel.Rules, model.Rule)
 
 	if channel.SpaceID == "" && model.SpaceId.IsNull() {
@@ -331,5 +333,49 @@ func getChannelRuleDeploymentActionPackageAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"deployment_action": types.StringType,
 		"package_reference": types.StringType,
+	}
+}
+
+func expandChannelCustomFieldDefinitions(defs types.List) []channels.ChannelCustomFieldDefinition {
+	if defs.IsNull() || defs.IsUnknown() || len(defs.Elements()) == 0 {
+		return []channels.ChannelCustomFieldDefinition{}
+	}
+
+	result := make([]channels.ChannelCustomFieldDefinition, 0, len(defs.Elements()))
+	for _, elem := range defs.Elements() {
+		obj := elem.(types.Object)
+		attrs := obj.Attributes()
+
+		var def channels.ChannelCustomFieldDefinition
+		if v, ok := attrs["field_name"].(types.String); ok && !v.IsNull() {
+			def.FieldName = v.ValueString()
+		}
+		if v, ok := attrs["description"].(types.String); ok && !v.IsNull() {
+			def.Description = v.ValueString()
+		}
+		result = append(result, def)
+	}
+	return result
+}
+
+func flattenChannelCustomFieldDefinitions(defs []channels.ChannelCustomFieldDefinition) types.List {
+	if len(defs) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: getChannelCustomFieldDefinitionAttrTypes()})
+	}
+
+	elems := make([]attr.Value, 0, len(defs))
+	for _, def := range defs {
+		elems = append(elems, types.ObjectValueMust(getChannelCustomFieldDefinitionAttrTypes(), map[string]attr.Value{
+			"field_name":  types.StringValue(def.FieldName),
+			"description": types.StringValue(def.Description),
+		}))
+	}
+	return types.ListValueMust(types.ObjectType{AttrTypes: getChannelCustomFieldDefinitionAttrTypes()}, elems)
+}
+
+func getChannelCustomFieldDefinitionAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"field_name":  types.StringType,
+		"description": types.StringType,
 	}
 }

--- a/octopusdeploy_framework/schemas/channel.go
+++ b/octopusdeploy_framework/schemas/channel.go
@@ -20,6 +20,7 @@ type ChannelModel struct {
 	Name                             types.String `tfsdk:"name"`
 	ParentEnvironmentID              types.String `tfsdk:"parent_environment_id"`
 	ProjectId                        types.String `tfsdk:"project_id"`
+	CustomFieldDefinitions           types.List   `tfsdk:"custom_field_definitions"`
 	Rule                             types.List   `tfsdk:"rule"`
 	SpaceId                          types.String `tfsdk:"space_id"`
 	TenantTags                       types.Set    `tfsdk:"tenant_tags"`
@@ -54,6 +55,22 @@ func (c ChannelSchema) GetResourceSchema() resourceSchema.Schema {
 			"project_id": resourceSchema.StringAttribute{
 				Description: "The project ID associated with this channel.",
 				Required:    true,
+			},
+			"custom_field_definitions": resourceSchema.ListNestedAttribute{
+				Description: "A list of custom field definitions for this channel. Maximum of 10.",
+				Optional:    true,
+				NestedObject: resourceSchema.NestedAttributeObject{
+					Attributes: map[string]resourceSchema.Attribute{
+						"field_name": resourceSchema.StringAttribute{
+							Required:    true,
+							Description: "The name of the custom field.",
+						},
+						"description": resourceSchema.StringAttribute{
+							Required:    true,
+							Description: "The description of the custom field.",
+						},
+					},
+				},
 			},
 			"space_id": GetSpaceIdResourceSchema(ChannelResourceDescription),
 			"tenant_tags": resourceSchema.SetAttribute{


### PR DESCRIPTION
## Pending advice from Modern Deployments. Please hold off on reviewing for now 🛑 

## Background 🌇 

Custom field definitions were added to Channels as part of the Ephemeral Environments project, as a way to require custom fields on a release made into an ephemeral environment channel. The values for the custom fields on a release can then be used to name (or set other values within?) the ephemeral environments created from the release.

## What's this? 🌵 

We want to enable terraform users to set custom field definitions on channels in their terraform configuration. 

What it should be doing so far is:
〰️ adding `CustomFieldDefinitions` to the Channel schema
〰️ adding expander and flattener functions for `CustomFieldDefinitions`
〰️ referencing these inside the Channel expander and flattener functions.

## How to review 🔍 
🚩 Carefully! This is my first time touching terraform or the go client. I've checked the changes carefully but it is very much a claude special. 
🧪 You can test this by creating a channel in terraform and adding, editing and removing custom field definitions.  Example terraform config: 
```tf
resource "octopusdeploy_channel" "example" {
  name       = "Development Channel (OK to Delete)"
  project_id = "Projects-1"

  custom_field_definitions = [
    {
      field_name  = "Ticket Number"
      description = "The issue tracker ticket number associated with this deployment"
    },
    {
      field_name  = "Ticket Number 2"
      description = "Hello"
    }
  ]
}
```

Completes DEVEX-147