### PR TITLE
feat: Add custom field definitions to channels

### DIFF
--- a/docs/resources/channel.md
+++ b/docs/resources/channel.md
@@ -29,6 +29,7 @@ resource "octopusdeploy_channel" "example" {
 
 ### Optional
 
+- `custom_field_definitions` (Attributes List) A list of custom field definitions for this channel. Maximum of 10. (see [below for nested schema](#nestedatt--custom_field_definitions))
 - `description` (String) The description of this channel.
 - `ephemeral_environment_name_template` (String) The name template for ephemeral environments created from this channel.
 - `is_default` (Boolean) Indicates whether this is the default channel for the associated project.
@@ -42,6 +43,15 @@ resource "octopusdeploy_channel" "example" {
 ### Read-Only
 
 - `id` (String) The unique ID for this resource.
+
+<a id="nestedatt--custom_field_definitions"></a>
+### Nested Schema for `custom_field_definitions`
+
+Required:
+
+- `description` (String) The description of the custom field.
+- `field_name` (String) The name of the custom field.
+
 
 <a id="nestedblock--rule"></a>
 ### Nested Schema for `rule`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.25.8
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.107.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.109.0
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.107.0 h1:BDxry1Qk599dfNygWRUMLJJoOJKEVi5wTxj3oG3Mwto=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.107.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.109.0 h1:6XouVmWwxeGczIV2OyAdRf/PUGnQbcMRT21/h4WN5pg=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.109.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2 h1:960T/UryMsoc2ZOnoLEg7rM9QpxWIdkdB9sR5gsUFAQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2/go.mod h1:kllISYzQ8N3P6+3rScVhyW/KWnPWQbwzm8pFcMInSRM=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/octopusdeploy_framework/resource_channel.go
+++ b/octopusdeploy_framework/resource_channel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
@@ -97,12 +98,15 @@ func (r *channelResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	channel := expandChannel(ctx, plan)
-	updatedChannel, err := channels.Update(r.Client, channel)
+	updateReq := newclient.NewUpdateRequest(channel)
+	if plan.CustomFieldDefinitions.IsNull() || len(plan.CustomFieldDefinitions.Elements()) == 0 {
+		updateReq.Clear("CustomFieldDefinitions")
+	}
+	updatedChannel, err := channels.UpdateChannel(r.Client, updateReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating channel", err.Error())
 		return
 	}
-
 	state := flattenChannel(ctx, updatedChannel, plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 	return
@@ -139,6 +143,7 @@ func expandChannel(ctx context.Context, model schemas.ChannelModel) *channels.Ch
 	channel.Description = model.Description.ValueString()
 	channel.IsDefault = model.IsDefault.ValueBool()
 	channel.LifecycleID = model.LifecycleId.ValueString()
+	channel.CustomFieldDefinitions = expandChannelCustomFieldDefinitions(model.CustomFieldDefinitions)
 	channel.Rules = expandChannelRules(model.Rule)
 	channel.SpaceID = model.SpaceId.ValueString()
 	channel.TenantTags = util.ExpandStringSet(model.TenantTags)
@@ -252,6 +257,7 @@ func flattenChannel(ctx context.Context, channel *channels.Channel, model schema
 	model.Name = types.StringValue(channel.Name)
 	model.ProjectId = types.StringValue(channel.ProjectID)
 
+	model.CustomFieldDefinitions = flattenChannelCustomFieldDefinitions(channel.CustomFieldDefinitions)
 	model.Rule = flattenChannelRules(channel.Rules, model.Rule)
 
 	if channel.SpaceID == "" && model.SpaceId.IsNull() {
@@ -331,5 +337,49 @@ func getChannelRuleDeploymentActionPackageAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"deployment_action": types.StringType,
 		"package_reference": types.StringType,
+	}
+}
+
+func expandChannelCustomFieldDefinitions(defs types.List) []channels.ChannelCustomFieldDefinition {
+	if defs.IsNull() || defs.IsUnknown() || len(defs.Elements()) == 0 {
+		return []channels.ChannelCustomFieldDefinition{}
+	}
+
+	result := make([]channels.ChannelCustomFieldDefinition, 0, len(defs.Elements()))
+	for _, elem := range defs.Elements() {
+		obj := elem.(types.Object)
+		attrs := obj.Attributes()
+
+		var def channels.ChannelCustomFieldDefinition
+		if v, ok := attrs["field_name"].(types.String); ok && !v.IsNull() {
+			def.FieldName = v.ValueString()
+		}
+		if v, ok := attrs["description"].(types.String); ok && !v.IsNull() {
+			def.Description = v.ValueString()
+		}
+		result = append(result, def)
+	}
+	return result
+}
+
+func flattenChannelCustomFieldDefinitions(defs []channels.ChannelCustomFieldDefinition) types.List {
+	if len(defs) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: getChannelCustomFieldDefinitionAttrTypes()})
+	}
+
+	elems := make([]attr.Value, 0, len(defs))
+	for _, def := range defs {
+		elems = append(elems, types.ObjectValueMust(getChannelCustomFieldDefinitionAttrTypes(), map[string]attr.Value{
+			"field_name":  types.StringValue(def.FieldName),
+			"description": types.StringValue(def.Description),
+		}))
+	}
+	return types.ListValueMust(types.ObjectType{AttrTypes: getChannelCustomFieldDefinitionAttrTypes()}, elems)
+}
+
+func getChannelCustomFieldDefinitionAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"field_name":  types.StringType,
+		"description": types.StringType,
 	}
 }

--- a/octopusdeploy_framework/resource_channel.go
+++ b/octopusdeploy_framework/resource_channel.go
@@ -107,6 +107,7 @@ func (r *channelResource) Update(ctx context.Context, req resource.UpdateRequest
 		resp.Diagnostics.AddError("Error updating channel", err.Error())
 		return
 	}
+
 	state := flattenChannel(ctx, updatedChannel, plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 	return

--- a/octopusdeploy_framework/resource_channel.go
+++ b/octopusdeploy_framework/resource_channel.go
@@ -99,7 +99,8 @@ func (r *channelResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	channel := expandChannel(ctx, plan)
 	updateReq := newclient.NewUpdateRequest(channel)
-	if plan.CustomFieldDefinitions.IsNull() || len(plan.CustomFieldDefinitions.Elements()) == 0 {
+	if !plan.CustomFieldDefinitions.IsUnknown() &&
+		(plan.CustomFieldDefinitions.IsNull() || len(plan.CustomFieldDefinitions.Elements()) == 0) {
 		updateReq.Clear("CustomFieldDefinitions")
 	}
 	updatedChannel, err := channels.UpdateChannel(r.Client, updateReq)

--- a/octopusdeploy_framework/resource_channel_migration_test.go
+++ b/octopusdeploy_framework/resource_channel_migration_test.go
@@ -148,6 +148,12 @@ const updatedChannelConfig = `
 	  lifecycle_id = octopusdeploy_lifecycle.custom_lifecycle.id
 	  is_default   = false
 	  tenant_tags  = [octopusdeploy_tag.test_tag1.canonical_tag_name, octopusdeploy_tag.test_tag3.canonical_tag_name]
+	  custom_field_definitions = [
+	    {
+	      field_name  = "MyField"
+	      description = "A custom field"
+	    }
+	  ]
 	}`
 
 func testChannelUpdated(t *testing.T) resource.TestCheckFunc {
@@ -170,6 +176,10 @@ func testChannelUpdated(t *testing.T) resource.TestCheckFunc {
 
 		expectedTenantTags := []string{"test-tagset/tag1", "test-tagset/tag3"}
 		assert.ElementsMatch(t, expectedTenantTags, channel.TenantTags, "Tenant tags should match expected values")
+
+		assert.Len(t, channel.CustomFieldDefinitions, 1, "Channel should have one custom field definition")
+		assert.Equal(t, "MyField", channel.CustomFieldDefinitions[0].FieldName, "Custom field name did not match expected value")
+		assert.Equal(t, "A custom field", channel.CustomFieldDefinitions[0].Description, "Custom field description did not match expected value")
 
 		return nil
 	}

--- a/octopusdeploy_framework/schemas/channel.go
+++ b/octopusdeploy_framework/schemas/channel.go
@@ -20,6 +20,7 @@ type ChannelModel struct {
 	Name                             types.String `tfsdk:"name"`
 	ParentEnvironmentID              types.String `tfsdk:"parent_environment_id"`
 	ProjectId                        types.String `tfsdk:"project_id"`
+	CustomFieldDefinitions           types.List   `tfsdk:"custom_field_definitions"`
 	Rule                             types.List   `tfsdk:"rule"`
 	SpaceId                          types.String `tfsdk:"space_id"`
 	TenantTags                       types.Set    `tfsdk:"tenant_tags"`
@@ -54,6 +55,22 @@ func (c ChannelSchema) GetResourceSchema() resourceSchema.Schema {
 			"project_id": resourceSchema.StringAttribute{
 				Description: "The project ID associated with this channel.",
 				Required:    true,
+			},
+			"custom_field_definitions": resourceSchema.ListNestedAttribute{
+				Description: "A list of custom field definitions for this channel. Maximum of 10.",
+				Optional:    true,
+				NestedObject: resourceSchema.NestedAttributeObject{
+					Attributes: map[string]resourceSchema.Attribute{
+						"field_name": resourceSchema.StringAttribute{
+							Required:    true,
+							Description: "The name of the custom field.",
+						},
+						"description": resourceSchema.StringAttribute{
+							Required:    true,
+							Description: "The description of the custom field.",
+						},
+					},
+				},
 			},
 			"space_id": GetSpaceIdResourceSchema(ChannelResourceDescription),
 			"tenant_tags": resourceSchema.SetAttribute{

--- a/octopusdeploy_framework/schemas/channel.go
+++ b/octopusdeploy_framework/schemas/channel.go
@@ -2,9 +2,11 @@ package schemas
 
 import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -59,6 +61,9 @@ func (c ChannelSchema) GetResourceSchema() resourceSchema.Schema {
 			"custom_field_definitions": resourceSchema.ListNestedAttribute{
 				Description: "A list of custom field definitions for this channel. Maximum of 10.",
 				Optional:    true,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(10),
+				},
 				NestedObject: resourceSchema.NestedAttributeObject{
 					Attributes: map[string]resourceSchema.Attribute{
 						"field_name": resourceSchema.StringAttribute{


### PR DESCRIPTION
## Background 🌇 

Custom field definitions were added to Channels as part of the Ephemeral Environments project. They can be can be used to configure the name of an ephemeral environment by setting custom values on a release. 

## What's this? 🌵 

We want to enable terraform users to set custom field definitions on channels in their terraform configuration. 

What this changes does:
〰️ Adds `CustomFieldDefinitions` to the Channel schema
〰️ Adds expander and flattener functions for `CustomFieldDefinitions`
〰️ References these inside the Channel expander and flattener functions.

This allows users to add custom field definitions on a channel, and modify, delete (including clear) and import them. 

## 🎈 Go Client update
This PR updates to a new version of the Octopus Go client to make use of [new changes to enable clearing of all types of fields](https://github.com/OctopusDeploy/go-octopusdeploy/pull/413). 

## How to review 🔍 
🚩 Carefully! This is my first time touching Terraform.  
🧪 You can test this by creating a channel in terraform and adding, editing and removing custom field definitions.  Example terraform config: 
```tf
resource "octopusdeploy_channel" "example" {
  name       = "Development Channel"
  project_id = "Projects-1"

  custom_field_definitions = [
    {
      field_name  = "Ticket Number"
      description = "The issue tracker ticket number associated with this deployment"
    },
    {
      field_name  = "Ticket Number 2"
      description = "Hello"
    }
  ]
}
```

Completes DEVEX-147