### PR TITLE
feat: allow configuring version on package references on a step

### DIFF
--- a/docs/resources/deployment_process.md
+++ b/docs/resources/deployment_process.md
@@ -141,6 +141,7 @@ Optional:
 - `feed_id` (String) The feed ID associated with this package reference.
 - `id` (String) The unique ID for this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--action--primary_package"></a>
@@ -157,6 +158,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -309,6 +311,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--apply_terraform_template_action--primary_package"></a>
@@ -325,6 +328,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--apply_terraform_template_action--template"></a>
@@ -427,6 +431,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -477,6 +482,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--deploy_package_action--action_template"></a>
@@ -530,6 +536,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--deploy_package_action--windows_service"></a>
@@ -611,6 +618,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--deploy_windows_service_action--action_template"></a>
@@ -664,6 +672,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -752,6 +761,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -849,6 +859,7 @@ Optional:
 - `feed_id` (String) The feed ID associated with this package reference.
 - `id` (String) The unique ID for this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--run_kubectl_script_action--primary_package"></a>
@@ -865,6 +876,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -961,6 +973,7 @@ Optional:
 - `feed_id` (String) The feed ID associated with this package reference.
 - `id` (String) The unique ID for this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--run_script_action--primary_package"></a>
@@ -977,3 +990,4 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.

--- a/docs/resources/runbook_process.md
+++ b/docs/resources/runbook_process.md
@@ -143,6 +143,7 @@ Optional:
 - `feed_id` (String) The feed ID associated with this package reference.
 - `id` (String) The unique ID for this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--action--primary_package"></a>
@@ -159,6 +160,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -311,6 +313,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--apply_terraform_template_action--primary_package"></a>
@@ -327,6 +330,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--apply_terraform_template_action--template"></a>
@@ -429,6 +433,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -479,6 +484,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--deploy_package_action--action_template"></a>
@@ -532,6 +538,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--deploy_package_action--windows_service"></a>
@@ -613,6 +620,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--deploy_windows_service_action--action_template"></a>
@@ -666,6 +674,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -754,6 +763,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -851,6 +861,7 @@ Optional:
 - `feed_id` (String) The feed ID associated with this package reference.
 - `id` (String) The unique ID for this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--run_kubectl_script_action--primary_package"></a>
@@ -867,6 +878,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 
@@ -963,6 +975,7 @@ Optional:
 - `feed_id` (String) The feed ID associated with this package reference.
 - `id` (String) The unique ID for this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.
 
 
 <a id="nestedblock--step--run_script_action--primary_package"></a>
@@ -979,3 +992,4 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
+- `version` (String) Package version, or a variable expression. Leave empty to select at release creation time.

--- a/octopusdeploy/schema_package_reference.go
+++ b/octopusdeploy/schema_package_reference.go
@@ -51,6 +51,7 @@ func flattenPackageReference(packageReference *packages.PackageReference) map[st
 		"name":                 packageReference.Name,
 		"package_id":           packageReference.PackageID,
 		"properties":           packageReference.Properties,
+		"version":              packageReference.Version,
 	}
 
 	// primary packages have no name and always extract during deployment; therefore, this
@@ -96,6 +97,12 @@ func getPackageSchema(required bool) *schema.Schema {
 					Optional:    true,
 					Type:        schema.TypeMap,
 				},
+				"version": {
+					Default:     "",
+					Description: "Package version, or a variable expression. Leave empty to select at release creation time.",
+					Optional:    true,
+					Type:        schema.TypeString,
+				},
 			},
 		},
 		Optional: !required,
@@ -111,6 +118,7 @@ func expandPackageReference(tfPkg map[string]interface{}) *packages.PackageRefer
 		Name:                getStringOrEmpty(tfPkg["name"]),
 		PackageID:           tfPkg["package_id"].(string),
 		Properties:          map[string]string{},
+		Version:             getStringOrEmpty(tfPkg["version"]),
 	}
 
 	if id, ok := tfPkg["id"]; ok {


### PR DESCRIPTION
Customer is using the old `octopusdeploy_deployment_process` resource and asked if we could add the `version` property to it. Normally we wouldn't as it has been deprecated, but in this case it was a simple enough change that I updated it.

```terraform
resource "octopusdeploy_deployment_process" "example" {
  project_id  = octopusdeploy_project.example.id

  step {
    name = "Run My Script"
    target_roles = ["role-1", "role-2"]

    run_script_action {
      name = "Run My Script"
      run_on_server = true
      script_source = "Inline"
      script_syntax = "PowerShell"
      script_body = <<-EOT
        Write-Host "Executing step..."
      EOT

      package {
        name = "Additional package"
        package_id = "my.additional.package"
        feed_id = "Feeds-1443"
        version = "1.0.0"
      }
    }
  }
  step {
    name = "Package deployment"
    target_roles = ["role-one"]

    deploy_package_action {
      name = "Package deployment"
      
      primary_package {
        package_id = "my.package"
        feed_id = "Feeds-1443"
        version = "1.0.0"
      }
    }
  }
}
```

Fixes HPY-1340