### PR TITLE
feat: Support slack subscriptions

### DIFF
--- a/docs/resources/subscription.md
+++ b/docs/resources/subscription.md
@@ -39,6 +39,10 @@ Optional:
 - `email_show_dates_in_timezone_id` (String) Timezone ID for dates shown in emails (e.g. 'UTC').
 - `email_teams` (Set of String) Team IDs to notify via email.
 - `filter` (Attributes) Filter criteria to limit which events trigger this subscription. When omitted, all events trigger the subscription. (see [below for nested schema](#nestedatt--event_notification_subscription--filter))
+- `slack_channel_ids` (List of String) Slack channel IDs to post to.
+- `slack_channel_names` (List of String) Display names for the channels in slack_channel_ids, in the same order. If a name is omitted, the channel ID is shown instead.
+- `slack_digest_format` (String) Format of Slack digest messages. Valid values: Summary, Detailed.
+- `slack_frequency_period` (String) How often to send Slack digests (e.g. '01:00:00' for hourly).
 - `webhook_header_key` (String) Custom header key to include in webhook requests.
 - `webhook_header_value` (String, Sensitive) Custom header value to include in webhook requests.
 - `webhook_teams` (Set of String) Team IDs to notify via webhook.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.25.8
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.111.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.0
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.111.0 h1:0r7rKTTxm9XnATlzOVuXoxuLYGMWUCYwKcQsUWkp1Yk=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.111.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.0 h1:2BSFwHg6f/02dbS2F5YyeNDPXOdIHXOAGDM3oumweao=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2 h1:960T/UryMsoc2ZOnoLEg7rM9QpxWIdkdB9sR5gsUFAQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2/go.mod h1:kllISYzQ8N3P6+3rScVhyW/KWnPWQbwzm8pFcMInSRM=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/octopusdeploy_framework/resource_subscription.go
+++ b/octopusdeploy_framework/resource_subscription.go
@@ -32,6 +32,10 @@ type eventNotificationSubscriptionModel struct {
 	WebhookTimeout             types.String             `tfsdk:"webhook_timeout"`
 	WebhookHeaderKey           types.String             `tfsdk:"webhook_header_key"`
 	WebhookHeaderValue         types.String             `tfsdk:"webhook_header_value"`
+	SlackChannelIds            types.List               `tfsdk:"slack_channel_ids"`
+	SlackChannelNames          types.List               `tfsdk:"slack_channel_names"`
+	SlackFrequencyPeriod       types.String             `tfsdk:"slack_frequency_period"`
+	SlackDigestFormat          types.String             `tfsdk:"slack_digest_format"`
 }
 
 type subscriptionFilterModel struct {
@@ -170,6 +174,10 @@ func expandSubscription(model *subscriptionModel) *subscriptions.Subscription {
 	s.EventNotificationSubscription.WebhookTimeout = n.WebhookTimeout.ValueString()
 	s.EventNotificationSubscription.WebhookHeaderKey = n.WebhookHeaderKey.ValueString()
 	s.EventNotificationSubscription.WebhookHeaderValue = n.WebhookHeaderValue.ValueString()
+	s.EventNotificationSubscription.SlackChannelIds = util.ExpandStringList(n.SlackChannelIds)
+	s.EventNotificationSubscription.SlackChannelNames = util.ExpandStringList(n.SlackChannelNames)
+	s.EventNotificationSubscription.SlackFrequencyPeriod = n.SlackFrequencyPeriod.ValueString()
+	s.EventNotificationSubscription.SlackDigestFormat = n.SlackDigestFormat.ValueString()
 	s.EventNotificationSubscription.EmailTeams = util.ExpandStringSet(n.EmailTeams)
 	s.EventNotificationSubscription.WebhookTeams = util.ExpandStringSet(n.WebhookTeams)
 	s.EventNotificationSubscription.Filter = expandSubscriptionFilter(n.Filter)
@@ -214,6 +222,10 @@ func flattenSubscription(api *subscriptions.Subscription, model *subscriptionMod
 	n.EmailPriority = types.StringValue(apiN.EmailPriority)
 	n.EmailShowDatesInTimeZoneId = types.StringValue(apiN.EmailShowDatesInTimeZoneId)
 	n.WebhookTimeout = types.StringValue(apiN.WebhookTimeout)
+	n.SlackFrequencyPeriod = types.StringValue(apiN.SlackFrequencyPeriod)
+	n.SlackDigestFormat = types.StringValue(apiN.SlackDigestFormat)
+	n.SlackChannelIds = util.FlattenStringList(apiN.SlackChannelIds)
+	n.SlackChannelNames = util.FlattenStringList(apiN.SlackChannelNames)
 
 	// Optional-only fields: the API returns "" when unset. Preserve null in state so the
 	// plan value (null) stays consistent; only store a value when the API returned one.

--- a/octopusdeploy_framework/resource_subscription_test.go
+++ b/octopusdeploy_framework/resource_subscription_test.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/subscriptions"
@@ -82,6 +83,72 @@ func TestAccSubscriptionEmailAndWebhook(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccSubscriptionSlack(t *testing.T) {
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	resourceName := "octopusdeploy_subscription." + name
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		CheckDestroy:             testAccSubscriptionCheckDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubscriptionSlackConfig(name, []string{"C0123"}, []string{"general"}, "Summary"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_ids.0", "C0123"),
+					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_names.0", "general"),
+					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_digest_format", "Summary"),
+					resource.TestCheckResourceAttrSet(resourceName, "event_notification_subscription.slack_frequency_period"),
+				),
+			},
+			{
+				Config: testAccSubscriptionSlackConfig(name, []string{"C0123", "C0456"}, []string{"general", "releases"}, "Detailed"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_ids.1", "C0456"),
+					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_digest_format", "Detailed"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSubscriptionSlackConfig(resourceID string, channelIDs, channelNames []string, digestFormat string) string {
+	channelIDsList := "[]"
+	if len(channelIDs) > 0 {
+		channelIDsList = fmt.Sprintf(`["%s"]`, strings.Join(channelIDs, `", "`))
+	}
+	channelNamesList := "[]"
+	if len(channelNames) > 0 {
+		channelNamesList = fmt.Sprintf(`["%s"]`, strings.Join(channelNames, `", "`))
+	}
+
+	return fmt.Sprintf(`
+resource "octopusdeploy_subscription" "%s" {
+  name = "%s"
+
+  event_notification_subscription = {
+    slack_channel_ids   = %s
+    slack_channel_names = %s
+    slack_digest_format = "%s"
+
+    filter = {
+      event_categories = ["Modified"]
+    }
+  }
+}`, resourceID, resourceID, channelIDsList, channelNamesList, digestFormat)
 }
 
 func testAccSubscriptionExists(n string) resource.TestCheckFunc {

--- a/octopusdeploy_framework/schemas/subscription.go
+++ b/octopusdeploy_framework/schemas/subscription.go
@@ -90,6 +90,31 @@ func (s SubscriptionSchema) GetResourceSchema() resourceSchema.Schema {
 						Description("Timezone ID for dates shown in emails (e.g. 'UTC').").
 						Default("UTC").
 						Build(),
+					"slack_channel_ids": util.ResourceList(types.StringType).
+						Optional().
+						Computed().
+						Description("Slack channel IDs to post to.").
+						PlanModifiers(listplanmodifier.UseStateForUnknown()).
+						Build(),
+					"slack_channel_names": util.ResourceList(types.StringType).
+						Optional().
+						Computed().
+						Description("Display names for the channels in slack_channel_ids, in the same order. If a name is omitted, the channel ID is shown instead.").
+						PlanModifiers(listplanmodifier.UseStateForUnknown()).
+						Build(),
+					"slack_frequency_period": util.ResourceString().
+						Optional().
+						Computed().
+						Description("How often to send Slack digests (e.g. '01:00:00' for hourly).").
+						Default("01:00:00").
+						Build(),
+					"slack_digest_format": util.ResourceString().
+						Optional().
+						Computed().
+						Description("Format of Slack digest messages. Valid values: Summary, Detailed.").
+						Default("Summary").
+						Validators(stringvalidator.OneOf("Summary", "Detailed")).
+						Build(),
 					"webhook_uri": util.ResourceString().
 						Optional().
 						Description("URI to send webhook notifications to.").


### PR DESCRIPTION
# Background

The `octopusdeploy_subscription` resource only supported email and webhook notifications. 

Update the subscription resource to support new slack notifications.

# Results

- Added `slack_channel_ids`, `slack_channel_names`, `slack_frequency_period`, `slack_digest_format` attributes to `event_notification_subscription`
- Added test covering create, update, and import
- Bumped the `go-octopusdeploy` dependency to the version with the new Slack fields

Fixes HPY-1358

## Before

N/A

## After

```
resource "octopusdeploy_subscription" "slack_test" {
  name = "Slack Test Subscription"

  event_notification_subscription = {
    slack_channel_ids   = ["C0BBDATV1HQ"]
    slack_channel_names = ["grace-test"]
    slack_frequency_period = "00:00:01"
    slack_digest_format    = "Summary"

    filter = {
      event_categories = ["DeploymentStarted"]
    }
  }
}
```

<img width="2144" height="1470" alt="image" src="https://github.com/user-attachments/assets/fc17c141-c508-4960-b0a4-5e6b5a8902a6" />

----

Test with channel that does not exist:
```
resource "octopusdeploy_subscription" "slack_test" {
  name = "Slack Test Subscription"

  event_notification_subscription = {
    slack_channel_ids   = ["C0BBDATV1HQ", "C123456789"]
    slack_channel_names = ["grace-test", "channel-does-not-exist"]
    slack_frequency_period = "00:00:01"
    slack_digest_format    = "Summary"

    filter = {
      event_categories = ["DeploymentStarted"]
    }
  }
}
```

Response:
```
octopusdeploy_subscription.slack_test: Modifying... [id=Subscriptions-141]
╷
│ Error: error updating subscription
│ 
│   with octopusdeploy_subscription.slack_test,
│   on main.tf line 188, in resource "octopusdeploy_subscription" "slack_test":
│  188: resource "octopusdeploy_subscription" "slack_test" {
│ 
│ Octopus API error: There was a problem with your request. [The Octopus bot can't post to #C123456789. It must be a public channel that exists, or one the bot has been invited to.] 
╵
```
