### PR TITLE
Allow system-level (spaceless) user roles via `octopusdeploy_team` resource

### DIFF
--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -56,7 +56,6 @@ Optional:
 
 Required:
 
-- `space_id` (String)
 - `user_role_id` (String)
 
 Optional:
@@ -64,6 +63,7 @@ Optional:
 - `environment_ids` (Set of String)
 - `project_group_ids` (Set of String)
 - `project_ids` (Set of String)
+- `space_id` (String)
 - `tenant_ids` (Set of String)
 
 Read-Only:

--- a/octopusdeploy_framework/resource_team_mappers.go
+++ b/octopusdeploy_framework/resource_team_mappers.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"context"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/teams"
@@ -172,11 +173,12 @@ func mapUserRoleSetStateToResource(ctx context.Context, team *teams.Team, userRo
 		userRoleSetElementAttributes := userRoleSetElement.(types.Object).Attributes()
 
 		userRoleId := userRoleSetElementAttributes["user_role_id"].(types.String).ValueString()
-		spaceId := userRoleSetElementAttributes["space_id"].(types.String).ValueString()
-
 		scopedUserRole := userroles.NewScopedUserRole(userRoleId)
 		scopedUserRole.TeamID = team.ID
-		scopedUserRole.SpaceID = spaceId
+
+		if spaceId, ok := userRoleSetElementAttributes["space_id"]; ok && !spaceId.IsNull() && !spaceId.IsUnknown() {
+			scopedUserRole.SpaceID = spaceId.(types.String).ValueString()
+		}
 
 		if id, ok := userRoleSetElementAttributes["id"]; ok && !id.IsNull() && !id.IsUnknown() {
 			scopedUserRole.ID = id.(types.String).ValueString()

--- a/octopusdeploy_framework/resource_team_migration_test.go
+++ b/octopusdeploy_framework/resource_team_migration_test.go
@@ -2,14 +2,15 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestTeamResource_UpgradeFromSDK_ToPluginFramework(t *testing.T) {
@@ -84,6 +85,13 @@ func TestTeamResource_UpgradeFromSDK_ToPluginFramework_WithUserRole(t *testing.T
 					testTeamWithUserRole(t, name, description),
 				),
 			},
+			{
+				ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+				Config:                   updateTeamConfigWithSystemLevelUserRole(name, description, userRoleName),
+				Check: resource.ComposeTestCheckFunc(
+					testTeamWithSystemLevelUserRole(t, name, description),
+				),
+			},
 		},
 	})
 }
@@ -133,6 +141,24 @@ func updateTeamConfigWithUserRole(name, description, userRoleName string) string
 
 		user_role {
 			space_id = "Spaces-1"
+			user_role_id = octopusdeploy_user_role.user_role1.id
+		}
+	}`, userRoleName, name, description)
+}
+
+func updateTeamConfigWithSystemLevelUserRole(name, description, userRoleName string) string {
+	return fmt.Sprintf(`
+	resource "octopusdeploy_user_role" "user_role1" {
+		granted_space_permissions = ["AccountCreate"]
+		name = "%s"
+	}
+
+	resource "octopusdeploy_team" "team1" {
+		name = "%s"
+		description = "%s - updated"
+
+		user_role {
+			space_id = null
 			user_role_id = octopusdeploy_user_role.user_role1.id
 		}
 	}`, userRoleName, name, description)
@@ -189,6 +215,31 @@ func testTeamWithUserRole(t *testing.T, name, description string) resource.TestC
 		assert.NotEmpty(t, userRoles.Items, "Team should have user roles")
 		assert.Len(t, userRoles.Items, 1, "Team should have exactly one user role")
 		assert.Equal(t, "Spaces-1", userRoles.Items[0].SpaceID, "User role space ID should match")
+
+		return nil
+	}
+}
+
+func testTeamWithSystemLevelUserRole(t *testing.T, name, description string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		teamId := s.RootModule().Resources["octopusdeploy_team.team1"].Primary.ID
+		team, err := octoClient.Teams.GetByID(teamId)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve team by ID: %s", err)
+		}
+
+		assert.NotEmpty(t, team.ID, "Team ID should not be empty")
+		assert.Equal(t, name, team.Name, "Team name did not match expected value")
+		assert.Equal(t, description+" - updated", team.Description, "Team description did not match expected value")
+
+		userRoles, err := octoClient.Teams.GetScopedUserRoles(*team, core.SkipTakeQuery{})
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve user roles: %s", err)
+		}
+
+		assert.NotEmpty(t, userRoles.Items, "Team should have user roles")
+		assert.Len(t, userRoles.Items, 1, "Team should have exactly one user role")
+		assert.Empty(t, userRoles.Items[0].SpaceID, "User role space ID should be empty")
 
 		return nil
 	}

--- a/octopusdeploy_framework/schemas/team.go
+++ b/octopusdeploy_framework/schemas/team.go
@@ -89,7 +89,8 @@ func GetUserRoleSchema() resourceSchema.NestedBlockObject {
 				ElementType: types.StringType,
 			},
 			"space_id": resourceSchema.StringAttribute{
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 			"team_id": resourceSchema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
Allow system-level (spaceless) user role bindings in `octopusdeploy_team` resource instances.

Currently `space_id` is marked **optional** when using separate `octopusdeploy_scoped_user_role` resources, but **required** when using `octopusdeploy_team` - which makes it impossible to map a team with a role such as `System manager`:

```terraform
resource "octopusdeploy_team" "test" {
  space_id = null

  name = "Test Team"

  user_role {
    space_id     = null
    user_role_id = "userroles-systemmanager"
  }
}
```

```terraform
╷
│ Error: Missing required argument
│ 
│   on main.tf line 25, in resource "octopusdeploy_team" "test":
│   25:   user_role {
│ 
│ The argument "space_id" is required, but no definition was found.
╵
```

Via `octopusdeploy_scoped_user_role` instead:

```terraform
resource "octopusdeploy_team" "test" {
  space_id = null

  name = "Test Team"
}

resource "octopusdeploy_scoped_user_role" "test_team_system_manager" {
  team_id      = octopusdeploy_team.test.id
  space_id     = null
  user_role_id = "userroles-systemmanager"
}
```

```terraform
Terraform will perform the following actions:

  # octopusdeploy_scoped_user_role.test_team_system_manager will be created
  + resource "octopusdeploy_scoped_user_role" "test_team_system_manager" {
      + environment_ids   = (known after apply)
      + id                = (known after apply)
      + project_group_ids = (known after apply)
      + project_ids       = (known after apply)
      + space_id          = (known after apply)
      + team_id           = (known after apply)
      + tenant_ids        = (known after apply)
      + user_role_id      = "userroles-systemmanager"
    }

  # octopusdeploy_team.test will be created
  + resource "octopusdeploy_team" "test" {
      + can_be_deleted     = (known after apply)
      + can_be_renamed     = (known after apply)
      + can_change_members = (known after apply)
      + can_change_roles   = (known after apply)
      + id                 = (known after apply)
      + name               = "Test Team"
      + space_id           = (known after apply)
      + users              = (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

Appears to have regressed in the framework conversion work for this resource (#62), but these changes match the optional `space_id` support in `octopusdeploy_scoped_user_role` (#85).