### PR TITLE
fix: make rate limiting request limit per minute rather than hour

### DIFF
--- a/docs/resources/built_in_rate_limiting_policy.md
+++ b/docs/resources/built_in_rate_limiting_policy.md
@@ -14,11 +14,11 @@ Manages the settings of a built-in rate limiting policy.
 
 ```terraform
 resource "octopusdeploy_built_in_rate_limiting_policy" "authenticated_user" {
-  slug              = "user"
-  is_enabled        = true
-  requests_per_hour = 10000
-  burst_limit       = 100
-  audit_mode        = false
+  slug                = "user"
+  is_enabled          = true
+  requests_per_minute = 1000
+  burst_limit         = 100
+  audit_mode          = false
 }
 ```
 
@@ -30,7 +30,7 @@ resource "octopusdeploy_built_in_rate_limiting_policy" "authenticated_user" {
 - `audit_mode` (Boolean) When enabled, requests that exceed the limit are logged but not rejected.
 - `burst_limit` (Number) The maximum burst capacity.
 - `is_enabled` (Boolean) Whether rate limiting is enforced for this policy.
-- `requests_per_hour` (Number) The request rate allowed per hour.
+- `requests_per_minute` (Number) The request rate allowed per minute.
 - `slug` (String) The slug identifying the built-in policy to manage. One of `anon` (unauthenticated), `user` (authenticated human), or `agent` (authenticated agent).
 
 ### Read-Only

--- a/examples/resources/octopusdeploy_built_in_rate_limiting_policy/resource.tf
+++ b/examples/resources/octopusdeploy_built_in_rate_limiting_policy/resource.tf
@@ -1,7 +1,7 @@
 resource "octopusdeploy_built_in_rate_limiting_policy" "authenticated_user" {
-  slug              = "user"
-  is_enabled        = true
-  requests_per_hour = 10000
-  burst_limit       = 100
-  audit_mode        = false
+  slug                = "user"
+  is_enabled          = true
+  requests_per_minute = 1000
+  burst_limit         = 100
+  audit_mode          = false
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.25.8
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.1
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.0 h1:u2wy5vYU+OiDkwcZkdJ98DqfjGwB4XDh7Z1gkwbus60=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.1 h1:7lrYQSCo2HeixFRBGGKA8a7QjuBw9L+4A4kmUDUEzSE=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.1/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2 h1:960T/UryMsoc2ZOnoLEg7rM9QpxWIdkdB9sR5gsUFAQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v1.0.2/go.mod h1:kllISYzQ8N3P6+3rScVhyW/KWnPWQbwzm8pFcMInSRM=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/octopusdeploy_framework/resource_built_in_rate_limiting_policy.go
+++ b/octopusdeploy_framework/resource_built_in_rate_limiting_policy.go
@@ -83,7 +83,7 @@ func updateStateFromPolicy(data *schemas.BuiltInRateLimitingPolicyResourceModel,
 	data.Name = types.StringValue(policy.Name)
 	data.ScopeType = types.StringValue(policy.ScopeType.String())
 	data.IsEnabled = types.BoolValue(policy.IsEnabled)
-	data.RequestsPerHour = types.Int64Value(int64(policy.RequestsPerHour))
+	data.RequestsPerMinute = types.Int64Value(int64(policy.RequestsPerMinute))
 	data.BurstLimit = types.Int64Value(int64(policy.BurstLimit))
 	data.AuditMode = types.BoolValue(policy.AuditMode)
 }
@@ -182,12 +182,12 @@ func (r *builtInRateLimitingPolicyResource) ImportState(ctx context.Context, req
 
 func (r *builtInRateLimitingPolicyResource) modify(data schemas.BuiltInRateLimitingPolicyResourceModel, policy *ratelimitingpolicies.RateLimitingPolicy) (*ratelimitingpolicies.RateLimitingPolicy, error) {
 	return ratelimitingpolicies.Modify(r.Client, ratelimitingpolicies.ModifyRateLimitingPolicyCommand{
-		ID:              policy.ID,
-		Name:            policy.Name,
-		ScopeType:       policy.ScopeType,
-		IsEnabled:       data.IsEnabled.ValueBool(),
-		RequestsPerHour: int(data.RequestsPerHour.ValueInt64()),
-		BurstLimit:      int(data.BurstLimit.ValueInt64()),
-		AuditMode:       data.AuditMode.ValueBool(),
+		ID:                policy.ID,
+		Name:              policy.Name,
+		ScopeType:         policy.ScopeType,
+		IsEnabled:         data.IsEnabled.ValueBool(),
+		RequestsPerMinute: int(data.RequestsPerMinute.ValueInt64()),
+		BurstLimit:        int(data.BurstLimit.ValueInt64()),
+		AuditMode:         data.AuditMode.ValueBool(),
 	})
 }

--- a/octopusdeploy_framework/resource_built_in_rate_limiting_policy_test.go
+++ b/octopusdeploy_framework/resource_built_in_rate_limiting_policy_test.go
@@ -24,7 +24,7 @@ func TestAccOctopusDeployBuiltInRateLimitingPolicyBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "slug", "anon"),
 					resource.TestCheckResourceAttr(resourceName, "scope_type", "Unauthenticated"),
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "requests_per_hour", "5000"),
+					resource.TestCheckResourceAttr(resourceName, "requests_per_minute", "5000"),
 					resource.TestCheckResourceAttr(resourceName, "burst_limit", "100"),
 					resource.TestCheckResourceAttr(resourceName, "audit_mode", "false"),
 				),
@@ -48,12 +48,12 @@ func TestAccOctopusDeployBuiltInRateLimitingPolicyUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: builtInRateLimitingPolicyConfig("anon", "anon", true, 5000, 100, false),
-				Check:  resource.TestCheckResourceAttr(resourceName, "requests_per_hour", "5000"),
+				Check:  resource.TestCheckResourceAttr(resourceName, "requests_per_minute", "5000"),
 			},
 			{
 				Config: builtInRateLimitingPolicyConfig("anon", "anon", true, 8000, 200, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "requests_per_hour", "8000"),
+					resource.TestCheckResourceAttr(resourceName, "requests_per_minute", "8000"),
 					resource.TestCheckResourceAttr(resourceName, "burst_limit", "200"),
 					resource.TestCheckResourceAttr(resourceName, "audit_mode", "true"),
 				),
@@ -105,19 +105,19 @@ func TestAccOctopusDeployBuiltInRateLimitingPolicyReplaceOnSlugChange(t *testing
 	})
 }
 
-func builtInRateLimitingPolicyConfig(label, slug string, isEnabled bool, requestsPerHour, burstLimit int, auditMode bool) string {
+func builtInRateLimitingPolicyConfig(label, slug string, isEnabled bool, requestsPerMinute, burstLimit int, auditMode bool) string {
 	return fmt.Sprintf(
 		`resource "octopusdeploy_built_in_rate_limiting_policy" "%[1]s" {
-			slug              = "%[2]s"
-			is_enabled        = %[3]t
-			requests_per_hour = %[4]d
-			burst_limit       = %[5]d
-			audit_mode        = %[6]t
+			slug                = "%[2]s"
+			is_enabled          = %[3]t
+			requests_per_minute = %[4]d
+			burst_limit         = %[5]d
+			audit_mode          = %[6]t
 		}`,
 		label,
 		slug,
 		isEnabled,
-		requestsPerHour,
+		requestsPerMinute,
 		burstLimit,
 		auditMode)
 }

--- a/octopusdeploy_framework/schemas/built_in_rate_limiting_policy.go
+++ b/octopusdeploy_framework/schemas/built_in_rate_limiting_policy.go
@@ -27,8 +27,8 @@ func (s BuiltInRateLimitingPolicySchema) GetResourceSchema() resourceSchema.Sche
 				Description("Whether rate limiting is enforced for this policy.").
 				Required().
 				Build(),
-			"requests_per_hour": util.ResourceInt64().
-				Description("The request rate allowed per hour.").
+			"requests_per_minute": util.ResourceInt64().
+				Description("The request rate allowed per minute.").
 				Required().
 				Validators(int64validator.AtLeast(1)).
 				Build(),
@@ -50,12 +50,12 @@ func (s BuiltInRateLimitingPolicySchema) GetResourceSchema() resourceSchema.Sche
 }
 
 type BuiltInRateLimitingPolicyResourceModel struct {
-	ID              types.String `tfsdk:"id"`
-	Slug            types.String `tfsdk:"slug"`
-	IsEnabled       types.Bool   `tfsdk:"is_enabled"`
-	RequestsPerHour types.Int64  `tfsdk:"requests_per_hour"`
-	BurstLimit      types.Int64  `tfsdk:"burst_limit"`
-	AuditMode       types.Bool   `tfsdk:"audit_mode"`
-	Name            types.String `tfsdk:"name"`
-	ScopeType       types.String `tfsdk:"scope_type"`
+	ID                types.String `tfsdk:"id"`
+	Slug              types.String `tfsdk:"slug"`
+	IsEnabled         types.Bool   `tfsdk:"is_enabled"`
+	RequestsPerMinute types.Int64  `tfsdk:"requests_per_minute"`
+	BurstLimit        types.Int64  `tfsdk:"burst_limit"`
+	AuditMode         types.Bool   `tfsdk:"audit_mode"`
+	Name              types.String `tfsdk:"name"`
+	ScopeType         types.String `tfsdk:"scope_type"`
 }

--- a/octopusdeploy_framework/testing_container_test.go
+++ b/octopusdeploy_framework/testing_container_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 				"OCTOPUS__FeatureToggles__DeploymentFreezeByTenantFeatureToggle": "true",
 				"OCTOPUS__FeatureToggles__ExternalOidcFeedsFeatureToggle":        "true",
 				"OCTOPUS__FeatureToggles__RateLimitingV2FeatureToggle":           "true",
+				"DISABLE_RATE_LIMITING":                                          "Y",
 			},
 		}
 


### PR DESCRIPTION
On the server side, we changed requests per hour to requests per minute before releasing the rate limiting feature, so this PR makes the corresponding changes to the Terraform provider.