### PR TITLE
Deprecate slack_digest_format on subscription resource

### DIFF
--- a/docs/resources/subscription.md
+++ b/docs/resources/subscription.md
@@ -41,7 +41,7 @@ Optional:
 - `filter` (Attributes) Filter criteria to limit which events trigger this subscription. When omitted, all events trigger the subscription. (see [below for nested schema](#nestedatt--event_notification_subscription--filter))
 - `slack_channel_ids` (List of String) Slack channel IDs to post to.
 - `slack_channel_names` (List of String) Display names for the channels in slack_channel_ids, in the same order. If a name is omitted, the channel ID is shown instead.
-- `slack_digest_format` (String) Format of Slack digest messages. Valid values: Summary, Detailed.
+- `slack_digest_format` (String, Deprecated) Deprecated and ignored. Slack digests always send a summary.
 - `slack_frequency_period` (String) How often to send Slack digests (e.g. '01:00:00' for hourly).
 - `webhook_header_key` (String) Custom header key to include in webhook requests.
 - `webhook_header_value` (String, Sensitive) Custom header value to include in webhook requests.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.25.8
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.1
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.0 h1:2BSFwHg6f/02dbS2F5YyeNDPXOdIHXOAGDM3oumweao=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.1 h1:a/UEgCu7F8BbY+95W10aQ5VYhlf5jP/LVigZOH0eu/k=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.112.1/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2 h1:960T/UryMsoc2ZOnoLEg7rM9QpxWIdkdB9sR5gsUFAQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2/go.mod h1:kllISYzQ8N3P6+3rScVhyW/KWnPWQbwzm8pFcMInSRM=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/octopusdeploy_framework/resource_subscription.go
+++ b/octopusdeploy_framework/resource_subscription.go
@@ -35,7 +35,8 @@ type eventNotificationSubscriptionModel struct {
 	SlackChannelIds            types.List               `tfsdk:"slack_channel_ids"`
 	SlackChannelNames          types.List               `tfsdk:"slack_channel_names"`
 	SlackFrequencyPeriod       types.String             `tfsdk:"slack_frequency_period"`
-	SlackDigestFormat          types.String             `tfsdk:"slack_digest_format"`
+	// Deprecated and ignored; not mapped to the API. Preserved from config/state so existing configs don't drift.
+	SlackDigestFormat types.String `tfsdk:"slack_digest_format"`
 }
 
 type subscriptionFilterModel struct {
@@ -177,7 +178,6 @@ func expandSubscription(model *subscriptionModel) *subscriptions.Subscription {
 	s.EventNotificationSubscription.SlackChannelIds = util.ExpandStringList(n.SlackChannelIds)
 	s.EventNotificationSubscription.SlackChannelNames = util.ExpandStringList(n.SlackChannelNames)
 	s.EventNotificationSubscription.SlackFrequencyPeriod = n.SlackFrequencyPeriod.ValueString()
-	s.EventNotificationSubscription.SlackDigestFormat = n.SlackDigestFormat.ValueString()
 	s.EventNotificationSubscription.EmailTeams = util.ExpandStringSet(n.EmailTeams)
 	s.EventNotificationSubscription.WebhookTeams = util.ExpandStringSet(n.WebhookTeams)
 	s.EventNotificationSubscription.Filter = expandSubscriptionFilter(n.Filter)
@@ -223,7 +223,6 @@ func flattenSubscription(api *subscriptions.Subscription, model *subscriptionMod
 	n.EmailShowDatesInTimeZoneId = types.StringValue(apiN.EmailShowDatesInTimeZoneId)
 	n.WebhookTimeout = types.StringValue(apiN.WebhookTimeout)
 	n.SlackFrequencyPeriod = types.StringValue(apiN.SlackFrequencyPeriod)
-	n.SlackDigestFormat = types.StringValue(apiN.SlackDigestFormat)
 	n.SlackChannelIds = util.FlattenStringList(apiN.SlackChannelIds)
 	n.SlackChannelNames = util.FlattenStringList(apiN.SlackChannelNames)
 

--- a/octopusdeploy_framework/resource_subscription_test.go
+++ b/octopusdeploy_framework/resource_subscription_test.go
@@ -95,7 +95,7 @@ func TestAccSubscriptionSlack(t *testing.T) {
 		CheckDestroy:             testAccSubscriptionCheckDestroy(resourceName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubscriptionSlackConfig(name, []string{"C0123"}, []string{"general"}, "Summary"),
+				Config: testAccSubscriptionSlackConfig(name, []string{"C0123"}, []string{"general"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSubscriptionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -103,17 +103,15 @@ func TestAccSubscriptionSlack(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_ids.0", "C0123"),
 					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_names.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_names.0", "general"),
-					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_digest_format", "Summary"),
 					resource.TestCheckResourceAttrSet(resourceName, "event_notification_subscription.slack_frequency_period"),
 				),
 			},
 			{
-				Config: testAccSubscriptionSlackConfig(name, []string{"C0123", "C0456"}, []string{"general", "releases"}, "Detailed"),
+				Config: testAccSubscriptionSlackConfig(name, []string{"C0123", "C0456"}, []string{"general", "releases"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSubscriptionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_channel_ids.1", "C0456"),
-					resource.TestCheckResourceAttr(resourceName, "event_notification_subscription.slack_digest_format", "Detailed"),
 				),
 			},
 			{
@@ -125,7 +123,7 @@ func TestAccSubscriptionSlack(t *testing.T) {
 	})
 }
 
-func testAccSubscriptionSlackConfig(resourceID string, channelIDs, channelNames []string, digestFormat string) string {
+func testAccSubscriptionSlackConfig(resourceID string, channelIDs, channelNames []string) string {
 	channelIDsList := "[]"
 	if len(channelIDs) > 0 {
 		channelIDsList = fmt.Sprintf(`["%s"]`, strings.Join(channelIDs, `", "`))
@@ -142,13 +140,12 @@ resource "octopusdeploy_subscription" "%s" {
   event_notification_subscription = {
     slack_channel_ids   = %s
     slack_channel_names = %s
-    slack_digest_format = "%s"
 
     filter = {
       event_categories = ["Modified"]
     }
   }
-}`, resourceID, resourceID, channelIDsList, channelNamesList, digestFormat)
+}`, resourceID, resourceID, channelIDsList, channelNamesList)
 }
 
 func testAccSubscriptionExists(n string) resource.TestCheckFunc {

--- a/octopusdeploy_framework/schemas/subscription.go
+++ b/octopusdeploy_framework/schemas/subscription.go
@@ -110,10 +110,8 @@ func (s SubscriptionSchema) GetResourceSchema() resourceSchema.Schema {
 						Build(),
 					"slack_digest_format": util.ResourceString().
 						Optional().
-						Computed().
-						Description("Format of Slack digest messages. Valid values: Summary, Detailed.").
-						Default("Summary").
-						Validators(stringvalidator.OneOf("Summary", "Detailed")).
+						Description("Deprecated and ignored. Slack digests always send a summary.").
+						Deprecated("slack_digest_format is no longer used and will be removed in a future release.").
 						Build(),
 					"webhook_uri": util.ResourceString().
 						Optional().


### PR DESCRIPTION
Deprecates the `slack_digest_format` attribute on the `octopusdeploy_subscription` resource.

Octopus Server no longer uses this setting (see OctopusDeploy/OctopusDeploy#45159) — Slack digests always send a summary, and it was never wired into any behaviour or UI.

Rather than remove it (breaking for anyone with it in their config, since it shipped in v1.18.0), the attribute is now:
- marked `Deprecated` (emits a warning when used),
- `Optional` only (no longer `Computed`/defaulted), and
- no longer sent to or read from the API — the value carries through from config/state so existing configurations don't drift.

It can be removed in a future major release (with a state upgrader for the nested object).