### PR TITLE
fix: stop team update from deleting externally-managed scoped user roles

### DIFF
--- a/octopusdeploy_framework/resource_team.go
+++ b/octopusdeploy_framework/resource_team.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -54,7 +55,8 @@ func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	if err := r.updateUserRoles(ctx, plan, createdTeam); err != nil {
+	// On create there are no previously-managed roles, so nothing is eligible for removal.
+	if err := r.updateUserRoles(ctx, plan, createdTeam, types.SetNull(userRoleObjectType)); err != nil {
 		resp.Diagnostics.AddError("Error updating user roles for team", err.Error())
 		return
 	}
@@ -83,8 +85,9 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan schemas.TeamModel
+	var plan, state schemas.TeamModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -96,13 +99,14 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	if err := r.updateUserRoles(ctx, plan, updatedTeam); err != nil {
+	// Pass the prior state's user roles so removals are limited to roles this resource owned.
+	if err := r.updateUserRoles(ctx, plan, updatedTeam, state.UserRole); err != nil {
 		resp.Diagnostics.AddError("Error updating user roles for team", err.Error())
 		return
 	}
 
-	state := mapTeamResourceToState(ctx, updatedTeam, plan, r.Client)
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	newState := mapTeamResourceToState(ctx, updatedTeam, plan, r.Client)
+	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
 
 func (r *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -123,7 +127,7 @@ func (*teamResource) ImportState(ctx context.Context, req resource.ImportStateRe
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *teamResource) updateUserRoles(ctx context.Context, model schemas.TeamModel, team *teams.Team) error {
+func (r *teamResource) updateUserRoles(ctx context.Context, model schemas.TeamModel, team *teams.Team, previousUserRoles types.Set) error {
 	newUserRoles := mapUserRoleSetStateToResource(ctx, team, model.UserRole)
 
 	existingUserRoles, err := r.Client.Teams.GetScopedUserRoles(*team, core.SkipTakeQuery{})
@@ -131,8 +135,12 @@ func (r *teamResource) updateUserRoles(ctx context.Context, model schemas.TeamMo
 		return fmt.Errorf("error getting existing user roles for team %s: %s", team.ID, err)
 	}
 
+	// Only remove roles previously managed by this team resource; leave roles managed by standalone
+	// octopusdeploy_scoped_user_role resources untouched (mirrors the read-path filter, see #180)
+	removableUserRoles := filterUserRolesByPreviousState(ctx, existingUserRoles.Items, previousUserRoles)
+
 	userRolesToAdd := findAddedScopedUserRoles(newUserRoles, existingUserRoles.Items)
-	userRolesToRemove := findRemovedScopedUserRoles(newUserRoles, existingUserRoles.Items)
+	userRolesToRemove := findRemovedScopedUserRoles(newUserRoles, removableUserRoles)
 	userRolesToEdit := findModifiedScopedUserRoles(newUserRoles, existingUserRoles.Items)
 
 	for _, userRole := range userRolesToAdd {

--- a/octopusdeploy_framework/resource_team.go
+++ b/octopusdeploy_framework/resource_team.go
@@ -135,12 +135,10 @@ func (r *teamResource) updateUserRoles(ctx context.Context, model schemas.TeamMo
 		return fmt.Errorf("error getting existing user roles for team %s: %s", team.ID, err)
 	}
 
-	// Only remove roles previously managed by this team resource; leave roles managed by standalone
-	// octopusdeploy_scoped_user_role resources untouched (mirrors the read-path filter, see #180)
-	removableUserRoles := filterUserRolesByPreviousState(ctx, existingUserRoles.Items, previousUserRoles)
-
 	userRolesToAdd := findAddedScopedUserRoles(newUserRoles, existingUserRoles.Items)
-	userRolesToRemove := findRemovedScopedUserRoles(newUserRoles, removableUserRoles)
+	// Only remove roles previously managed by this team resource; roles managed by standalone
+	// octopusdeploy_scoped_user_role resources are never previously-owned and are left untouched (#180)
+	userRolesToRemove := scopedUserRolesToRemove(newUserRoles, existingUserRoles.Items, previousUserRoles)
 	userRolesToEdit := findModifiedScopedUserRoles(newUserRoles, existingUserRoles.Items)
 
 	for _, userRole := range userRolesToAdd {
@@ -189,6 +187,15 @@ func findRemovedScopedUserRoles(newRoles, existingRoles []*userroles.ScopedUserR
 	return util.SliceFilter(existingRoles, func(existingRole *userroles.ScopedUserRole) bool {
 		return !util.SliceContains(newUserRoleIds, existingRole.ID)
 	})
+}
+
+// scopedUserRolesToRemove returns the roles a team update should delete: the roles this resource previously
+// managed (per prior state) that are no longer in the desired config. Removal candidates are narrowed to
+// previously-owned roles first, so roles managed by standalone octopusdeploy_scoped_user_role resources are
+// never deleted by a team create/update (#180).
+func scopedUserRolesToRemove(newUserRoles, existingUserRoles []*userroles.ScopedUserRole, previousUserRoles types.Set) []*userroles.ScopedUserRole {
+	removableUserRoles := filterRemovableUserRoles(previousUserRoles, existingUserRoles)
+	return findRemovedScopedUserRoles(newUserRoles, removableUserRoles)
 }
 
 // findModifiedScopedUserRoles returns roles from the first slice that have matching IDs in the second slice

--- a/octopusdeploy_framework/resource_team_mappers.go
+++ b/octopusdeploy_framework/resource_team_mappers.go
@@ -232,6 +232,38 @@ func mapUserRoleSetResourceToState(ctx context.Context, userRoles []*userroles.S
 	return types.SetValueMust(userRoleObjectType, roleList)
 }
 
+// collectManagedUserRoleIDs returns the scoped-user-role ids recorded in prior state, and whether any element
+// carried a null/unknown id (ownership cannot be positively determined for those elements).
+func collectManagedUserRoleIDs(previousUserRolesState types.Set) (map[string]bool, bool) {
+	previouslyManagedIDs := make(map[string]bool)
+	hasUnknownIds := false
+
+	for _, element := range previousUserRolesState.Elements() {
+		objElement, ok := element.(types.Object)
+		if !ok {
+			continue
+		}
+		idAttr, exists := objElement.Attributes()["id"]
+		if !exists {
+			continue
+		}
+		idStr, ok := idAttr.(types.String)
+		if !ok {
+			continue
+		}
+		if idStr.IsNull() || idStr.IsUnknown() {
+			hasUnknownIds = true
+			continue
+		}
+		previouslyManagedIDs[idStr.ValueString()] = true
+	}
+
+	return previouslyManagedIDs, hasUnknownIds
+}
+
+// filterUserRolesByPreviousState is the read-path filter: it hides roles this resource did not manage from
+// state. When ownership is indeterminate (unknown state or a missing id), it deliberately returns every server
+// role so the refresh shows what exists. Do not use it to decide deletions, see filterRemovableUserRoles.
 func filterUserRolesByPreviousState(ctx context.Context, serverUserRoles []*userroles.ScopedUserRole, previousUserRolesState types.Set) []*userroles.ScopedUserRole {
 	if previousUserRolesState.IsNull() {
 		return []*userroles.ScopedUserRole{}
@@ -241,36 +273,9 @@ func filterUserRolesByPreviousState(ctx context.Context, serverUserRoles []*user
 		return serverUserRoles
 	}
 
-	previousElements := previousUserRolesState.Elements()
-
-	hasUnknownIds := false
-	for _, element := range previousElements {
-		if objElement, ok := element.(types.Object); ok {
-			attributes := objElement.Attributes()
-			if idAttr, exists := attributes["id"]; exists {
-				if idStr, ok := idAttr.(types.String); ok && (idStr.IsNull() || idStr.IsUnknown()) {
-					hasUnknownIds = true
-					break
-				}
-			}
-		}
-	}
-
+	previouslyManagedIDs, hasUnknownIds := collectManagedUserRoleIDs(previousUserRolesState)
 	if hasUnknownIds {
 		return serverUserRoles
-	}
-
-	previouslyManagedIDs := make(map[string]bool)
-
-	for _, element := range previousElements {
-		if objElement, ok := element.(types.Object); ok {
-			attributes := objElement.Attributes()
-			if idAttr, exists := attributes["id"]; exists {
-				if idStr, ok := idAttr.(types.String); ok && !idStr.IsNull() && !idStr.IsUnknown() {
-					previouslyManagedIDs[idStr.ValueString()] = true
-				}
-			}
-		}
 	}
 
 	var managedUserRoles []*userroles.ScopedUserRole
@@ -281,4 +286,25 @@ func filterUserRolesByPreviousState(ctx context.Context, serverUserRoles []*user
 	}
 
 	return managedUserRoles
+}
+
+// filterRemovableUserRoles is the write-path filter: it returns only the server roles this resource can
+// positively confirm it previously managed (their id appears in prior state), so those are the only roles a
+// team update may delete. Unlike the read-path fallback, an indeterminate prior state (null, unknown, or a
+// missing/unknown id) yields no removable roles, so an update can never delete a role it did not own (#180).
+func filterRemovableUserRoles(previousUserRolesState types.Set, serverUserRoles []*userroles.ScopedUserRole) []*userroles.ScopedUserRole {
+	if previousUserRolesState.IsNull() || previousUserRolesState.IsUnknown() {
+		return nil
+	}
+
+	previouslyManagedIDs, _ := collectManagedUserRoleIDs(previousUserRolesState)
+
+	var removableUserRoles []*userroles.ScopedUserRole
+	for _, serverRole := range serverUserRoles {
+		if serverRole.ID != "" && previouslyManagedIDs[serverRole.ID] {
+			removableUserRoles = append(removableUserRoles, serverRole)
+		}
+	}
+
+	return removableUserRoles
 }

--- a/octopusdeploy_framework/resource_team_mappers_test.go
+++ b/octopusdeploy_framework/resource_team_mappers_test.go
@@ -110,3 +110,69 @@ func TestFilterUserRolesByPreviousState(t *testing.T) {
 		assert.Empty(t, result, "Should filter out roles that were not previously managed by the team")
 	})
 }
+
+// TestUpdateUserRolesRemovalOwnership guards updateUserRoles' removal-candidate selection.
+// Regression test for #180: updating a team must not delete externally-managed scoped user roles.
+func TestUpdateUserRolesRemovalOwnership(t *testing.T) {
+	ctx := context.Background()
+
+	newRole := func(id, userRoleID string) *userroles.ScopedUserRole {
+		r := userroles.NewScopedUserRole(userRoleID)
+		r.ID = id
+		return r
+	}
+
+	previousStateWithIDs := func(ids ...string) types.Set {
+		elems := make([]attr.Value, 0, len(ids))
+		for _, id := range ids {
+			elems = append(elems, types.ObjectValueMust(userRoleObjectType.AttrTypes, map[string]attr.Value{
+				"id":                types.StringValue(id),
+				"user_role_id":      types.StringValue("user-role-for-" + id),
+				"space_id":          types.StringValue("Spaces-1"),
+				"team_id":           types.StringValue("Teams-1"),
+				"environment_ids":   types.SetNull(types.StringType),
+				"project_group_ids": types.SetNull(types.StringType),
+				"project_ids":       types.SetNull(types.StringType),
+				"tenant_ids":        types.SetNull(types.StringType),
+			}))
+		}
+		return types.SetValueMust(userRoleObjectType, elems)
+	}
+
+	removalIDs := func(newUserRoles, serverRoles []*userroles.ScopedUserRole, previous types.Set) map[string]bool {
+		removable := filterUserRolesByPreviousState(ctx, serverRoles, previous)
+		toRemove := findRemovedScopedUserRoles(newUserRoles, removable)
+		ids := make(map[string]bool)
+		for _, r := range toRemove {
+			ids[r.ID] = true
+		}
+		return ids
+	}
+
+	t.Run("ShouldNotRemoveExternallyManagedRolesWhenTeamHasNoInlineRoles", func(t *testing.T) {
+		// Team resource declares no user_role blocks (newUserRoles empty) and never managed any
+		// (previous state null). All roles on the server belong to standalone resources.
+		external := []*userroles.ScopedUserRole{newRole("role-1", "ur-1"), newRole("role-2", "ur-2")}
+
+		ids := removalIDs(nil, external, types.SetNull(userRoleObjectType))
+		assert.Empty(t, ids, "must not delete scoped user roles managed outside the team resource")
+	})
+
+	t.Run("ShouldRemoveOnlyPreviouslyOwnedRolesDroppedFromConfig", func(t *testing.T) {
+		// Inline user_role user previously owned role-a and role-b, now keeps only role-a.
+		// role-ext is a standalone-managed role that also lives on the team.
+		roleA := newRole("role-a", "ur-a")
+		roleB := newRole("role-b", "ur-b")
+		roleExt := newRole("role-ext", "ur-ext")
+
+		newUserRoles := []*userroles.ScopedUserRole{roleA}
+		serverRoles := []*userroles.ScopedUserRole{roleA, roleB, roleExt}
+
+		ids := removalIDs(newUserRoles, serverRoles, previousStateWithIDs("role-a", "role-b"))
+
+		assert.True(t, ids["role-b"], "should remove role-b (previously owned, dropped from config)")
+		assert.False(t, ids["role-ext"], "must not remove externally-managed role-ext")
+		assert.False(t, ids["role-a"], "must not remove role-a (still in config)")
+		assert.Len(t, ids, 1)
+	})
+}

--- a/octopusdeploy_framework/resource_team_mappers_test.go
+++ b/octopusdeploy_framework/resource_team_mappers_test.go
@@ -111,11 +111,10 @@ func TestFilterUserRolesByPreviousState(t *testing.T) {
 	})
 }
 
-// TestUpdateUserRolesRemovalOwnership guards updateUserRoles' removal-candidate selection.
-// Regression test for #180: updating a team must not delete externally-managed scoped user roles.
+// TestUpdateUserRolesRemovalOwnership guards scopedUserRolesToRemove, the exact removal-candidate selection
+// updateUserRoles uses. Regression test for #180: updating a team must not delete externally-managed scoped
+// user roles, and must still delete roles it previously owned that are dropped from config.
 func TestUpdateUserRolesRemovalOwnership(t *testing.T) {
-	ctx := context.Background()
-
 	newRole := func(id, userRoleID string) *userroles.ScopedUserRole {
 		r := userroles.NewScopedUserRole(userRoleID)
 		r.ID = id
@@ -140,8 +139,7 @@ func TestUpdateUserRolesRemovalOwnership(t *testing.T) {
 	}
 
 	removalIDs := func(newUserRoles, serverRoles []*userroles.ScopedUserRole, previous types.Set) map[string]bool {
-		removable := filterUserRolesByPreviousState(ctx, serverRoles, previous)
-		toRemove := findRemovedScopedUserRoles(newUserRoles, removable)
+		toRemove := scopedUserRolesToRemove(newUserRoles, serverRoles, previous)
 		ids := make(map[string]bool)
 		for _, r := range toRemove {
 			ids[r.ID] = true

--- a/octopusdeploy_framework/resource_team_test.go
+++ b/octopusdeploy_framework/resource_team_test.go
@@ -339,6 +339,72 @@ resource "octopusdeploy_scoped_user_role" "test_role" {
 }`, userRoleName, teamName, description, spaceID, spaceID)
 }
 
+// Over-correction guard for #180: dropping an inline user_role on update must still delete that role
+// server-side. The ownership narrowing must not stop removing roles the team resource genuinely owned.
+func TestAccOctopusDeployTeamUpdateRemovesDroppedInlineUserRole(t *testing.T) {
+	teamName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	space := NewTestSpace(t)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccTeamCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamWithInlineUserRoles(teamName, space.ID, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("octopusdeploy_team.test_team", "user_role.#", "2"),
+				),
+			},
+			// Drop one inline user_role; the previously-owned role must be removed, leaving exactly one.
+			{
+				Config: testAccTeamWithInlineUserRoles(teamName, space.ID, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("octopusdeploy_team.test_team", "user_role.#", "1"),
+				),
+			},
+			{
+				Config:             testAccTeamWithInlineUserRoles(teamName, space.ID, false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccTeamWithInlineUserRoles(teamName, spaceID string, includeSecond bool) string {
+	secondRole := ""
+	if includeSecond {
+		secondRole = fmt.Sprintf(`
+	user_role {
+		space_id     = "%s"
+		user_role_id = octopusdeploy_user_role.role_b.id
+	}`, spaceID)
+	}
+
+	return providerSpaceConfig(spaceID) + fmt.Sprintf(`
+resource "octopusdeploy_user_role" "role_a" {
+	name                      = "%[1]s-a"
+	granted_space_permissions = ["EnvironmentView"]
+}
+
+resource "octopusdeploy_user_role" "role_b" {
+	name                      = "%[1]s-b"
+	granted_space_permissions = ["EnvironmentView"]
+}
+
+resource "octopusdeploy_team" "test_team" {
+	name        = "%[1]s"
+	description = "inline user role removal test"
+	space_id    = "%[2]s"
+
+	user_role {
+		space_id     = "%[2]s"
+		user_role_id = octopusdeploy_user_role.role_a.id
+	}%[3]s
+}`, teamName, spaceID, secondRole)
+}
+
 func testAccTeamImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/octopusdeploy_framework/resource_team_test.go
+++ b/octopusdeploy_framework/resource_team_test.go
@@ -284,6 +284,61 @@ resource "octopusdeploy_scoped_user_role" "test_role" {
 }`, userRoleName, teamName, spaceID, spaceID)
 }
 
+// Regression test for #180: a team update must not delete a standalone scoped user role.
+func TestAccOctopusDeployTeamUpdateKeepsStandaloneScopedUserRole(t *testing.T) {
+	teamName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	userRoleName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	space := NewTestSpace(t)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccTeamCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamWithStandaloneScopedUserRoleConfigDesc(teamName, userRoleName, space.ID, "before update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("octopusdeploy_scoped_user_role.test_role", "id"),
+				),
+			},
+			// Change the team description to force a team update; the standalone role must survive
+			{
+				Config: testAccTeamWithStandaloneScopedUserRoleConfigDesc(teamName, userRoleName, space.ID, "after update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("octopusdeploy_team.test_team", "description", "after update"),
+					resource.TestCheckResourceAttrSet("octopusdeploy_scoped_user_role.test_role", "id"),
+				),
+			},
+			{
+				Config:             testAccTeamWithStandaloneScopedUserRoleConfigDesc(teamName, userRoleName, space.ID, "after update"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccTeamWithStandaloneScopedUserRoleConfigDesc(teamName, userRoleName, spaceID, description string) string {
+	return providerSpaceConfig(spaceID) + fmt.Sprintf(`
+resource "octopusdeploy_user_role" "test_user_role" {
+	name = "%s"
+	description = "Test user role"
+	granted_space_permissions = ["EnvironmentView"]
+}
+
+resource "octopusdeploy_team" "test_team" {
+	name        = "%s"
+	description = "%s"
+	space_id    = "%s"
+}
+
+resource "octopusdeploy_scoped_user_role" "test_role" {
+	team_id      = octopusdeploy_team.test_team.id
+	user_role_id = octopusdeploy_user_role.test_user_role.id
+	space_id     = "%s"
+}`, userRoleName, teamName, description, spaceID, spaceID)
+}
+
 func testAccTeamImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/octopusdeploy_framework/resource_team_test.go
+++ b/octopusdeploy_framework/resource_team_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -341,6 +342,8 @@ resource "octopusdeploy_scoped_user_role" "test_role" {
 
 // Over-correction guard for #180: dropping an inline user_role on update must still delete that role
 // server-side. The ownership narrowing must not stop removing roles the team resource genuinely owned.
+// The scoped-user-role count is asserted against the server API rather than Terraform state, because the
+// read path filters roles out of state and would otherwise hide a role that leaked server-side.
 func TestAccOctopusDeployTeamUpdateRemovesDroppedInlineUserRole(t *testing.T) {
 	teamName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	space := NewTestSpace(t)
@@ -354,13 +357,15 @@ func TestAccOctopusDeployTeamUpdateRemovesDroppedInlineUserRole(t *testing.T) {
 				Config: testAccTeamWithInlineUserRoles(teamName, space.ID, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("octopusdeploy_team.test_team", "user_role.#", "2"),
+					testAccCheckTeamScopedUserRoleCount("octopusdeploy_team.test_team", 2),
 				),
 			},
-			// Drop one inline user_role; the previously-owned role must be removed, leaving exactly one.
+			// Drop one inline user_role; the previously-owned role must be removed server-side, leaving one.
 			{
 				Config: testAccTeamWithInlineUserRoles(teamName, space.ID, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("octopusdeploy_team.test_team", "user_role.#", "1"),
+					testAccCheckTeamScopedUserRoleCount("octopusdeploy_team.test_team", 1),
 				),
 			},
 			{
@@ -370,6 +375,33 @@ func TestAccOctopusDeployTeamUpdateRemovesDroppedInlineUserRole(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testAccCheckTeamScopedUserRoleCount asserts the number of scoped user roles attached to the team on the
+// server, bypassing Terraform state so a role that leaked server-side cannot be masked by the read filter.
+func testAccCheckTeamScopedUserRoleCount(resourceName string, expected int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		team, err := octoClient.Teams.GetByID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error retrieving team %s: %w", rs.Primary.ID, err)
+		}
+
+		roles, err := octoClient.Teams.GetScopedUserRoles(*team, core.SkipTakeQuery{})
+		if err != nil {
+			return fmt.Errorf("error retrieving scoped user roles for team %s: %w", rs.Primary.ID, err)
+		}
+
+		if len(roles.Items) != expected {
+			return fmt.Errorf("expected %d scoped user role(s) on team %s, got %d", expected, rs.Primary.ID, len(roles.Items))
+		}
+
+		return nil
+	}
 }
 
 func testAccTeamWithInlineUserRoles(teamName, spaceID string, includeSecond bool) string {


### PR DESCRIPTION
Original [PR](https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/235) by @fv-nhastings recreated here to handle GH Actions auth issues with the forked repository. Fork PRs run with no secret access, so the acceptance-test jobs can't fetch the license or pull the Octopus container image. Commits & contribution preserved.

## What

Stops the `octopusdeploy_team` resource from deleting scoped user roles that are managed **outside** the team resource (i.e. via standalone `octopusdeploy_scoped_user_role` resources) whenever the team is created or updated.

Fixes #180. Follow-up to #100 / #105.
[HPY-1493](https://linear.app/octopus/issue/HPY-1493/sev-2-medium-or-a-bug-with-the-tf-provider)
## Why

`updateUserRoles` (called on every team `Create`/`Update`) reconciled the team's scoped user roles by:

1. building `newUserRoles` from the team's own inline `user_role` blocks,
2. fetching **all** scoped user roles attached to the team on the server, and
3. deleting every server role not present in `newUserRoles`.

When a team is managed without inline `user_role` blocks (roles managed by standalone `octopusdeploy_scoped_user_role` resources), `newUserRoles` is empty, so step 3 deletes **every** scoped user role attached to the team. Terraform then detects the standalone resources as missing on the next refresh and recreates them — requiring 2+ applies to converge, or looping indefinitely if the team drifts on every apply.

PR #105 addressed the symptom on the **read/refresh** path (`filterUserRolesByPreviousState` in `mapTeamResourceToState`), but the **write** path in `resource_team.go::updateUserRoles` was never given the equivalent ownership check, so the deletion persisted (re-reported in #180).

## How

Apply the same ownership filter to removals. Removal candidates are now drawn only from roles this team resource **previously managed** (derived from prior state via the existing `filterUserRolesByPreviousState` helper), rather than from every role on the server:

- `Update` now reads `req.State` and passes the prior `user_role` set into `updateUserRoles`.
- `Create` passes a null set (nothing was previously managed, so nothing is removable — and a freshly created team has no pre-existing roles anyway).
- `findRemovedScopedUserRoles` is now fed the filtered "previously managed" set instead of all server roles.

Add/edit behavior is unchanged; only the removal set is narrowed. Roles managed by inline `user_role` blocks continue to be added/removed/edited exactly as before.

## Tests

**Unit** — `TestUpdateUserRolesRemovalOwnership` covering the removal-candidate selection:

- team with no inline `user_role` blocks → externally-managed roles are **not** selected for removal (the #180 case);
- inline-`user_role` team that drops one role from config → only that previously-owned role is removed, while an externally-managed role on the same team is left untouched.

**Acceptance** — `TestAccOctopusDeployTeamUpdateKeepsStandaloneScopedUserRole`: creates a team with a standalone `octopusdeploy_scoped_user_role`, changes the team's description to force a team update, and asserts an empty follow-up plan (the role survives). The pre-existing `TestAccOctopusDeployTeamScopedUserRoleNoConflict` never updated the team after adding the standalone role, so it did not exercise this path.

Validated red→green against a live Octopus instance: the new acceptance test fails on the unpatched code (post-update refresh plan shows `octopusdeploy_scoped_user_role ... will be created`, `Plan: 1 to add`) and passes with the fix. Existing `TestFilterUserRolesByPreviousState` continues to pass. `gofmt` clean; `go vet` clean.