### PR TITLE
fix: allow variable binding defaults on sensitive step template parameters

### DIFF
--- a/docs/data-sources/community_step_template.md
+++ b/docs/data-sources/community_step_template.md
@@ -88,8 +88,8 @@ Required:
 
 Optional:
 
-- `default_sensitive_value` (String, Sensitive) Use this attribute to set a sensitive default value for the parameter when display settings are set to 'Sensitive'
-- `default_value` (String) A default value for the parameter, if applicable. This can be a hard-coded value or a variable reference.
+- `default_sensitive_value` (String, Sensitive) Use this attribute to set a literal secret as the default value for the parameter when display settings are set to 'Sensitive'. Do not use it for a variable reference such as '#{MyVariable}': the reference would be stored encrypted and would never resolve. Use 'default_value' for that instead.
+- `default_value` (String) A default value for the parameter, if applicable. This can be a hard-coded value or a variable reference such as '#{MyVariable}'. Use this attribute for a variable reference even when display settings are set to 'Sensitive', because Octopus stores the reference itself rather than the secret it points at.
 - `display_settings` (Map of String) The display settings for the parameter.
 - `help_text` (String) The help presented alongside the parameter input.
 - `label` (String) The label shown beside the parameter when presented in the deployment process. Example: `Server name`.

--- a/docs/resources/step_template.md
+++ b/docs/resources/step_template.md
@@ -130,8 +130,8 @@ Required:
 
 Optional:
 
-- `default_sensitive_value` (String, Sensitive) Use this attribute to set a sensitive default value for the parameter when display settings are set to 'Sensitive'
-- `default_value` (String) A default value for the parameter, if applicable. This can be a hard-coded value or a variable reference.
+- `default_sensitive_value` (String, Sensitive) Use this attribute to set a literal secret as the default value for the parameter when display settings are set to 'Sensitive'. Do not use it for a variable reference such as '#{MyVariable}': the reference would be stored encrypted and would never resolve. Use 'default_value' for that instead.
+- `default_value` (String) A default value for the parameter, if applicable. This can be a hard-coded value or a variable reference such as '#{MyVariable}'. Use this attribute for a variable reference even when display settings are set to 'Sensitive', because Octopus stores the reference itself rather than the secret it points at.
 - `display_settings` (Map of String) The display settings for the parameter.
 - `help_text` (String) The help presented alongside the parameter input.
 - `label` (String) The label shown beside the parameter when presented in the deployment process. Example: `Server name`.

--- a/octopusdeploy_framework/resource_step_template.go
+++ b/octopusdeploy_framework/resource_step_template.go
@@ -3,6 +3,8 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
@@ -554,10 +556,24 @@ func validateStepTemplateParameterDefaultValue(param schemas.StepTemplateParamet
 	hasPlainValue := !param.DefaultValue.IsNull() && !param.DefaultValue.IsUnknown() && param.DefaultValue.ValueString() != ""
 	hasSensitiveValue := !param.DefaultSensitiveValue.IsNull() && !param.DefaultSensitiveValue.IsUnknown()
 
-	if isSensitive && hasPlainValue {
+	// Only one of the two attributes reaches the server: convertStepTemplateToParameters
+	// prefers 'default_sensitive_value' whenever it is set, silently dropping 'default_value'.
+	if isSensitive && hasPlainValue && hasSensitiveValue {
 		diags.AddError(
 			"Invalid step template parameter configuration",
-			fmt.Sprintf("Parameter '%s' has display setting 'Octopus.ControlType=Sensitive' but uses 'default_value' instead of 'default_sensitive_value'. Sensitive parameters should use the 'default_sensitive_value' attribute.", param.Name.ValueString()),
+			fmt.Sprintf("Parameter '%s' sets both 'default_value' and 'default_sensitive_value'. Set only one: 'default_value' for a variable binding such as '#{MyVariable}', or 'default_sensitive_value' for a literal secret.", param.Name.ValueString()),
+		)
+
+		return diags
+	}
+
+	// A variable binding is a pointer to a secret rather than a secret itself, so Octopus stores
+	// it as a plain value - that is what the Octopus UI writes for a sensitive parameter, and
+	// wrapping it as a sensitive value would encrypt the binding text so it never resolves.
+	if isSensitive && hasPlainValue && !isVariableBinding(param.DefaultValue.ValueString()) {
+		diags.AddWarning(
+			"Step template parameter may expose a secret",
+			fmt.Sprintf("Parameter '%s' has display setting 'Octopus.ControlType=Sensitive' and a literal 'default_value', which is stored unencrypted in Octopus and in Terraform state. Use 'default_sensitive_value' for a literal secret, or 'default_value' with a variable binding such as '#{MyVariable}'.", param.Name.ValueString()),
 		)
 
 		return diags
@@ -571,4 +587,11 @@ func validateStepTemplateParameterDefaultValue(param schemas.StepTemplateParamet
 	}
 
 	return diags
+}
+
+// isVariableBinding reports whether a default value contains an Octopus variable binding
+// expression. It only informs a warning, so partial bindings such as "prefix-#{MyVariable}"
+// are deliberately treated the same as a whole-value binding.
+func isVariableBinding(value string) bool {
+	return strings.Contains(value, "#{")
 }

--- a/octopusdeploy_framework/resource_step_template_mapping_test.go
+++ b/octopusdeploy_framework/resource_step_template_mapping_test.go
@@ -367,7 +367,8 @@ func TestStepTemplateParametersValidationWhenNonSensitiveDefaultValueSetForSensi
 
 	// Act
 	diags := validateStepTemplateParameters(ctx, &state)
-	assert.Equal(t, 1, len(diags.Errors()), "Expected diagnostics to contain errors")
+	assert.Equal(t, 0, len(diags.Errors()), "Expected a literal sensitive default to warn rather than error")
+	assert.Equal(t, 1, len(diags.Warnings()), "Expected diagnostics to contain a warning")
 }
 
 func TestStepTemplateParametersValidationWhenSensitiveDefaultValueSetForNonSensitiveControlType(t *testing.T) {

--- a/octopusdeploy_framework/resource_step_template_test.go
+++ b/octopusdeploy_framework/resource_step_template_test.go
@@ -117,6 +117,72 @@ func TestAccOctopusStepTemplateBasic(t *testing.T) {
 	})
 }
 
+// A sensitive parameter may default to a variable binding rather than a literal secret.
+// Octopus stores the binding as a plain value, so it belongs in default_value.
+func TestAccOctopusStepTemplateSensitiveParameterWithVariableBinding(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	prefix := "octopusdeploy_step_template." + localName
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	parameterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             func(s *terraform.State) error { return testStepTemplateDestroy(s, localName) },
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testStepTemplateSensitiveParameterWithVariableBinding(localName, name, parameterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(prefix, "name", name),
+					resource.TestCheckResourceAttr(prefix, "parameters.0.default_value", "#{DefaultPasswordVariable}"),
+					resource.TestCheckResourceAttr(prefix, "parameters.0.display_settings.Octopus.ControlType", "Sensitive"),
+				),
+			},
+			{
+				// Re-applying the same configuration must produce no diff, which proves the
+				// binding round-trips through the API instead of being stored encrypted.
+				Config: testStepTemplateSensitiveParameterWithVariableBinding(localName, name, parameterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(prefix, "parameters.0.default_value", "#{DefaultPasswordVariable}"),
+				),
+			},
+		},
+	})
+}
+
+func testStepTemplateSensitiveParameterWithVariableBinding(localName string, name string, parameterName string) string {
+	return fmt.Sprintf(`
+		resource "octopusdeploy_step_template" "%s" {
+			action_type     = "Octopus.Script"
+			name            = "%s"
+			description     = "Sensitive parameter defaulting to a variable binding"
+			step_package_id = "Octopus.Script"
+			packages        = []
+			parameters      = [
+				{
+					default_value = "#{DefaultPasswordVariable}"
+					display_settings = {
+						"Octopus.ControlType" : "Sensitive"
+					}
+					help_text = "Password used by the script"
+					label     = "Password"
+					name      = "%s"
+					id        = "2f0c1a5c-0f5e-4a6d-9d33-0c0f0b1e2d34"
+				},
+			]
+			properties = {
+				"Octopus.Action.Script.ScriptBody" : "echo 'Hello World'"
+				"Octopus.Action.Script.ScriptSource" : "Inline"
+				"Octopus.Action.Script.Syntax" : "Bash"
+			}
+		}
+`,
+		localName,
+		name,
+		parameterName,
+	)
+}
+
 func testStepTemplateRunScriptBasic(data stepTemplateTestData) string {
 	return fmt.Sprintf(`
 		resource "octopusdeploy_step_template" "%s" {

--- a/octopusdeploy_framework/resource_step_template_validation_test.go
+++ b/octopusdeploy_framework/resource_step_template_validation_test.go
@@ -72,9 +72,11 @@ func TestValidateStepTemplateParameters_Valid(t *testing.T) {
 	}
 }
 
-func TestValidateStepTemplateParameters_SensitiveWithDefaultValue(t *testing.T) {
+// stepTemplateParameterModel builds a single parameter model for validation tests.
+// Pass types.StringNull() for either default to leave it unset.
+func stepTemplateParameterModel(controlType string, defaultValue attr.Value, defaultSensitiveValue attr.Value) *schemas.StepTemplateTypeResourceModel {
 	displaySettings, _ := types.MapValue(types.StringType, map[string]attr.Value{
-		"Octopus.ControlType": types.StringValue("Sensitive"),
+		"Octopus.ControlType": types.StringValue(controlType),
 	})
 
 	paramObj, _ := types.ObjectValue(
@@ -84,8 +86,8 @@ func TestValidateStepTemplateParameters_SensitiveWithDefaultValue(t *testing.T) 
 			"name":                    types.StringValue("TestParam"),
 			"label":                   types.StringValue("Test Parameter"),
 			"help_text":               types.StringValue("Help text"),
-			"default_value":           types.StringValue("default_sensitive_value"),
-			"default_sensitive_value": types.StringNull(),
+			"default_value":           defaultValue,
+			"default_sensitive_value": defaultSensitiveValue,
 			"display_settings":        displaySettings,
 		},
 	)
@@ -95,31 +97,105 @@ func TestValidateStepTemplateParameters_SensitiveWithDefaultValue(t *testing.T) 
 		[]attr.Value{paramObj},
 	)
 
-	data := &schemas.StepTemplateTypeResourceModel{
-		Parameters: paramList,
-	}
+	return &schemas.StepTemplateTypeResourceModel{Parameters: paramList}
+}
+
+func TestValidateStepTemplateParameters_SensitiveWithDefaultValue(t *testing.T) {
+	data := stepTemplateParameterModel("Sensitive", types.StringValue("hunter2"), types.StringNull())
 
 	diags := validateStepTemplateParameters(context.Background(), data)
 
-	if !diags.HasError() {
-		t.Fatal("expected error for sensitive parameter using default_value")
+	if diags.HasError() {
+		t.Fatalf("expected a warning rather than an error for a literal sensitive default, got: %v", diags)
+	}
+
+	if diags.WarningsCount() == 0 {
+		t.Fatal("expected a warning for sensitive parameter using default_value")
 	}
 
 	found := false
-	for _, diag := range diags {
-		if diag.Summary() == "Invalid step template parameter configuration" {
-			detail := diag.Detail()
-			if strings.Contains(detail, "Sensitive") &&
-				strings.Contains(detail, "default_value") &&
-				strings.Contains(detail, "default_sensitive_value") {
-				found = true
-				break
-			}
+	for _, diag := range diags.Warnings() {
+		detail := diag.Detail()
+		if strings.Contains(detail, "Sensitive") &&
+			strings.Contains(detail, "default_value") &&
+			strings.Contains(detail, "default_sensitive_value") {
+			found = true
+			break
 		}
 	}
 
 	if !found {
-		t.Error("expected diagnostic detail to mention Sensitive, default_value, and default_sensitive_value")
+		t.Error("expected warning detail to mention Sensitive, default_value, and default_sensitive_value")
+	}
+}
+
+func TestValidateStepTemplateParameters_SensitiveWithBindingDefaultValue(t *testing.T) {
+	bindings := []string{
+		"#{DefaultPasswordVariable}",
+		"  #{DefaultPasswordVariable}  ",
+		"prefix-#{DefaultPasswordVariable}",
+		"#{DefaultPasswordVariable}-suffix",
+		"#{First}#{Second}",
+		"#{DefaultPasswordVariable | ToUpper}",
+	}
+
+	for _, binding := range bindings {
+		t.Run(binding, func(t *testing.T) {
+			data := stepTemplateParameterModel("Sensitive", types.StringValue(binding), types.StringNull())
+
+			diags := validateStepTemplateParameters(context.Background(), data)
+
+			if diags.HasError() {
+				t.Fatalf("expected no error for a variable binding default, got: %v", diags)
+			}
+
+			if diags.WarningsCount() > 0 {
+				t.Errorf("expected no warning for a variable binding default, got: %v", diags.Warnings())
+			}
+		})
+	}
+}
+
+func TestValidateStepTemplateParameters_SensitiveWithBothDefaultValues(t *testing.T) {
+	data := stepTemplateParameterModel(
+		"Sensitive",
+		types.StringValue("#{DefaultPasswordVariable}"),
+		types.StringValue("hunter2"),
+	)
+
+	diags := validateStepTemplateParameters(context.Background(), data)
+
+	if !diags.HasError() {
+		t.Fatal("expected error when both default_value and default_sensitive_value are set")
+	}
+
+	found := false
+	for _, diag := range diags.Errors() {
+		detail := diag.Detail()
+		if strings.Contains(detail, "both") &&
+			strings.Contains(detail, "default_value") &&
+			strings.Contains(detail, "default_sensitive_value") {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("expected error detail to state that both default_value and default_sensitive_value are set")
+	}
+}
+
+func TestValidateStepTemplateParameters_SensitiveWithSensitiveValue(t *testing.T) {
+	data := stepTemplateParameterModel("Sensitive", types.StringNull(), types.StringValue("hunter2"))
+
+	diags := validateStepTemplateParameters(context.Background(), data)
+
+	if diags.HasError() {
+		t.Fatalf("expected no error for sensitive parameter using default_sensitive_value, got: %v", diags)
+	}
+
+	if diags.WarningsCount() > 0 {
+		t.Errorf("expected no warning for sensitive parameter using default_sensitive_value, got: %v", diags.Warnings())
 	}
 }
 

--- a/octopusdeploy_framework/schemas/schema.go
+++ b/octopusdeploy_framework/schemas/schema.go
@@ -550,14 +550,14 @@ func GetStepTemplateParameterResourceSchema(resourceType string) resourceSchema.
 		NestedObject: resourceSchema.NestedAttributeObject{
 			Attributes: map[string]resourceSchema.Attribute{
 				"default_value": util.ResourceString().
-					Description("A default value for the parameter, if applicable. This can be a hard-coded value or a variable reference.").
+					Description("A default value for the parameter, if applicable. This can be a hard-coded value or a variable reference such as '#{MyVariable}'. Use this attribute for a variable reference even when display settings are set to 'Sensitive', because Octopus stores the reference itself rather than the secret it points at.").
 					Optional().
 					Computed().
 					Default(stringdefault.StaticString("")).
 					PlanModifiers(stringplanmodifier.UseStateForUnknown()).
 					Build(),
 				"default_sensitive_value": util.ResourceString().
-					Description("Use this attribute to set a sensitive default value for the parameter when display settings are set to 'Sensitive'").
+					Description("Use this attribute to set a literal secret as the default value for the parameter when display settings are set to 'Sensitive'. Do not use it for a variable reference such as '#{MyVariable}': the reference would be stored encrypted and would never resolve. Use 'default_value' for that instead.").
 					Optional().
 					Sensitive().
 					Build(),


### PR DESCRIPTION
## What

`octopusdeploy_step_template` could not express a sensitive parameter whose default is a variable binding.

Given a parameter with `Octopus.ControlType = "Sensitive"`:

- putting `#{DefaultPasswordVariable}` in `default_value` was rejected at plan time by the provider's own validation
- putting it in `default_sensitive_value` wrapped it in a `SensitiveValue`, so Octopus stored the binding text encrypted and it never resolved

There was no third option, so the configuration could not be reached through the provider at all.

## Why the fix looks like this

Octopus stores a binding on a sensitive parameter as a plain value. That is what the Octopus UI itself writes, confirmed against a 2026.3 server:

```
POST /api/actiontemplates  { "DefaultValue": "#{DefaultPasswordVariable}", "DisplaySettings": { "Octopus.ControlType": "Sensitive" } }
GET  /api/actiontemplates/{id}  ->  "DefaultValue": "#{DefaultPasswordVariable}"
```

The same payload sent as a `SensitiveValue` comes back as `{ "HasValue": true, "NewValue": null }`. The binding text is encrypted at that point, cannot be read back, and never resolves at deployment time.

So `default_value` is the right place for a binding, and the validation added in #41 was over-broad rather than wrong. The invariant it meant to protect is that a sensitive parameter should not hold a *literal* secret in a plain field, and a binding is a pointer to a secret rather than the secret itself.

## Changes

- `resource_step_template.go:557` no longer errors when a sensitive parameter uses `default_value`. It warns instead, and only when the value contains no binding expression, so a literal secret still points the user at `default_sensitive_value`.
- Setting both `default_value` and `default_sensitive_value` is now an error. Only one of them reaches the server, because `convertStepTemplateToParameters` at `:297-305` prefers `default_sensitive_value` whenever it is set. Without this check the binding would be dropped after a plan that looked clean.
- `isVariableBinding` uses `strings.Contains(value, "#{")`. It is deliberately loose because it only gates a warning, so embedded bindings such as `prefix-#{MyVariable}` are never rejected.
- Attribute descriptions in `schemas/schema.go` now say which attribute takes a binding and why. Docs regenerated.

## Testing

- New unit tests covering whole, padded, prefixed, suffixed, repeated and filtered bindings, plus the both-attributes-set error and the literal-secret warning
- `TestAccOctopusStepTemplateSensitiveParameterWithVariableBinding` creates a sensitive parameter with a binding default and re-applies the same configuration. An empty second plan proves the value round-trips instead of being stored encrypted.
- `TestAccOctopusStepTemplateBasic` still passes

Both acceptance tests were run against a live Octopus 2026.3 instance.

## Note for anyone already affected

Anyone who worked around this by putting a binding in `default_sensitive_value` has an encrypted `#{...}` sitting in Octopus that will never resolve. The read path at `:422-426` substitutes state whenever `IsSensitive` is set, so no future plan will surface the drift. Those parameters have to be moved to `default_value` by hand.

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
