### PR TITLE
Suppress server-injected OctopusUseBundledTooling in process step

### DIFF
--- a/octopusdeploy_framework/resource_process_step.go
+++ b/octopusdeploy_framework/resource_process_step.go
@@ -642,6 +642,17 @@ func mapActionExecutionPropertiesToState(properties map[string]core.PropertyValu
 			continue
 		}
 
+		// The server automatically injects OctopusUseBundledTooling into a step's
+		// execution properties when the step runs inside a container. If the user
+		// has not explicitly declared this property in their configuration, surfacing
+		// it into state would cause a "Provider produced inconsistent result after
+		// apply" error. Only include it when the user has explicitly set it.
+		if key == schemas.OctopusUseBundledToolingPropertyKey {
+			if _, declared := currentStateValues[key]; !declared {
+				continue
+			}
+		}
+
 		apiValue := value.Value
 		// Preserve the user's original casing for boolean-like strings if they're semantically equivalent
 		if currentValue, exists := currentStateValues[key]; exists {

--- a/octopusdeploy_framework/resource_process_step_test.go
+++ b/octopusdeploy_framework/resource_process_step_test.go
@@ -92,11 +92,10 @@ func TestAccOctopusDeployProcessStepContainerBundledTooling(t *testing.T) {
 func testAccProcessStepContainerConfiguration(dependencies string, process string, step string, scriptBody string, extraProperties string) string {
 	return fmt.Sprintf(`
 		%s
-		data "octopusdeploy_feeds" "docker" {
-		  feed_type    = "Docker"
-		  partial_name = "Docker"
-		  skip         = 0
-		  take         = 1
+		resource "octopusdeploy_docker_container_registry" "docker" {
+		  name        = "Docker Hub %s"
+		  feed_uri    = "https://index.docker.io"
+		  api_version = "v2"
 		}
 
 		resource "octopusdeploy_process_step" "%s" {
@@ -105,7 +104,7 @@ func testAccProcessStepContainerConfiguration(dependencies string, process strin
 		  type           = "Octopus.Script"
 		  worker_pool_id = data.octopusdeploy_worker_pools.default.worker_pools[0].id
 		  container = {
-			feed_id = data.octopusdeploy_feeds.docker.feeds[0].id
+			feed_id = octopusdeploy_docker_container_registry.docker.id
 			image   = "octopusdeploy/worker-tools:latest"
 		  }
 		  execution_properties = {
@@ -118,6 +117,7 @@ func testAccProcessStepContainerConfiguration(dependencies string, process strin
 		}
 		`,
 		dependencies,
+		step,
 		step,
 		process,
 		step,

--- a/octopusdeploy_framework/resource_process_step_test.go
+++ b/octopusdeploy_framework/resource_process_step_test.go
@@ -39,6 +39,93 @@ func TestAccOctopusDeployProcessStepRunScript(t *testing.T) {
 	})
 }
 
+// TestAccOctopusDeployProcessStepContainerBundledTooling reproduces the issue where
+// a step configured with a container causes the server to inject the
+// OctopusUseBundledTooling execution property. When the user has not explicitly set
+// that property, the provider would previously surface the server-injected value into
+// state, producing a "Provider produced inconsistent result after apply" error.
+// The acceptance test framework asserts a non-empty plan after apply fails the test,
+// so this passing confirms the fix.
+func TestAccOctopusDeployProcessStepContainerBundledTooling(t *testing.T) {
+	scenario := newProcessStepTestDependenciesConfiguration("container")
+	step := fmt.Sprintf("container_%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	createScript := fmt.Sprintf(`Write-Host 'create: %s'`, acctest.RandStringFromCharSet(20, acctest.CharSetAlpha))
+	qualifiedName := fmt.Sprintf("octopusdeploy_process_step.%s", step)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccProjectCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Step 1: container set, user does NOT declare OctopusUseBundledTooling.
+			// Server injects it; provider must suppress it from state so apply succeeds.
+			{
+				Config: testAccProcessStepContainerConfiguration(scenario.config, scenario.process, step, createScript, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckResourceProcessStepExists(),
+					resource.TestCheckResourceAttrSet(qualifiedName, "id"),
+					resource.TestCheckResourceAttr(qualifiedName, "container.image", "octopusdeploy/worker-tools:latest"),
+					// Server-injected OctopusUseBundledTooling must NOT appear in state
+					// because the user did not declare it.
+					resource.TestCheckNoResourceAttr(qualifiedName, "execution_properties.OctopusUseBundledTooling"),
+				),
+			},
+			// Step 2: re-apply identical config. Confirms no perpetual diff is produced
+			// by the suppression (the framework fails the test on a non-empty plan).
+			{
+				Config:   testAccProcessStepContainerConfiguration(scenario.config, scenario.process, step, createScript, ""),
+				PlanOnly: true,
+			},
+			// Step 3: user explicitly declares OctopusUseBundledTooling (the documented
+			// workaround). It must be preserved in state, unchanged from prior behaviour.
+			{
+				Config: testAccProcessStepContainerConfiguration(scenario.config, scenario.process, step, createScript, `"OctopusUseBundledTooling" = "False"`),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckResourceProcessStepExists(),
+					resource.TestCheckResourceAttr(qualifiedName, "execution_properties.OctopusUseBundledTooling", "False"),
+				),
+			},
+		},
+	})
+}
+
+func testAccProcessStepContainerConfiguration(dependencies string, process string, step string, scriptBody string, extraProperties string) string {
+	return fmt.Sprintf(`
+		%s
+		data "octopusdeploy_feeds" "docker" {
+		  feed_type    = "Docker"
+		  partial_name = "Docker"
+		  skip         = 0
+		  take         = 1
+		}
+
+		resource "octopusdeploy_process_step" "%s" {
+		  process_id     = octopusdeploy_process.%s.id
+		  name           = "%s"
+		  type           = "Octopus.Script"
+		  worker_pool_id = data.octopusdeploy_worker_pools.default.worker_pools[0].id
+		  container = {
+			feed_id = data.octopusdeploy_feeds.docker.feeds[0].id
+			image   = "octopusdeploy/worker-tools:latest"
+		  }
+		  execution_properties = {
+			"Octopus.Action.RunOnServer"         = "True"
+			"Octopus.Action.Script.ScriptSource" = "Inline"
+			"Octopus.Action.Script.Syntax"       = "PowerShell"
+			"Octopus.Action.Script.ScriptBody"   = "%s"
+			%s
+		  }
+		}
+		`,
+		dependencies,
+		step,
+		process,
+		step,
+		scriptBody,
+		extraProperties,
+	)
+}
+
 func testAccProcessStepRunScriptConfiguration(dependencies string, process string, step string, scriptBody string) string {
 	return fmt.Sprintf(`
 		%s

--- a/octopusdeploy_framework/resource_process_templated_step.go
+++ b/octopusdeploy_framework/resource_process_templated_step.go
@@ -677,6 +677,17 @@ func mapTemplatedActionPropertiesToState(ctx context.Context, template *actionte
 			continue
 		}
 
+		// The server automatically injects OctopusUseBundledTooling into a step's
+		// execution properties when the step runs inside a container. If the user has
+		// not explicitly declared this property, surfacing it into state causes a
+		// "Provider produced inconsistent result after apply" error. Only include it
+		// when the user has explicitly set it.
+		if key == schemas.OctopusUseBundledToolingPropertyKey {
+			if _, declared := stateExecutionProperties[key]; !declared {
+				continue
+			}
+		}
+
 		executionPropertyValues[key] = value
 	}
 

--- a/octopusdeploy_framework/schemas/process_step_reserved_execution_properties_validator.go
+++ b/octopusdeploy_framework/schemas/process_step_reserved_execution_properties_validator.go
@@ -7,6 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// OctopusUseBundledToolingPropertyKey is an execution property that the server
+// automatically injects when a step is configured to run inside a container.
+const OctopusUseBundledToolingPropertyKey = "OctopusUseBundledTooling"
+
 type reservedExecutionPropertiesValidator struct{}
 
 func warnAboutReservedExecutionProperties() validator.Map {


### PR DESCRIPTION
When a process step runs inside a container, the server injects the OctopusUseBundledTooling execution property. The provider surfaced it into state even when the user had not declared it, causing "Provider produced inconsistent result after apply". Now suppress it unless the user explicitly sets it. Applies to process_step, process_child_step, process_templated_step and process_templated_child_step.

Fixes #184 
Resolves MAS-2479