### PR TITLE
chore: Update primary package documentation

### DIFF
--- a/docs/guides/migration-guide-v1.0.0.md
+++ b/docs/guides/migration-guide-v1.0.0.md
@@ -44,7 +44,8 @@ Please ensure you are working from a clean slate and have no pending changes to 
 1. Transpose `run_on_server` to the `execution_properties` using the key `Octopus.Action.RunOnServer`
 1. Transpose `window_size` to the `execution_properties` using the key `Octopus.Action.TargetRoles`
 1. Transpose `target_roles` to the `properties` using the key `Octopus.Action.TargetRoles`
-1. Transpose `primary_package` to the `packages` attribute with the key being an empty string `""`
+1. Transpose the `primary_package` block to the new resource's `primary_package` attribute
+1. Transpose any additional `package` blocks to the `packages` attribute, with the key being the name of each package reference
 1. Repeat until all parent `steps` have been transposed
 1. For child steps create a new resource of type `octopusdeploy_process_child_step` (nested actions) for regular child steps or `octopusdeploy_process_templated_child_step` for templated child steps
 1. Set the `process_id` to the `id` of the new process resource

--- a/docs/resources/process.md
+++ b/docs/resources/process.md
@@ -81,8 +81,8 @@ resource "octopusdeploy_process_step" "deploy_package" {
   }
   type = "Octopus.TentaclePackage"
   primary_package = {
-      package_id: "my.package"
-      feed_id: "Feeds-1"
+    package_id = "my.package"
+    feed_id = "Feeds-1"
   }
 
   execution_properties = {
@@ -142,8 +142,8 @@ resource "octopusdeploy_process_step" "deploy_package" {
   }
   type = "Octopus.TentaclePackage"
   primary_package = {
-      package_id: "my.package"
-      feed_id: "Feeds-1"
+    package_id = "my.package"
+    feed_id = "Feeds-1"
   }
   execution_properties = {
     "Octopus.Action.RunOnServer" = "True"

--- a/docs/resources/process.md
+++ b/docs/resources/process.md
@@ -80,18 +80,13 @@ resource "octopusdeploy_process_step" "deploy_package" {
     "Octopus.Action.TargetRoles" = "role-one"
   }
   type = "Octopus.TentaclePackage"
-  packages = {
-    "": {
+  primary_package = {
       package_id: "my.package"
       feed_id: "Feeds-1"
-    }
   }
+
   execution_properties = {
-    "Octopus.Action.RunOnServer" = "True"    
-    # Reference primary package in execution properties for legacy purposes
-    "Octopus.Action.Package.DownloadOnTentacle" = "False"
-    "Octopus.Action.Package.FeedId" = "Feeds-1"
-    "Octopus.Action.Package.PackageId" = "my.package"
+    "Octopus.Action.RunOnServer" = "True"
   }
 }
 
@@ -146,18 +141,12 @@ resource "octopusdeploy_process_step" "deploy_package" {
     "Octopus.Action.TargetRoles" = "role-one"
   }
   type = "Octopus.TentaclePackage"
-  packages = {
-    "": {
+  primary_package = {
       package_id: "my.package"
       feed_id: "Feeds-1"
-    }
   }
   execution_properties = {
-    "Octopus.Action.RunOnServer" = "True"    
-    # Reference primary package in execution properties for legacy purposes
-    "Octopus.Action.Package.DownloadOnTentacle" = "False"
-    "Octopus.Action.Package.FeedId" = "Feeds-1"
-    "Octopus.Action.Package.PackageId" = "my.package"
+    "Octopus.Action.RunOnServer" = "True"
   }
 }
 

--- a/docs/resources/process_child_step.md
+++ b/docs/resources/process_child_step.md
@@ -99,7 +99,7 @@ resource "octopusdeploy_process_child_step" "run_script" {
 - `is_disabled` (Boolean) Indicates the disabled status of this step.
 - `is_required` (Boolean) Indicates the required status of this step.
 - `notes` (String) The notes associated with this step.
-- `packages` (Attributes Map) Package references associated with this step where key is a name of the package reference (use empty name for primary package) (see [below for nested schema](#nestedatt--packages))
+- `packages` (Attributes Map) Package references associated with this step where key is a name of the package reference (see [below for nested schema](#nestedatt--packages))
 - `primary_package` (Attributes) Primary package of the step (see [below for nested schema](#nestedatt--primary_package))
 - `slug` (String) The human-readable unique identifier for the step.
 - `space_id` (String) The space ID associated with this process_child_step.

--- a/docs/resources/process_step.md
+++ b/docs/resources/process_step.md
@@ -127,7 +127,7 @@ resource "octopusdeploy_process_step" "deploy_package" {
 - `is_required` (Boolean) Indicates the required status of this step.
 - `notes` (String) The notes associated with this step.
 - `package_requirement` (String) Whether to run this step before or after package acquisition (if possible).
-- `packages` (Attributes Map) Package references associated with this step where key is a name of the package reference (use empty name for primary package) (see [below for nested schema](#nestedatt--packages))
+- `packages` (Attributes Map) Package references associated with this step where key is a name of the package reference (see [below for nested schema](#nestedatt--packages))
 - `primary_package` (Attributes) Primary package of the step (see [below for nested schema](#nestedatt--primary_package))
 - `properties` (Map of String) A collection of process step properties where the key is the property name and the value is its value.
 - `slug` (String) The human-readable unique identifier for the step.

--- a/examples/resources/octopusdeploy_process/resource-runbook.tf
+++ b/examples/resources/octopusdeploy_process/resource-runbook.tf
@@ -37,18 +37,12 @@ resource "octopusdeploy_process_step" "deploy_package" {
     "Octopus.Action.TargetRoles" = "role-one"
   }
   type = "Octopus.TentaclePackage"
-  packages = {
-    "": {
+  primary_package = {
       package_id: "my.package"
       feed_id: "Feeds-1"
-    }
   }
   execution_properties = {
-    "Octopus.Action.RunOnServer" = "True"    
-    # Reference primary package in execution properties for legacy purposes
-    "Octopus.Action.Package.DownloadOnTentacle" = "False"
-    "Octopus.Action.Package.FeedId" = "Feeds-1"
-    "Octopus.Action.Package.PackageId" = "my.package"
+    "Octopus.Action.RunOnServer" = "True"
   }
 }
 

--- a/examples/resources/octopusdeploy_process/resource-runbook.tf
+++ b/examples/resources/octopusdeploy_process/resource-runbook.tf
@@ -38,8 +38,8 @@ resource "octopusdeploy_process_step" "deploy_package" {
   }
   type = "Octopus.TentaclePackage"
   primary_package = {
-      package_id: "my.package"
-      feed_id: "Feeds-1"
+    package_id = "my.package"
+    feed_id = "Feeds-1"
   }
   execution_properties = {
     "Octopus.Action.RunOnServer" = "True"

--- a/examples/resources/octopusdeploy_process/resource.tf
+++ b/examples/resources/octopusdeploy_process/resource.tf
@@ -48,18 +48,13 @@ resource "octopusdeploy_process_step" "deploy_package" {
     "Octopus.Action.TargetRoles" = "role-one"
   }
   type = "Octopus.TentaclePackage"
-  packages = {
-    "": {
+  primary_package = {
       package_id: "my.package"
       feed_id: "Feeds-1"
-    }
   }
+
   execution_properties = {
-    "Octopus.Action.RunOnServer" = "True"    
-    # Reference primary package in execution properties for legacy purposes
-    "Octopus.Action.Package.DownloadOnTentacle" = "False"
-    "Octopus.Action.Package.FeedId" = "Feeds-1"
-    "Octopus.Action.Package.PackageId" = "my.package"
+    "Octopus.Action.RunOnServer" = "True"
   }
 }
 

--- a/examples/resources/octopusdeploy_process/resource.tf
+++ b/examples/resources/octopusdeploy_process/resource.tf
@@ -49,8 +49,8 @@ resource "octopusdeploy_process_step" "deploy_package" {
   }
   type = "Octopus.TentaclePackage"
   primary_package = {
-      package_id: "my.package"
-      feed_id: "Feeds-1"
+    package_id = "my.package"
+    feed_id = "Feeds-1"
   }
 
   execution_properties = {

--- a/octopusdeploy_framework/schemas/process_step.go
+++ b/octopusdeploy_framework/schemas/process_step.go
@@ -248,7 +248,7 @@ func ProcessStepPackageReferenceAttributeTypes() map[string]attr.Type {
 
 func resourceActionPackageReferencesAttribute() resourceSchema.MapNestedAttribute {
 	return resourceSchema.MapNestedAttribute{
-		Description:  "Package references associated with this step where key is a name of the package reference (use empty name for primary package)",
+		Description:  "Package references associated with this step where key is a name of the package reference",
 		Optional:     true,
 		Computed:     true,
 		Default:      mapdefault.StaticValue(types.MapValueMust(ProcessStepPackageReferenceObjectType(), map[string]attr.Value{})),

--- a/templates/guides/migration-guide-v1.0.0.md.tmpl
+++ b/templates/guides/migration-guide-v1.0.0.md.tmpl
@@ -44,7 +44,8 @@ Please ensure you are working from a clean slate and have no pending changes to 
 1. Transpose `run_on_server` to the `execution_properties` using the key `Octopus.Action.RunOnServer`
 1. Transpose `window_size` to the `execution_properties` using the key `Octopus.Action.TargetRoles`
 1. Transpose `target_roles` to the `properties` using the key `Octopus.Action.TargetRoles`
-1. Transpose `primary_package` to the `packages` attribute with the key being an empty string `""`
+1. Transpose the `primary_package` block to the new resource's `primary_package` attribute
+1. Transpose any additional `package` blocks to the `packages` attribute, with the key being the name of each package reference
 1. Repeat until all parent `steps` have been transposed
 1. For child steps create a new resource of type `octopusdeploy_process_child_step` (nested actions) for regular child steps or `octopusdeploy_process_templated_child_step` for templated child steps
 1. Set the `process_id` to the `id` of the new process resource


### PR DESCRIPTION
The docs around primary package usage in `octopusdeploy_process_step` resource is inconsistent. Some places mention to use the `primary_package` attribute and others mention to use the `packages` attribute with an empty string as the key. 

This inconsistency lead to user [confusion](https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/182) and provider errors. 

This Pr changes all examples of primary packages to use the `primary_package` attribute. 
It also removes the following legacy package properties from `execution_properties`:

```
    "Octopus.Action.Package.DownloadOnTentacle" = "False"
    "Octopus.Action.Package.FeedId"             = "feeds-id"
    "Octopus.Action.Package.PackageId"          = "my-package.id"
```

As specifying these causes the following errors:

```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to octopusdeploy_process_step.deploy_package, provider "provider[\"octopus.com/com/octopusdeploy\"]" produced an unexpected new value: .execution_properties: element
│ "Octopus.Action.Package.DownloadOnTentacle" has vanished.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to octopusdeploy_process_step.deploy_package, provider "provider[\"octopus.com/com/octopusdeploy\"]" produced an unexpected new value: .execution_properties: element "Octopus.Action.Package.FeedId" has
│ vanished.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to octopusdeploy_process_step.deploy_package, provider "provider[\"octopus.com/com/octopusdeploy\"]" produced an unexpected new value: .execution_properties: element "Octopus.Action.Package.PackageId" has
│ vanished.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

I have tested manually without providing these properties and steps run correctly. 

closes https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/182
fixes https://linear.app/octopus/issue/MAS-2441/octopusdeploy-process-step-empty-key-packages-migration-fails-with