### PR TITLE
fix: prompt block errors on octopusdeploy_variable

### DIFF
--- a/octopusdeploy_framework/datasource_variables.go
+++ b/octopusdeploy_framework/datasource_variables.go
@@ -72,7 +72,7 @@ func (v *variablesDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if variable.Prompt != nil {
 		data.Prompt = types.ListValueMust(
 			types.ObjectType{AttrTypes: schemas.VariablePromptOptionsObjectType()},
-			[]attr.Value{schemas.MapFromVariablePromptOptions(variable.Prompt)},
+			[]attr.Value{schemas.MapFromVariablePromptOptions(variable.Prompt, data.Prompt)},
 		)
 	}
 	if !variable.Scope.IsEmpty() {

--- a/octopusdeploy_framework/datasource_variables.go
+++ b/octopusdeploy_framework/datasource_variables.go
@@ -72,7 +72,10 @@ func (v *variablesDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if variable.Prompt != nil {
 		data.Prompt = types.ListValueMust(
 			types.ObjectType{AttrTypes: schemas.VariablePromptOptionsObjectType()},
-			[]attr.Value{schemas.MapFromVariablePromptOptions(variable.Prompt, data.Prompt)},
+			[]attr.Value{schemas.MapFromVariablePromptOptions(
+				variable.Prompt,
+				types.ListNull(types.ObjectType{AttrTypes: schemas.VariablePromptOptionsObjectType()}),
+			)},
 		)
 	}
 	if !variable.Scope.IsEmpty() {

--- a/octopusdeploy_framework/resource_variable.go
+++ b/octopusdeploy_framework/resource_variable.go
@@ -304,7 +304,7 @@ func mapVariableToState(data *schemas.VariableTypeResourceModel, variable *varia
 	if !data.Prompt.IsNull() {
 		data.Prompt = types.ListValueMust(
 			types.ObjectType{AttrTypes: schemas.VariablePromptOptionsObjectType()},
-			[]attr.Value{schemas.MapFromVariablePromptOptions(variable.Prompt)},
+			[]attr.Value{schemas.MapFromVariablePromptOptions(variable.Prompt, data.Prompt)},
 		)
 	}
 

--- a/octopusdeploy_framework/schemas/variable_prompt_options.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options.go
@@ -66,9 +66,20 @@ func VariableSelectOptionsObjectType() map[string]attr.Type {
 	}
 }
 
-func MapFromVariablePromptOptions(variablePromptOptions *variables.VariablePromptOptions) attr.Value {
+func MapFromVariablePromptOptions(variablePromptOptions *variables.VariablePromptOptions, currentState types.List) attr.Value {
 	if variablePromptOptions == nil {
 		return nil
+	}
+
+	// The Octopus server injects a default display_settings onto every prompted
+	// variable. Only surface it when the prior state already declared display_settings.
+	displaySettingsDeclared := false
+	if !currentState.IsNull() && len(currentState.Elements()) > 0 {
+		if obj, ok := currentState.Elements()[0].(types.Object); ok {
+			if displaySettings, ok := obj.Attributes()[VariableSchemaAttributeNames.DisplaySettings].(types.List); ok {
+				displaySettingsDeclared = !displaySettings.IsNull() && len(displaySettings.Elements()) > 0
+			}
+		}
 	}
 
 	attrs := map[string]attr.Value{
@@ -77,7 +88,7 @@ func MapFromVariablePromptOptions(variablePromptOptions *variables.VariablePromp
 		VariableSchemaAttributeNames.Label:           types.StringValue(variablePromptOptions.Label),
 		VariableSchemaAttributeNames.DisplaySettings: types.ListNull(types.ObjectType{AttrTypes: VariableDisplaySettingsObjectType()}),
 	}
-	if variablePromptOptions.DisplaySettings != nil {
+	if variablePromptOptions.DisplaySettings != nil && displaySettingsDeclared {
 		attrs[VariableSchemaAttributeNames.DisplaySettings] = types.ListValueMust(
 			types.ObjectType{
 				AttrTypes: VariableDisplaySettingsObjectType(),

--- a/octopusdeploy_framework/schemas/variable_prompt_options.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options.go
@@ -73,7 +73,7 @@ func MapFromVariablePromptOptions(variablePromptOptions *variables.VariablePromp
 
 	// The Octopus server injects a default display_settings onto every prompted
 	// variable. Only surface it when the prior state already declared display_settings.
-	displaySettingsDeclared := false
+	displaySettingsDeclared := true
 	if !currentState.IsNull() && len(currentState.Elements()) > 0 {
 		if obj, ok := currentState.Elements()[0].(types.Object); ok {
 			if displaySettings, ok := obj.Attributes()[VariableSchemaAttributeNames.DisplaySettings].(types.List); ok {

--- a/octopusdeploy_framework/schemas/variable_prompt_options.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -258,9 +260,13 @@ func getVariablePromptResourceSchema() resourceSchema.ListNestedBlock {
 				SchemaAttributeNames.Description: GetDescriptionResourceSchema("variable prompt option"),
 				VariableSchemaAttributeNames.IsRequired: resourceSchema.BoolAttribute{
 					Optional: true,
+					Computed: true,
+					Default:  booldefault.StaticBool(false),
 				},
 				VariableSchemaAttributeNames.Label: resourceSchema.StringAttribute{
 					Optional: true,
+					Computed: true,
+					Default:  stringdefault.StaticString(""),
 				},
 			},
 			Blocks: map[string]resourceSchema.Block{

--- a/octopusdeploy_framework/schemas/variable_prompt_options_test.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options_test.go
@@ -131,7 +131,7 @@ func TestFlattenPromptedVariableDisplaySettingsWithNilInput(t *testing.T) {
 }
 
 func TestFlattenPromptedVariableSettingsWithNilInput(t *testing.T) {
-	result := MapFromVariablePromptOptions(nil)
+	result := MapFromVariablePromptOptions(nil, types.ListNull(types.ObjectType{AttrTypes: VariablePromptOptionsObjectType()}))
 	require.Empty(t, result)
 }
 


### PR DESCRIPTION
When specifying prompt on `octopusdeploy_variable` all attributes are optional however not specifying them causes ` inconsistent result after apply` error. 

This pr makes `is_required` and `label` computed with their defaults, Similar to how description is already declared. 
Similarly, server always returns a value for `display_settings` so logic has been added to check if it was declared before mapping the value to state. This solution follows existing patterns e.g. `resource_process_step`

fixes https://linear.app/octopus/issue/MAS-2440/octopusdeploy-variable-with-is-required-true-and-no-label-causes
fixes https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/181