### PR TITLE
fix: stop team update from deleting externally-managed scoped user roles

### DIFF
--- a/octopusdeploy_framework/resource_team.go
+++ b/octopusdeploy_framework/resource_team.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -54,7 +55,8 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	if err := r.updateUserRoles(ctx, plan, createdTeam); err != nil {
+	// On create there are no previously-managed roles, so nothing is eligible for removal.
+	if err := r.updateUserRoles(ctx, plan, createdTeam, types.SetNull(userRoleObjectType)); err != nil {
 		resp.Diagnostics.AddError("Error updating user roles for team", err.Error())
 		return
 	}
@@ -83,8 +85,9 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan schemas.TeamModel
+	var plan, state schemas.TeamModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -96,13 +99,14 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	if err := r.updateUserRoles(ctx, plan, updatedTeam); err != nil {
+	// Pass the prior state's user roles so removals are limited to roles this resource owned.
+	if err := r.updateUserRoles(ctx, plan, updatedTeam, state.UserRole); err != nil {
 		resp.Diagnostics.AddError("Error updating user roles for team", err.Error())
 		return
 	}
 
-	state := mapTeamResourceToState(ctx, updatedTeam, plan, r.Client)
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	newState := mapTeamResourceToState(ctx, updatedTeam, plan, r.Client)
+	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
 
 func (r *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -123,7 +127,7 @@ func (*teamResource) ImportState(ctx context.Context, req resource.ImportStateRe
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *teamResource) updateUserRoles(ctx context.Context, model schemas.TeamModel, team *teams.Team) error {
+func (r *teamResource) updateUserRoles(ctx context.Context, model schemas.TeamModel, team *teams.Team, previousUserRoles types.Set) error {
 	newUserRoles := mapUserRoleSetStateToResource(ctx, team, model.UserRole)
 
 	existingUserRoles, err := r.Client.Teams.GetScopedUserRoles(*team, core.SkipTakeQuery{})
@@ -131,8 +135,12 @@ func (r *teamResource) updateUserRoles(ctx context.Context, model schemas.TeamMo
 		return fmt.Errorf("error getting existing user roles for team %s: %s", team.ID, err)
 	}
 
+	// Only remove roles previously managed by this team resource; leave roles managed by standalone
+	// octopusdeploy_scoped_user_role resources untouched (mirrors the read-path filter, see #180)
+	removableUserRoles := filterUserRolesByPreviousState(ctx, existingUserRoles.Items, previousUserRoles)
+
 	userRolesToAdd := findAddedScopedUserRoles(newUserRoles, existingUserRoles.Items)
-	userRolesToRemove := findRemovedScopedUserRoles(newUserRoles, existingUserRoles.Items)
+	userRolesToRemove := findRemovedScopedUserRoles(newUserRoles, removableUserRoles)
 	userRolesToEdit := findModifiedScopedUserRoles(newUserRoles, existingUserRoles.Items)
 
 	for _, userRole := range userRolesToAdd {

--- a/octopusdeploy_framework/resource_team_mappers_test.go
+++ b/octopusdeploy_framework/resource_team_mappers_test.go
@@ -110,3 +110,69 @@ func TestFilterUserRolesByPreviousState(t *testing.T) {
 		assert.Empty(t, result, "Should filter out roles that were not previously managed by the team")
 	})
 }
+
+// TestUpdateUserRolesRemovalOwnership guards updateUserRoles' removal-candidate selection.
+// Regression test for #180: updating a team must not delete externally-managed scoped user roles.
+func TestUpdateUserRolesRemovalOwnership(t *testing.T) {
+	ctx := context.Background()
+
+	newRole := func(id, userRoleID string) *userroles.ScopedUserRole {
+		r := userroles.NewScopedUserRole(userRoleID)
+		r.ID = id
+		return r
+	}
+
+	previousStateWithIDs := func(ids ...string) types.Set {
+		elems := make([]attr.Value, 0, len(ids))
+		for _, id := range ids {
+			elems = append(elems, types.ObjectValueMust(userRoleObjectType.AttrTypes, map[string]attr.Value{
+				"id":                types.StringValue(id),
+				"user_role_id":      types.StringValue("user-role-for-" + id),
+				"space_id":          types.StringValue("Spaces-1"),
+				"team_id":           types.StringValue("Teams-1"),
+				"environment_ids":   types.SetNull(types.StringType),
+				"project_group_ids": types.SetNull(types.StringType),
+				"project_ids":       types.SetNull(types.StringType),
+				"tenant_ids":        types.SetNull(types.StringType),
+			}))
+		}
+		return types.SetValueMust(userRoleObjectType, elems)
+	}
+
+	removalIDs := func(newUserRoles, serverRoles []*userroles.ScopedUserRole, previous types.Set) map[string]bool {
+		removable := filterUserRolesByPreviousState(ctx, serverRoles, previous)
+		toRemove := findRemovedScopedUserRoles(newUserRoles, removable)
+		ids := make(map[string]bool)
+		for _, r := range toRemove {
+			ids[r.ID] = true
+		}
+		return ids
+	}
+
+	t.Run("ShouldNotRemoveExternallyManagedRolesWhenTeamHasNoInlineRoles", func(t *testing.T) {
+		// Team resource declares no user_role blocks (newUserRoles empty) and never managed any
+		// (previous state null). All roles on the server belong to standalone resources.
+		external := []*userroles.ScopedUserRole{newRole("role-1", "ur-1"), newRole("role-2", "ur-2")}
+
+		ids := removalIDs(nil, external, types.SetNull(userRoleObjectType))
+		assert.Empty(t, ids, "must not delete scoped user roles managed outside the team resource")
+	})
+
+	t.Run("ShouldRemoveOnlyPreviouslyOwnedRolesDroppedFromConfig", func(t *testing.T) {
+		// Inline user_role user previously owned role-a and role-b, now keeps only role-a.
+		// role-ext is a standalone-managed role that also lives on the team.
+		roleA := newRole("role-a", "ur-a")
+		roleB := newRole("role-b", "ur-b")
+		roleExt := newRole("role-ext", "ur-ext")
+
+		newUserRoles := []*userroles.ScopedUserRole{roleA}
+		serverRoles := []*userroles.ScopedUserRole{roleA, roleB, roleExt}
+
+		ids := removalIDs(newUserRoles, serverRoles, previousStateWithIDs("role-a", "role-b"))
+
+		assert.True(t, ids["role-b"], "should remove role-b (previously owned, dropped from config)")
+		assert.False(t, ids["role-ext"], "must not remove externally-managed role-ext")
+		assert.False(t, ids["role-a"], "must not remove role-a (still in config)")
+		assert.Len(t, ids, 1)
+	})
+}

--- a/octopusdeploy_framework/resource_team_test.go
+++ b/octopusdeploy_framework/resource_team_test.go
@@ -284,6 +284,61 @@ resource "octopusdeploy_scoped_user_role" "test_role" {
 }`, userRoleName, teamName, spaceID, spaceID)
 }
 
+// Regression test for #180: a team update must not delete a standalone scoped user role.
+func TestAccOctopusDeployTeamUpdateKeepsStandaloneScopedUserRole(t *testing.T) {
+	teamName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	userRoleName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	space := NewTestSpace(t)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccTeamCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamWithStandaloneScopedUserRoleConfigDesc(teamName, userRoleName, space.ID, "before update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("octopusdeploy_scoped_user_role.test_role", "id"),
+				),
+			},
+			// Change the team description to force a team update; the standalone role must survive
+			{
+				Config: testAccTeamWithStandaloneScopedUserRoleConfigDesc(teamName, userRoleName, space.ID, "after update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("octopusdeploy_team.test_team", "description", "after update"),
+					resource.TestCheckResourceAttrSet("octopusdeploy_scoped_user_role.test_role", "id"),
+				),
+			},
+			{
+				Config:             testAccTeamWithStandaloneScopedUserRoleConfigDesc(teamName, userRoleName, space.ID, "after update"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccTeamWithStandaloneScopedUserRoleConfigDesc(teamName, userRoleName, spaceID, description string) string {
+	return providerSpaceConfig(spaceID) + fmt.Sprintf(`
+resource "octopusdeploy_user_role" "test_user_role" {
+	name = "%s"
+	description = "Test user role"
+	granted_space_permissions = ["EnvironmentView"]
+}
+
+resource "octopusdeploy_team" "test_team" {
+	name        = "%s"
+	description = "%s"
+	space_id    = "%s"
+}
+
+resource "octopusdeploy_scoped_user_role" "test_role" {
+	team_id      = octopusdeploy_team.test_team.id
+	user_role_id = octopusdeploy_user_role.test_user_role.id
+	space_id     = "%s"
+}`, userRoleName, teamName, description, spaceID, spaceID)
+}
+
 func testAccTeamImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]


### PR DESCRIPTION
## What

Stops the `octopusdeploy_team` resource from deleting scoped user roles that are managed **outside** the team resource (i.e. via standalone `octopusdeploy_scoped_user_role` resources) whenever the team is created or updated.

Fixes #180. Follow-up to #100 / #105.

## Why

`updateUserRoles` (called on every team `Create`/`Update`) reconciled the team's scoped user roles by:

1. building `newUserRoles` from the team's own inline `user_role` blocks,
2. fetching **all** scoped user roles attached to the team on the server, and
3. deleting every server role not present in `newUserRoles`.

When a team is managed without inline `user_role` blocks (roles managed by standalone `octopusdeploy_scoped_user_role` resources), `newUserRoles` is empty, so step 3 deletes **every** scoped user role attached to the team. Terraform then detects the standalone resources as missing on the next refresh and recreates them — requiring 2+ applies to converge, or looping indefinitely if the team drifts on every apply.

PR #105 addressed the symptom on the **read/refresh** path (`filterUserRolesByPreviousState` in `mapTeamResourceToState`), but the **write** path in `resource_team.go::updateUserRoles` was never given the equivalent ownership check, so the deletion persisted (re-reported in #180).

## How

Apply the same ownership filter to removals. Removal candidates are now drawn only from roles this team resource **previously managed** (derived from prior state via the existing `filterUserRolesByPreviousState` helper), rather than from every role on the server:

- `Update` now reads `req.State` and passes the prior `user_role` set into `updateUserRoles`.
- `Create` passes a null set (nothing was previously managed, so nothing is removable — and a freshly created team has no pre-existing roles anyway).
- `findRemovedScopedUserRoles` is now fed the filtered "previously managed" set instead of all server roles.

Add/edit behavior is unchanged; only the removal set is narrowed. Roles managed by inline `user_role` blocks continue to be added/removed/edited exactly as before.

## Tests

**Unit** — `TestUpdateUserRolesRemovalOwnership` covering the removal-candidate selection:

- team with no inline `user_role` blocks → externally-managed roles are **not** selected for removal (the #180 case);
- inline-`user_role` team that drops one role from config → only that previously-owned role is removed, while an externally-managed role on the same team is left untouched.

**Acceptance** — `TestAccOctopusDeployTeamUpdateKeepsStandaloneScopedUserRole`: creates a team with a standalone `octopusdeploy_scoped_user_role`, changes the team's description to force a team update, and asserts an empty follow-up plan (the role survives). The pre-existing `TestAccOctopusDeployTeamScopedUserRoleNoConflict` never updated the team after adding the standalone role, so it did not exercise this path.

Validated red→green against a live Octopus instance: the new acceptance test fails on the unpatched code (post-update refresh plan shows `octopusdeploy_scoped_user_role ... will be created`, `Plan: 1 to add`) and passes with the fix. Existing `TestFilterUserRolesByPreviousState` continues to pass. `gofmt` clean; `go vet` clean.
