### PR TITLE
fix: prevent panic on prompted variable with empty Select options

### DIFF
--- a/octopusdeploy_framework/resource_variable.go
+++ b/octopusdeploy_framework/resource_variable.go
@@ -302,10 +302,12 @@ func mapVariableToState(data *schemas.VariableTypeResourceModel, variable *varia
 	}
 
 	if !data.Prompt.IsNull() {
-		data.Prompt = types.ListValueMust(
-			types.ObjectType{AttrTypes: schemas.VariablePromptOptionsObjectType()},
-			[]attr.Value{schemas.MapFromVariablePromptOptions(variable.Prompt, data.Prompt)},
-		)
+		promptType := types.ObjectType{AttrTypes: schemas.VariablePromptOptionsObjectType()}
+		if prompt := schemas.MapFromVariablePromptOptions(variable.Prompt, data.Prompt); prompt != nil {
+			data.Prompt = types.ListValueMust(promptType, []attr.Value{prompt})
+		} else {
+			data.Prompt = types.ListNull(promptType)
+		}
 	}
 
 	if variable.Scope.IsEmpty() {

--- a/octopusdeploy_framework/resource_variable_test.go
+++ b/octopusdeploy_framework/resource_variable_test.go
@@ -351,3 +351,53 @@ func testVariableGenericOidcAccount(
 		environmentLocalName,
 	)
 }
+
+// Regression test for issue #166: a prompted variable whose display settings use the
+// "Select" control type without any select_option blocks used to crash the provider
+// with "ObjectValueMust received error(s): ... Missing Object Attribute Value".
+func TestAccOctopusDeployVariablePromptedSelectWithoutOptions(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	variableLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	variablePrefix := "octopusdeploy_variable." + variableLocalName
+
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	variableName := "Test.Variable " + name
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testVariablePromptedSelectWithoutOptions(localName, variableLocalName, name, variableName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(variablePrefix, "prompt.0.display_settings.0.control_type", "Select"),
+					resource.TestCheckResourceAttr(variablePrefix, "prompt.0.display_settings.0.select_option.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testVariablePromptedSelectWithoutOptions(localName string, variableLocalName string, name string, variableName string) string {
+	return fmt.Sprintf(`
+resource "octopusdeploy_library_variable_set" "%s" {
+  name = "%s"
+}
+
+resource "octopusdeploy_variable" "%s" {
+  name     = "%s"
+  type     = "String"
+  owner_id = octopusdeploy_library_variable_set.%s.id
+  value    = "True"
+
+  prompt {
+    description = "test description"
+    label       = "test label"
+    is_required = false
+    display_settings {
+      control_type = "Select"
+    }
+  }
+}
+`, localName, name, variableLocalName, variableName, localName)
+}

--- a/octopusdeploy_framework/schemas/variable_prompt_options.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options.go
@@ -107,18 +107,18 @@ func MapFromDisplaySettings(displaySettings *resources.DisplaySettings) attr.Val
 		return nil
 	}
 
+	// select_option must always be present, even when null. A "Select" control type
+	// carrying no options is valid both in configuration and in server responses, and
+	// omitting the key here makes ObjectValueMust below panic.
 	attrs := map[string]attr.Value{
-		VariableSchemaAttributeNames.ControlType: types.StringValue(string(displaySettings.ControlType)),
+		VariableSchemaAttributeNames.ControlType:  types.StringValue(string(displaySettings.ControlType)),
+		VariableSchemaAttributeNames.SelectOption: types.ListNull(types.ObjectType{AttrTypes: VariableSelectOptionsObjectType()}),
 	}
-	if displaySettings.ControlType == resources.ControlTypeSelect {
-		if len(displaySettings.SelectOptions) > 0 {
-			attrs[VariableSchemaAttributeNames.SelectOption] = types.ListValueMust(
-				types.ObjectType{AttrTypes: VariableSelectOptionsObjectType()},
-				MapFromSelectOptions(displaySettings.SelectOptions),
-			)
-		}
-	} else {
-		attrs[VariableSchemaAttributeNames.SelectOption] = types.ListNull(types.ObjectType{AttrTypes: VariableSelectOptionsObjectType()})
+	if displaySettings.ControlType == resources.ControlTypeSelect && len(displaySettings.SelectOptions) > 0 {
+		attrs[VariableSchemaAttributeNames.SelectOption] = types.ListValueMust(
+			types.ObjectType{AttrTypes: VariableSelectOptionsObjectType()},
+			MapFromSelectOptions(displaySettings.SelectOptions),
+		)
 	}
 
 	return types.ObjectValueMust(

--- a/octopusdeploy_framework/schemas/variable_prompt_options_test.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options_test.go
@@ -130,6 +130,34 @@ func TestFlattenPromptedVariableDisplaySettingsWithNilInput(t *testing.T) {
 	require.Empty(t, result)
 }
 
+func TestFlattenPromptedDisplaySettingsWithSelectAndNoOptions(t *testing.T) {
+	// A "Select" control type carrying no options used to omit the select_option
+	// attribute entirely, panicking in ObjectValueMust. See issue #166.
+	result := MapFromDisplaySettings(resources.NewDisplaySettings(resources.ControlTypeSelect, nil))
+	require.NotNil(t, result)
+
+	obj, ok := result.(types.Object)
+	require.True(t, ok)
+
+	selectOption, ok := obj.Attributes()[VariableSchemaAttributeNames.SelectOption]
+	require.True(t, ok, "select_option must be present even when there are no options")
+	require.True(t, selectOption.IsNull())
+}
+
+func TestFlattenPromptedDisplaySettingsWithSelectAndOptions(t *testing.T) {
+	displaySettings := resources.NewDisplaySettings(resources.ControlTypeSelect, []*resources.SelectOption{
+		{Value: "Value-1", DisplayName: "Name-1"},
+	})
+
+	obj, ok := MapFromDisplaySettings(displaySettings).(types.Object)
+	require.True(t, ok)
+
+	selectOption, ok := obj.Attributes()[VariableSchemaAttributeNames.SelectOption].(types.List)
+	require.True(t, ok)
+	require.False(t, selectOption.IsNull())
+	require.Len(t, selectOption.Elements(), 1)
+}
+
 func TestFlattenPromptedVariableSettingsWithNilInput(t *testing.T) {
 	result := MapFromVariablePromptOptions(nil, types.ListNull(types.ObjectType{AttrTypes: VariablePromptOptionsObjectType()}))
 	require.Empty(t, result)


### PR DESCRIPTION
Fixes #166.

## The crash

A prompted variable whose display settings use the `Select` control type with no `select_option` blocks crashes the provider:

```
ObjectValueMust received error(s): Error | Missing Object Attribute Value | While creating a Object value, a
missing attribute value was detected. A Object must contain values for all attributes, even if null or unknown.

Object Attribute Name (select_option) Expected Type:
types.ListType[types.ObjectType["display_name":basetypes.StringType, "value":basetypes.StringType]]
```

`select_option` is an optional block, so this is valid HCL and reaches the panic:

```hcl
prompt {
  display_settings {
    control_type = "Select"
  }
}
```

## Cause

`MapFromDisplaySettings` in `octopusdeploy_framework/schemas/variable_prompt_options.go` wrote the `select_option` attribute in two situations: when the control type was not `Select`, or when `Select` carried at least one option. A `Select` with zero options fell through both, leaving the attribute unset, and `ObjectValueMust` requires a value for every attribute declared in the object type.

The empty case is reachable from more than user config. In `go-octopusdeploy`, `DisplaySettings.UnmarshalJSON` produces a zero-length `SelectOptions` when the server omits `Octopus.SelectOptions`, when it returns the field as an empty string, and when every option fails to parse. A server response can therefore trigger this as well, which may be why the reporter could not isolate a reproduction.

## Fix

`select_option` is now seeded as a null list before the control-type branch and overwritten only when options are present, so every declared attribute always has a value. This follows the shape already used in `runbook_retention_policy.go`, which assigns a null for the inapplicable case rather than skipping the key.

The change also guards a second latent panic at the same call site. `MapFromVariablePromptOptions` returns an untyped `nil` when a variable has no prompt, and `mapVariableToState` fed that straight into `ListValueMust` as a list element whenever the prior state declared a `prompt` block.

## On the choice of null

Writing a null here rather than an empty list is the part worth checking, because Terraform's post-apply consistency check compares what the provider writes against the plan.

I tested it against a real Octopus server before writing the fix. On unpatched `main`, an acceptance test applying a prompt with `control_type = "SingleLineText"` and no `select_option` blocks (the existing branch that already writes `ListNull`) passes, including the post-apply empty-plan check. So null is accepted for an absent `select_option` block list and produces no perpetual diff.

## No validator

I considered rejecting an empty `Select` at plan time instead, and decided against it. The server accepts an empty `Select`. In the crash above, the POST succeeds and the panic happens afterwards, while reading the response. A validator would break configs that work today, and it would not help the case where the empty value comes from the server rather than the config.

## Tests

- `TestFlattenPromptedDisplaySettingsWithSelectAndNoOptions` verifies a `Select` with no options returns a null `select_option` instead of panicking.
- `TestFlattenPromptedDisplaySettingsWithSelectAndOptions` verifies a `Select` with options still populates the list.
- `TestAccOctopusDeployVariablePromptedSelectWithoutOptions` applies the config from the issue. It crashes with the exact error above on unpatched `main` and passes with the fix.

All 14 variable-related acceptance tests pass against a local Octopus instance, including the existing `TestAccOctopusDeployLibraryVariableSetWithVariable`, which covers `Select` with options.

No state migration, no breaking change, no schema change.
