### PR TITLE
fix: nil dereference and misleading diagnostics in feed and rate limiting resources

### DIFF
--- a/octopusdeploy_framework/resource_azure_container_registry.go
+++ b/octopusdeploy_framework/resource_azure_container_registry.go
@@ -253,12 +253,12 @@ func updateDataFromDockerContainerRegistryFeedForACR(data *schemas.AzureContaine
 // has been updated first.
 func ensureFeedIsAzureContainerRegistry(ctx context.Context, data *schemas.AzureContainerRegistryFeedTypeResourceModel, client *client.Client, resp *resource.UpdateResponse) error {
 	currentFeed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
-	if currentFeed.GetFeedType() == "Docker" {
-		if err != nil {
-			resp.Diagnostics.AddError("unable to load Azure Container Registry feed", err.Error())
-			return err
-		}
+	if err != nil {
+		resp.Diagnostics.AddError("unable to load Azure Container Registry feed", err.Error())
+		return err
+	}
 
+	if currentFeed.GetFeedType() == "Docker" {
 		newAcrFeed, err := feeds.NewAzureContainerRegistry(
 			currentFeed.GetName(),
 			currentFeed.GetUsername(),

--- a/octopusdeploy_framework/resource_built_in_rate_limiting_policy.go
+++ b/octopusdeploy_framework/resource_built_in_rate_limiting_policy.go
@@ -2,9 +2,11 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/ratelimitingpolicies"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
@@ -65,7 +67,14 @@ func (r *builtInRateLimitingPolicyResource) findPolicyBySlug(slug string) (*rate
 
 	list, err := ratelimitingpolicies.List(r.Client, ratelimitingpolicies.ListRateLimitingPoliciesRequest{Take: math.MaxInt32})
 	if err != nil {
-		return nil, err
+		// An instance that does not serve this endpoint answers 404 with no JSON body, which
+		// the client turns into an APIError carrying no message at all. Left alone that reaches
+		// the practitioner as "Octopus API error:  []", so name the likely cause instead.
+		var apiErr *core.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorMessage == "" && len(apiErr.Errors) == 0 {
+			return nil, fmt.Errorf("the rate limiting policies endpoint is not available on this Octopus instance; it requires Octopus Server 2026.3 or later and is not offered on every hosting type")
+		}
+		return nil, fmt.Errorf("unable to list rate limiting policies: %w", err)
 	}
 
 	for i := range list.Items {

--- a/octopusdeploy_framework/resource_google_container_registry.go
+++ b/octopusdeploy_framework/resource_google_container_registry.go
@@ -245,12 +245,12 @@ func updateDataFromDockerContainerRegistryFeedForGCR(data *schemas.GoogleContain
 // has been updated first.
 func ensureFeedIsGCR(ctx context.Context, data *schemas.GoogleContainerRegistryFeedTypeResourceModel, client *client.Client, resp *resource.UpdateResponse) error {
 	currentFeed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
-	if currentFeed.GetFeedType() == "Docker" {
-		if err != nil {
-			resp.Diagnostics.AddError("unable to load Google Container Registry feed", err.Error())
-			return err
-		}
+	if err != nil {
+		resp.Diagnostics.AddError("unable to load Google Container Registry feed", err.Error())
+		return err
+	}
 
+	if currentFeed.GetFeedType() == "Docker" {
 		newGcrFeed, err := feeds.NewGoogleContainerRegistry(
 			currentFeed.GetName(),
 			currentFeed.GetUsername(),
@@ -274,10 +274,10 @@ func ensureFeedIsGCR(ctx context.Context, data *schemas.GoogleContainerRegistryF
 
 		_, err = feeds.Update(client, newGcrFeed)
 		if err != nil {
-			resp.Diagnostics.AddError("unable to update feed type to Azure Container Registry", err.Error())
+			resp.Diagnostics.AddError("unable to update feed type to Google Container Registry", err.Error())
 			return err
 		}
-		tflog.Info(ctx, fmt.Sprintf("Feed type updated from Docker to Azure Container Registry (%s)", dockerFeed.ID))
+		tflog.Info(ctx, fmt.Sprintf("Feed type updated from Docker to Google Container Registry (%s)", dockerFeed.ID))
 		return nil
 	}
 	return nil

--- a/octopusdeploy_framework/resource_team_mappers.go
+++ b/octopusdeploy_framework/resource_team_mappers.go
@@ -87,25 +87,18 @@ func mapTeamResourceToState(ctx context.Context, team *teams.Team, model schemas
 
 	// Temporary workaround to avoid errors due to differences in validation behaviour between SDKv2 and TPF providers.
 	// TODO: mark as read-only after deprecation phase.
+	// A known value is left as the practitioner configured it.
 	if model.CanBeDeleted.IsUnknown() {
 		model.CanBeDeleted = types.BoolNull()
-	} else {
-		model.CanBeDeleted = model.CanBeDeleted
 	}
 	if model.CanBeRenamed.IsUnknown() {
 		model.CanBeRenamed = types.BoolNull()
-	} else {
-		model.CanBeRenamed = model.CanBeRenamed
 	}
 	if model.CanChangeMembers.IsUnknown() {
 		model.CanChangeMembers = types.BoolNull()
-	} else {
-		model.CanChangeMembers = model.CanChangeMembers
 	}
 	if model.CanChangeRoles.IsUnknown() {
 		model.CanChangeRoles = types.BoolNull()
-	} else {
-		model.CanChangeRoles = model.CanChangeRoles
 	}
 
 	userRoles, err := client.Teams.GetScopedUserRoles(*team, core.SkipTakeQuery{})


### PR DESCRIPTION
Defects found while triaging a full acceptance-suite run.

`ensureFeedIsAzureContainerRegistry` and `ensureFeedIsGCR` both called `currentFeed.GetFeedType()` before checking the error returned by `feeds.GetByID`. Any failure to load the feed panicked instead of reporting the error. The error check now comes first.

The GCR migration path reported failures as "unable to update feed type to Azure Container Registry", naming the wrong registry in both the diagnostic and the trace log.

An instance that does not serve `/api/ratelimitingpolicies` answers 404 with no body, and the client turns that into an `APIError` with no message. Practitioners saw `Octopus API error:  []` and nothing else. The resource now names the likely cause.

`resource_team_mappers.go` assigned four fields to themselves, which `go vet` flags. A known value is already left untouched, so the redundant `else` branches are gone. `go vet ./octopusdeploy_framework/...` reported four warnings before this change and reports none after.

## Testing

`go build ./...` and `go vet ./octopusdeploy_framework/...` are clean. All eight team acceptance tests pass, including `TestTeamResource_UpgradeFromSDK_ToPluginFramework`, which is the one most sensitive to the mapper change.

I could not exercise the container registry migration path end to end. Feed creation on the test instance needed permissions the test account did not have. Those two changes are a reordered error check and two diagnostic strings.

## Not addressed here

`ensureFeedIsAzureContainerRegistry` uses an in-place `feeds.Update` to change a feed's type, and the comment concedes this depends on the server "inadvertently" allowing it. Current servers reject the change, so upgrades from provider 0.39.0 and earlier look stuck. Fixing it properly means marking the type change `RequiresReplace`, which destroys and recreates a real feed. That is a behaviour change worth discussing separately.

`built_in_rate_limiting_policy` gates on server version `2026.3`, but a 2026.3.7872 instance does not serve the endpoint at all. The gate probably should be a feature toggle. I did not want to guess at a toggle name.