### PR TITLE
chore: update contributing guide with details for managing external contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Once your pull request is merged, our build and test workflow will execute once 
 
 ## Merging Pull Requests from External Contributors
 
-Our PR checks don't run automatically on pull requests from forks. You can approve the run from the PR, but it won't help: the checks require access to secrets that GitHub Actions won't expose to a workflow running in the contributor's profile rather than the Octopus organization, so they will always fail and the change can't be validated where it is. To work around this, redirect the change through a branch in this repository so the checks can run before it reaches `main`.
+Our PR checks don't run automatically on pull requests from forks. You can approve the run from the PR, but it won't help: the checks require access to values that GitHub Actions won't expose to a workflow running in the contributor's profile rather than the Octopus organization, so they will always fail and the change can't be validated where it is. To work around this, redirect the change through a branch in this repository so the checks can run before it reaches `main`.
 
 > [!IMPORTANT]
 > Don't merge a fork PR directly into `main`. Follow the steps below to redirect it through a branch in this repository first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,10 @@ Once your pull request is merged, our build and test workflow will execute once 
 
 ## Merging Pull Requests from External Contributors
 
+Our PR checks don't run automatically on pull requests from forks. You can approve the run from the PR, but it won't help: the checks require access to secrets that GitHub Actions won't expose to a workflow running in the contributor's profile rather than the Octopus organization, so they will always fail and the change can't be validated where it is. To work around this, redirect the change through a branch in this repository so the checks can run before it reaches `main`.
+
 > [!IMPORTANT]
-> Pull requests from forks can't be merged directly into `main` because our PR checks don't run on fork PRs. Redirect them through a branch in this repository so the checks can run first.
+> Don't merge a fork PR directly into `main`. Follow the steps below to redirect it through a branch in this repository first.
 
 1. Create a new branch in this repository with a name similar to the contributor's branch (for example, if their branch is `fix-typo-in-docs`, create `fix-typo-in-docs`).
 2. Edit the contributor's PR and change its base branch from `main` to the new branch you just created.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,13 @@ This project employs [branch protection](https://docs.github.com/en/repositories
 Congratulations! :tada: And thank you very much for your contribution to this project!
 
 Once your pull request is merged, our build and test workflow will execute once again to validate changes. Afterward, your changes will be committed to the `main` branch.
+
+## Merging Pull Requests from External Contributors
+
+> [!IMPORTANT]
+> Pull requests from forks can't be merged directly into `main` because our PR checks don't run on fork PRs. Redirect them through a branch in this repository so the checks can run first.
+
+1. Create a new branch in this repository with a name similar to the contributor's branch (for example, if their branch is `fix-typo-in-docs`, create `fix-typo-in-docs`).
+2. Edit the contributor's PR and change its base branch from `main` to the new branch you just created.
+3. Squash and merge the PR into the new branch.
+4. Continue as you would for any other change: open a PR from the intermediate branch to `main` and merge it.

--- a/README.md
+++ b/README.md
@@ -185,3 +185,6 @@ The repository uses [conventional commits](https://www.conventionalcommits.org/)
 ## 🤝 Contributions
 
 Contributions are welcome! :heart: Please read our [Contributing Guide](CONTRIBUTING.md) for information about how to get involved in this project.
+
+> [!IMPORTANT]
+> Pull requests from forks need an extra step before merging so our PR checks can run — see [Merging Pull Requests from External Contributors](CONTRIBUTING.md#merging-pull-requests-from-external-contributors).


### PR DESCRIPTION
This PR is adding the high-level process for merging PRs from external contributors