### PR TITLE
fix: Prevent unnecessary CaC writes for Project updates

### DIFF
--- a/octopusdeploy_framework/resource_project.go
+++ b/octopusdeploy_framework/resource_project.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services"
@@ -67,9 +68,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	createdProject, err = projects.GetByID(r.Client, plan.SpaceID.ValueString(), createdProject.GetID())
-	if persistenceSettings != nil {
-		createdProject.PersistenceSettings = persistenceSettings
-	}
+	preserveGitPassword(createdProject.PersistenceSettings, persistenceSettings)
 
 	flattenedProject, diags := flattenProject(ctx, createdProject, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -104,9 +103,7 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		}
 		return
 	}
-	if persistenceSettings != nil {
-		project.PersistenceSettings = persistenceSettings
-	}
+	preserveGitPassword(project.PersistenceSettings, persistenceSettings)
 
 	flattenedProject, diags := flattenProject(ctx, project, &state)
 	resp.Diagnostics.Append(diags...)
@@ -125,6 +122,13 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan projectResourceModel
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state projectResourceModel
+	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -172,17 +176,48 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		updatedProject.VersioningStrategy = nil
 	}
 
+	// A default-branch change is a pointer update on the Project document. Read
+	// the target's DeploymentSettings before updating the Project so a missing or
+	// invalid OCL configuration cannot partially persist the new pointer.
+	if isCaC {
+		currentBranch, err := gitDefaultBranch(existingProject.PersistenceSettings)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error validating Config as Code default branch",
+				fmt.Sprintf("Could not determine the project's current default branch; the project was not updated: %s", err),
+			)
+			return
+		}
+
+		plannedBranch, err := gitDefaultBranch(updatedProject.PersistenceSettings)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error validating Config as Code default branch",
+				fmt.Sprintf("Could not determine the planned default branch; the project was not updated: %s", err),
+			)
+			return
+		}
+
+		if currentBranch != plannedBranch {
+			if _, err := r.Client.Deployments.GetDeploymentSettings(existingProject, plannedBranch); err != nil {
+				resp.Diagnostics.AddError(
+					"Error validating Config as Code default branch",
+					fmt.Sprintf("Config as Code configuration not found or unreadable on target branch %q; the project was not updated: %s", plannedBranch, err),
+				)
+				return
+			}
+		}
+	}
+
 	updatedProject, err = projects.Update(r.Client, updatedProject)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating project", err.Error())
 		return
 	}
 
-	if persistenceSettings != nil {
-		updatedProject.PersistenceSettings = persistenceSettings
-	}
+	preserveGitPassword(updatedProject.PersistenceSettings, persistenceSettings)
 
-	if isCaC {
+	if isCaC && caCDeploymentSettingsChanged(plan, state) {
 		if err := r.updateDeploymentSettingsForCaC(ctx, updatedProject, plan); err != nil {
 			resp.Diagnostics.AddError("Error updating deployment settings for CaC project", err.Error())
 			return
@@ -202,6 +237,46 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	diags = resp.State.Set(ctx, flattenedProject)
 	resp.Diagnostics.Append(diags...)
+}
+
+func caCDeploymentSettingsChanged(plan, state projectResourceModel) bool {
+	return !plan.DefaultGuidedFailureMode.Equal(state.DefaultGuidedFailureMode) ||
+		!plan.DefaultToSkipIfAlreadyInstalled.Equal(state.DefaultToSkipIfAlreadyInstalled) ||
+		!plan.DeploymentChangesTemplate.Equal(state.DeploymentChangesTemplate) ||
+		!plan.ReleaseNotesTemplate.Equal(state.ReleaseNotesTemplate) ||
+		!plan.ConnectivityPolicy.Equal(state.ConnectivityPolicy) ||
+		!plan.VersioningStrategy.Equal(state.VersioningStrategy)
+}
+
+func gitDefaultBranch(settings projects.PersistenceSettings) (string, error) {
+	gitSettings, ok := settings.(projects.GitPersistenceSettings)
+	if !ok {
+		return "", fmt.Errorf("expected Git persistence settings, got %T", settings)
+	}
+
+	branch := gitSettings.DefaultBranch()
+	if branch == "" {
+		return "", fmt.Errorf("Git persistence settings do not specify a default branch")
+	}
+
+	return branch, nil
+}
+
+func preserveGitPassword(remote, configured projects.PersistenceSettings) {
+	remoteGit, remoteIsGit := remote.(projects.GitPersistenceSettings)
+	configuredGit, configuredIsGit := configured.(projects.GitPersistenceSettings)
+	if !remoteIsGit || !configuredIsGit {
+		return
+	}
+
+	remoteCredential, remoteIsUsernamePassword := remoteGit.Credential().(*credentials.UsernamePassword)
+	configuredCredential, configuredIsUsernamePassword := configuredGit.Credential().(*credentials.UsernamePassword)
+	if !remoteIsUsernamePassword || !configuredIsUsernamePassword || configuredCredential.Password == nil {
+		return
+	}
+
+	remoteCredential.Password = configuredCredential.Password
+	remoteGit.SetCredential(remoteCredential)
 }
 
 func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/octopusdeploy_framework/resource_project_cac_update_test.go
+++ b/octopusdeploy_framework/resource_project_cac_update_test.go
@@ -1,12 +1,22 @@
 package octopusdeploy_framework
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"regexp"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // TestAccProjectCaCUpdate verifies that updating a CaC (Config as Code) project
@@ -44,6 +54,256 @@ func TestAccProjectCaCUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(projectPrefix, "default_guided_failure_mode", "On"),
 					resource.TestCheckResourceAttr(projectPrefix, "included_library_variable_sets.#", "1"),
 				),
+			},
+		},
+	})
+}
+
+// TestAccProjectCaCProtectedMainAllowsDatabaseBackedUpdates exercises the
+// compatibility contract for the current octopusdeploy_project schema.
+// Database-backed and repository-metadata changes must not implicitly write CaC
+// DeploymentSettings, while an explicitly configured OCL-backed change retains
+// the existing schema behavior and is rejected by Octopus protection.
+//
+// Protection in this test is exclusively Octopus ProtectedBranchNamePatterns;
+// the Git repository does not need GitHub branch protection.
+func TestAccProjectCaCProtectedMainAllowsDatabaseBackedUpdates(t *testing.T) {
+	gitURL, gitUsername, gitPassword := testAccGitSettings()
+	if gitURL == "" || gitUsername == "" || gitPassword == "" {
+		t.Skip("Skipping CaC protected-main database-backed update test: GIT_URL, GIT_USERNAME, and GIT_PASSWORD or GIT_CREDENTIAL must be set")
+	}
+
+	localName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	basePath := ".octopus/" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	projectPrefix := "octopusdeploy_project." + localName
+	baselineDescription := "CaC database baseline"
+	updatedDescription := "CaC database update"
+	baselineReleaseNotes := "CaC release notes baseline"
+	mutatedReleaseNotes := "CaC release notes mutation"
+	var projectID string
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccProjectCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCaCProjectBehaviorConfig(cacProjectBehaviorConfig{
+					LocalName:            localName,
+					BasePath:             basePath,
+					GitURL:               gitURL,
+					GitUsername:          gitUsername,
+					GitPassword:          gitPassword,
+					DefaultBranch:        "main",
+					ProtectedBranches:    nil,
+					Description:          baselineDescription,
+					ReleaseNotesTemplate: baselineReleaseNotes,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCaptureProjectID(projectPrefix, &projectID),
+					resource.TestCheckResourceAttr(projectPrefix, "description", baselineDescription),
+					resource.TestCheckResourceAttr(projectPrefix, "release_notes_template", baselineReleaseNotes),
+				),
+			},
+			{
+				// Repository protection metadata is Project-owned. Applying it
+				// must not echo DeploymentSettings after main becomes protected.
+				Config: testAccCaCProjectBehaviorConfig(cacProjectBehaviorConfig{
+					LocalName:            localName,
+					BasePath:             basePath,
+					GitURL:               gitURL,
+					GitUsername:          gitUsername,
+					GitPassword:          gitPassword,
+					DefaultBranch:        "main",
+					ProtectedBranches:    []string{"main"},
+					Description:          baselineDescription,
+					ReleaseNotesTemplate: baselineReleaseNotes,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(projectPrefix, "git_library_persistence_settings.0.protected_branches.#", "1"),
+					testAccCheckCaCProject(&projectID, "main", baselineDescription, []string{"main"}),
+				),
+			},
+			{
+				// Description is database-backed. Protected main must not make
+				// this update depend on a DeploymentSettings write.
+				Config: testAccCaCProjectBehaviorConfig(cacProjectBehaviorConfig{
+					LocalName:            localName,
+					BasePath:             basePath,
+					GitURL:               gitURL,
+					GitUsername:          gitUsername,
+					GitPassword:          gitPassword,
+					DefaultBranch:        "main",
+					ProtectedBranches:    []string{"main"},
+					Description:          updatedDescription,
+					ReleaseNotesTemplate: baselineReleaseNotes,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(projectPrefix, "description", updatedDescription),
+					testAccCheckCaCProject(&projectID, "main", updatedDescription, []string{"main"}),
+				),
+			},
+			{
+				// Included library variable sets are also database-backed.
+				Config: testAccCaCProjectBehaviorConfig(cacProjectBehaviorConfig{
+					LocalName:            localName,
+					BasePath:             basePath,
+					GitURL:               gitURL,
+					GitUsername:          gitUsername,
+					GitPassword:          gitPassword,
+					DefaultBranch:        "main",
+					ProtectedBranches:    []string{"main"},
+					Description:          updatedDescription,
+					ReleaseNotesTemplate: baselineReleaseNotes,
+					IncludeLibrarySet:    true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(projectPrefix, "included_library_variable_sets.#", "1"),
+					testAccCheckCaCProject(&projectID, "main", updatedDescription, []string{"main"}),
+				),
+			},
+			{
+				// The current schema still permits explicit OCL ownership. The
+				// tactical fix must retain that behavior until a future schema
+				// change: Octopus rejects this write because main is protected.
+				Config: testAccCaCProjectBehaviorConfig(cacProjectBehaviorConfig{
+					LocalName:            localName,
+					BasePath:             basePath,
+					GitURL:               gitURL,
+					GitUsername:          gitUsername,
+					GitPassword:          gitPassword,
+					DefaultBranch:        "main",
+					ProtectedBranches:    []string{"main"},
+					Description:          updatedDescription,
+					ReleaseNotesTemplate: mutatedReleaseNotes,
+					IncludeLibrarySet:    true,
+				}),
+				ExpectError: regexp.MustCompile(`(?i)protected branch|branch.*protected`),
+			},
+		},
+	})
+}
+
+// TestAccProjectCaCDefaultBranchFeatureToProtectedMainWithValidOCL verifies
+// that moving the default from a writable feature branch to protected main is a
+// Project-pointer operation once main contains valid OCL for the project. It
+// also verifies that a target missing OCL is rejected before the remote pointer
+// changes.
+//
+// GitHub is used only to create disposable refs with exact or missing content;
+// Octopus ProtectedBranchNamePatterns is the only protection under test.
+func TestAccProjectCaCDefaultBranchFeatureToProtectedMainWithValidOCL(t *testing.T) {
+	gitURL, gitUsername, gitPassword := testAccGitSettings()
+	if gitURL == "" || gitUsername == "" || gitPassword == "" {
+		t.Skip("Skipping CaC feature-to-protected-main default-branch test: GIT_URL, GIT_USERNAME, and GIT_PASSWORD or GIT_CREDENTIAL must be set")
+	}
+
+	github, err := newGitHubRefFixture(gitURL, gitPassword)
+	if err != nil {
+		t.Skipf("Skipping GitHub-specific CaC transition fixture: %s", err)
+	}
+
+	mainBeforeCreate, err := github.branchSHA("main")
+	if err != nil {
+		t.Fatalf("failed to capture main before CaC creation: %s", err)
+	}
+
+	localName := acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	basePath := ".octopus/" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	projectPrefix := "octopusdeploy_project." + localName
+	exactBranch := "octopus-test/exact-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	missingBranch := "octopus-test/missing-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+	description := "CaC branch transition"
+	releaseNotes := "CaC transition release notes"
+	var projectID string
+	refsCreated := false
+
+	t.Cleanup(func() {
+		if !refsCreated {
+			return
+		}
+		if err := github.deleteBranch(exactBranch); err != nil {
+			t.Logf("failed to delete exact-content fixture branch %q: %s", exactBranch, err)
+		}
+		if err := github.deleteBranch(missingBranch); err != nil {
+			t.Logf("failed to delete missing-content fixture branch %q: %s", missingBranch, err)
+		}
+	})
+
+	config := func(defaultBranch string, protected []string) string {
+		return testAccCaCProjectBehaviorConfig(cacProjectBehaviorConfig{
+			LocalName:            localName,
+			BasePath:             basePath,
+			GitURL:               gitURL,
+			GitUsername:          gitUsername,
+			GitPassword:          gitPassword,
+			DefaultBranch:        defaultBranch,
+			ProtectedBranches:    protected,
+			Description:          description,
+			ReleaseNotesTemplate: releaseNotes,
+		})
+	}
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccProjectCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config("main", nil),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCaptureProjectID(projectPrefix, &projectID),
+					func(_ *terraform.State) error {
+						mainWithOCL, err := github.branchSHA("main")
+						if err != nil {
+							return fmt.Errorf("read main after CaC creation: %w", err)
+						}
+						if err := github.createBranch(exactBranch, mainWithOCL); err != nil {
+							return fmt.Errorf("create exact-content branch: %w", err)
+						}
+						if err := github.createBranch(missingBranch, mainBeforeCreate); err != nil {
+							_ = github.deleteBranch(exactBranch)
+							return fmt.Errorf("create missing-content branch: %w", err)
+						}
+						refsCreated = true
+						return nil
+					},
+				),
+			},
+			{
+				// Establish a writable feature default while main is already
+				// protected in Octopus. The feature ref is an exact copy of main.
+				Config: config(exactBranch, []string{"main"}),
+				Check:  testAccCheckCaCProject(&projectID, exactBranch, description, []string{"main"}),
+			},
+			{
+				// Selecting protected main with exact OCL must be pointer-only.
+				// Any DeploymentSettings PUT would be rejected by Octopus.
+				Config: config("main", []string{"main"}),
+				Check:  testAccCheckCaCProject(&projectID, "main", description, []string{"main"}),
+			},
+			{
+				// The missing branch predates this project's OCL. The provider
+				// must preflight it and fail before changing the Project pointer.
+				Config:      config(missingBranch, []string{"main"}),
+				ExpectError: regexp.MustCompile(`(?i)configuration.*not found|schema_version\.ocl|does not exist|missing`),
+			},
+			{
+				PreConfig: func() {
+					project, err := projects.GetByID(octoClient, octoClient.GetSpaceID(), projectID)
+					if err != nil {
+						t.Fatalf("read project after rejected missing-OCL transition: %s", err)
+					}
+					settings, ok := project.PersistenceSettings.(projects.GitPersistenceSettings)
+					if !ok {
+						t.Fatalf("project %s does not have Git persistence settings", projectID)
+					}
+					if settings.DefaultBranch() != "main" {
+						t.Fatalf("missing-OCL transition partially changed default branch: got %q, want main", settings.DefaultBranch())
+					}
+				},
+				Config: config("main", []string{"main"}),
+				Check:  testAccCheckCaCProject(&projectID, "main", description, []string{"main"}),
 			},
 		},
 	})
@@ -122,4 +382,242 @@ func testAccCaCProjectConfig(localName, basePath, gitURL, gitUsername, gitPasswo
 		guidedFailureMode, // 6
 		includedSets,      // 7
 	)
+}
+
+type cacProjectBehaviorConfig struct {
+	LocalName            string
+	BasePath             string
+	GitURL               string
+	GitUsername          string
+	GitPassword          string
+	DefaultBranch        string
+	ProtectedBranches    []string
+	Description          string
+	ReleaseNotesTemplate string
+	IncludeLibrarySet    bool
+}
+
+func testAccCaCProjectBehaviorConfig(config cacProjectBehaviorConfig) string {
+	protectedBranches, _ := json.Marshal(config.ProtectedBranches)
+	if config.ProtectedBranches == nil {
+		protectedBranches = []byte("[]")
+	}
+
+	includedSets := "included_library_variable_sets = []"
+	if config.IncludeLibrarySet {
+		includedSets = fmt.Sprintf("included_library_variable_sets = [octopusdeploy_library_variable_set.%s.id]", config.LocalName)
+	}
+
+	return fmt.Sprintf(`
+		data "octopusdeploy_lifecycles" "default" {
+		  ids          = null
+		  partial_name = "Default Lifecycle"
+		  skip         = 0
+		  take         = 1
+		}
+
+		resource "octopusdeploy_project_group" "%[1]s" {
+		  name = "%[1]s"
+		}
+
+		resource "octopusdeploy_git_credential" "%[1]s" {
+		  name     = "%[1]s"
+		  username = "%[4]s"
+		  password = "%[5]s"
+		}
+
+		resource "octopusdeploy_library_variable_set" "%[1]s" {
+		  name = "%[1]s-lvs"
+		}
+
+		resource "octopusdeploy_project" "%[1]s" {
+		  name                          = "%[1]s"
+		  description                   = "%[8]s"
+		  default_guided_failure_mode   = "Off"
+		  default_to_skip_if_already_installed = false
+		  release_notes_template        = "%[9]s"
+		  is_version_controlled         = true
+		  project_group_id              = octopusdeploy_project_group.%[1]s.id
+		  lifecycle_id                  = data.octopusdeploy_lifecycles.default.lifecycles[0].id
+		  %[10]s
+
+		  git_library_persistence_settings {
+		    git_credential_id  = octopusdeploy_git_credential.%[1]s.id
+		    url                = "%[3]s"
+		    base_path          = "%[2]s"
+		    default_branch     = "%[6]s"
+		    protected_branches = %[7]s
+		  }
+
+		  connectivity_policy {
+		    allow_deployments_to_no_targets = true
+		    skip_machine_behavior           = "None"
+		  }
+		}
+		`,
+		config.LocalName,            // 1
+		config.BasePath,             // 2
+		config.GitURL,               // 3
+		config.GitUsername,          // 4
+		config.GitPassword,          // 5
+		config.DefaultBranch,        // 6
+		string(protectedBranches),   // 7
+		config.Description,          // 8
+		config.ReleaseNotesTemplate, // 9
+		includedSets,                // 10
+	)
+}
+
+func testAccCaptureProjectID(resourceName string, projectID *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		resourceState, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("project resource %q was not found in Terraform state", resourceName)
+		}
+		*projectID = resourceState.Primary.ID
+		if *projectID == "" {
+			return fmt.Errorf("project resource %q has an empty ID", resourceName)
+		}
+		return nil
+	}
+}
+
+func testAccCheckCaCProject(projectID *string, expectedDefault, expectedDescription string, expectedProtected []string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		if projectID == nil || *projectID == "" {
+			return fmt.Errorf("project ID was not captured")
+		}
+		project, err := projects.GetByID(octoClient, octoClient.GetSpaceID(), *projectID)
+		if err != nil {
+			return fmt.Errorf("read project %s: %w", *projectID, err)
+		}
+		if project.Description != expectedDescription {
+			return fmt.Errorf("project %s description = %q, want %q", *projectID, project.Description, expectedDescription)
+		}
+
+		settings, ok := project.PersistenceSettings.(projects.GitPersistenceSettings)
+		if !ok {
+			return fmt.Errorf("project %s does not have Git persistence settings", *projectID)
+		}
+		if settings.DefaultBranch() != expectedDefault {
+			return fmt.Errorf("project %s default branch = %q, want %q", *projectID, settings.DefaultBranch(), expectedDefault)
+		}
+
+		actualProtected := settings.ProtectedBranchNamePatterns()
+		for _, expected := range expectedProtected {
+			found := false
+			for _, actual := range actualProtected {
+				if actual == expected {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("project %s protected branches = %v, want branch %q", *projectID, actualProtected, expected)
+			}
+		}
+		return nil
+	}
+}
+
+type githubRefFixture struct {
+	owner  string
+	repo   string
+	token  string
+	client *http.Client
+}
+
+func newGitHubRefFixture(repositoryURL, token string) (*githubRefFixture, error) {
+	parsed, err := url.Parse(repositoryURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse repository URL: %w", err)
+	}
+	if !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return nil, fmt.Errorf("repository host %q is not github.com", parsed.Hostname())
+	}
+	path := strings.TrimSuffix(strings.Trim(parsed.Path, "/"), ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("repository URL does not identify owner/repo: %s", repositoryURL)
+	}
+	return &githubRefFixture{
+		owner:  parts[0],
+		repo:   parts[1],
+		token:  token,
+		client: &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+func (g *githubRefFixture) request(method, path string, body any, expected ...int) ([]byte, error) {
+	var requestBody io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		requestBody = bytes.NewReader(encoded)
+	}
+
+	request, err := http.NewRequest(method, "https://api.github.com"+path, requestBody)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("Authorization", "Bearer "+g.token)
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	request.Header.Set("User-Agent", "terraform-provider-octopusdeploy-acceptance-tests")
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	response, err := g.client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	for _, status := range expected {
+		if response.StatusCode == status {
+			return responseBody, nil
+		}
+	}
+	return nil, fmt.Errorf("GitHub %s %s returned HTTP %d: %s", method, path, response.StatusCode, string(responseBody))
+}
+
+func (g *githubRefFixture) branchSHA(branch string) (string, error) {
+	path := fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", g.owner, g.repo, url.PathEscape(branch))
+	body, err := g.request(http.MethodGet, path, nil, http.StatusOK)
+	if err != nil {
+		return "", err
+	}
+	var response struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
+	}
+	if response.Object.SHA == "" {
+		return "", fmt.Errorf("GitHub returned an empty SHA for branch %q", branch)
+	}
+	return response.Object.SHA, nil
+}
+
+func (g *githubRefFixture) createBranch(branch, sha string) error {
+	path := fmt.Sprintf("/repos/%s/%s/git/refs", g.owner, g.repo)
+	_, err := g.request(http.MethodPost, path, map[string]string{
+		"ref": "refs/heads/" + branch,
+		"sha": sha,
+	}, http.StatusCreated)
+	return err
+}
+
+func (g *githubRefFixture) deleteBranch(branch string) error {
+	path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", g.owner, g.repo, url.PathEscape(branch))
+	_, err := g.request(http.MethodDelete, path, nil, http.StatusNoContent, http.StatusNotFound)
+	return err
 }

--- a/octopusdeploy_framework/resource_project_test.go
+++ b/octopusdeploy_framework/resource_project_test.go
@@ -384,3 +384,119 @@ func TestExpandGitUsernamePasswordPersistenceSettings(t *testing.T) {
 	require.NotNil(t, upCred.Password.NewValue)
 	assert.Equal(t, "secret", *upCred.Password.NewValue)
 }
+
+func TestCaCDeploymentSettingsChanged(t *testing.T) {
+	connectivityType := types.ObjectType{AttrTypes: getConnectivityPolicyAttrTypes()}
+	versioningType := types.ObjectType{AttrTypes: getVersioningStrategyAttrTypes()}
+	baseline := projectResourceModel{
+		DefaultGuidedFailureMode:        types.StringValue("EnvironmentDefault"),
+		DefaultToSkipIfAlreadyInstalled: types.BoolValue(false),
+		DeploymentChangesTemplate:       types.StringValue("changes"),
+		ReleaseNotesTemplate:            types.StringValue("notes"),
+		ConnectivityPolicy:              types.ListNull(connectivityType),
+		VersioningStrategy:              types.ListNull(versioningType),
+	}
+
+	assert.False(t, caCDeploymentSettingsChanged(baseline, baseline))
+
+	tests := map[string]func(*projectResourceModel){
+		"guided failure mode": func(model *projectResourceModel) {
+			model.DefaultGuidedFailureMode = types.StringValue("Off")
+		},
+		"skip if installed": func(model *projectResourceModel) {
+			model.DefaultToSkipIfAlreadyInstalled = types.BoolValue(true)
+		},
+		"deployment changes template": func(model *projectResourceModel) {
+			model.DeploymentChangesTemplate = types.StringValue("updated changes")
+		},
+		"release notes template": func(model *projectResourceModel) {
+			model.ReleaseNotesTemplate = types.StringValue("updated notes")
+		},
+		"connectivity policy": func(model *projectResourceModel) {
+			model.ConnectivityPolicy = types.ListValueMust(connectivityType, []attr.Value{})
+		},
+		"versioning strategy": func(model *projectResourceModel) {
+			model.VersioningStrategy = types.ListValueMust(versioningType, []attr.Value{})
+		},
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			plan := baseline
+			mutate(&plan)
+			assert.True(t, caCDeploymentSettingsChanged(plan, baseline))
+		})
+	}
+}
+
+func TestGitDefaultBranchRequiresConfiguredGitBranch(t *testing.T) {
+	repositoryURL, err := url.Parse("https://github.com/example/repository")
+	require.NoError(t, err)
+
+	validSettings := projects.NewGitPersistenceSettings(
+		".octopus",
+		credentials.NewAnonymous(),
+		"feature/cac",
+		nil,
+		repositoryURL,
+	)
+	emptyBranchSettings := projects.NewGitPersistenceSettings(
+		".octopus",
+		credentials.NewAnonymous(),
+		"",
+		nil,
+		repositoryURL,
+	)
+
+	branch, err := gitDefaultBranch(validSettings)
+	require.NoError(t, err)
+	assert.Equal(t, "feature/cac", branch)
+
+	for name, settings := range map[string]projects.PersistenceSettings{
+		"missing settings":  nil,
+		"database settings": projects.NewDatabasePersistenceSettings(),
+		"empty branch":      emptyBranchSettings,
+	} {
+		t.Run(name, func(t *testing.T) {
+			branch, err := gitDefaultBranch(settings)
+			assert.Error(t, err)
+			assert.Empty(t, branch)
+		})
+	}
+}
+
+func TestPreserveGitPasswordDoesNotReplaceRemoteMetadata(t *testing.T) {
+	remoteURL, err := url.Parse("https://github.com/example/remote")
+	require.NoError(t, err)
+	configuredURL, err := url.Parse("https://github.com/example/configured")
+	require.NoError(t, err)
+
+	remote := projects.NewGitPersistenceSettings(
+		".remote",
+		credentials.NewUsernamePassword("remote-user", nil),
+		"remote-main",
+		[]string{"remote-protected"},
+		remoteURL,
+	)
+	configured := projects.NewGitPersistenceSettings(
+		".configured",
+		credentials.NewUsernamePassword("configured-user", core.NewSensitiveValue("secret")),
+		"configured-main",
+		[]string{"configured-protected"},
+		configuredURL,
+	)
+
+	preserveGitPassword(remote, configured)
+
+	assert.Equal(t, ".remote", remote.BasePath())
+	assert.Equal(t, "remote-main", remote.DefaultBranch())
+	assert.Equal(t, []string{"remote-protected"}, remote.ProtectedBranchNamePatterns())
+	assert.Equal(t, remoteURL.String(), remote.URL().String())
+
+	credential, ok := remote.Credential().(*credentials.UsernamePassword)
+	require.True(t, ok)
+	assert.Equal(t, "remote-user", credential.Username)
+	require.NotNil(t, credential.Password)
+	require.NotNil(t, credential.Password.NewValue)
+	assert.Equal(t, "secret", *credential.Password.NewValue)
+}


### PR DESCRIPTION
Fixes #232

**Summary**

Fixes several Config as Code update issues affecting octopusdeploy_project. The provider previously attempted DeploymentSettings writes for every Config as Code project update, even when only database-backed project fields changed. This caused updates to fail when the default branch was protected and could also leave projects partially updated if the default branch was changed to one without valid OCL. The provider now distinguishes between Project updates and DeploymentSettings updates, and validates default branch changes before modifying the project.

**Changes**

- Only updates DeploymentSettings when DeploymentSettings-owned fields have actually changed.
- Reads the previous Terraform state to determine whether a DeploymentSettings update is required.
- Validates target Config as Code branches before updating the project's default branch, preventing partial project updates when the target branch does not contain valid OCL.
- Preserves API-returned Git persistence settings when the Git password is omitted from API responses.

- Added comprehensive acceptance tests covering:
     protected default branches,
     database-backed project updates,
     DeploymentSettings updates,
     feature branch -> protected branch transitions,
     invalid branch transitions,
     atomic update behaviour.
- Added unit tests covering DeploymentSettings change detection, Git default branch validation, and Git password preservation.

**Result**

Database-backed project updates no longer perform unnecessary Config as Code writes, allowing them to succeed against protected branches. Default branch changes are now validated before the project is updated, preventing partially persisted project state when the target branch does not contain valid Config as Code configuration, while preserving existing behaviour for intentional DeploymentSettings updates.