### PR TITLE
refactor: build schema objects through a null-filling helper

### DIFF
--- a/octopusdeploy_framework/resource_variable.go
+++ b/octopusdeploy_framework/resource_variable.go
@@ -302,10 +302,12 @@ func mapVariableToState(data *schemas.VariableTypeResourceModel, variable *varia
 	}
 
 	if !data.Prompt.IsNull() {
-		data.Prompt = types.ListValueMust(
-			types.ObjectType{AttrTypes: schemas.VariablePromptOptionsObjectType()},
-			[]attr.Value{schemas.MapFromVariablePromptOptions(variable.Prompt, data.Prompt)},
-		)
+		promptType := types.ObjectType{AttrTypes: schemas.VariablePromptOptionsObjectType()}
+		if prompt := schemas.MapFromVariablePromptOptions(variable.Prompt, data.Prompt); prompt != nil {
+			data.Prompt = types.ListValueMust(promptType, []attr.Value{prompt})
+		} else {
+			data.Prompt = types.ListNull(promptType)
+		}
 	}
 
 	if variable.Scope.IsEmpty() {

--- a/octopusdeploy_framework/resource_variable_test.go
+++ b/octopusdeploy_framework/resource_variable_test.go
@@ -351,3 +351,53 @@ func testVariableGenericOidcAccount(
 		environmentLocalName,
 	)
 }
+
+// Regression test for issue #166: a prompted variable whose display settings use the
+// "Select" control type without any select_option blocks used to crash the provider
+// with "ObjectValueMust received error(s): ... Missing Object Attribute Value".
+func TestAccOctopusDeployVariablePromptedSelectWithoutOptions(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	variableLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	variablePrefix := "octopusdeploy_variable." + variableLocalName
+
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	variableName := "Test.Variable " + name
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testVariablePromptedSelectWithoutOptions(localName, variableLocalName, name, variableName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(variablePrefix, "prompt.0.display_settings.0.control_type", "Select"),
+					resource.TestCheckResourceAttr(variablePrefix, "prompt.0.display_settings.0.select_option.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testVariablePromptedSelectWithoutOptions(localName string, variableLocalName string, name string, variableName string) string {
+	return fmt.Sprintf(`
+resource "octopusdeploy_library_variable_set" "%s" {
+  name = "%s"
+}
+
+resource "octopusdeploy_variable" "%s" {
+  name     = "%s"
+  type     = "String"
+  owner_id = octopusdeploy_library_variable_set.%s.id
+  value    = "True"
+
+  prompt {
+    description = "test description"
+    label       = "test label"
+    is_required = false
+    display_settings {
+      control_type = "Select"
+    }
+  }
+}
+`, localName, name, variableLocalName, variableName, localName)
+}

--- a/octopusdeploy_framework/schemas/connectivity_policy.go
+++ b/octopusdeploy_framework/schemas/connectivity_policy.go
@@ -113,7 +113,7 @@ func MapFromConnectivityPolicy(connectivityPolicy *core.ConnectivityPolicy) attr
 		runbookConnectivityPolicySchemeAttributeNames.TargetRoles:                 util.FlattenStringList(connectivityPolicy.TargetRoles),
 	}
 
-	return types.ObjectValueMust(GetConnectivityPolicyObjectType(), attrs)
+	return util.ObjectValue(GetConnectivityPolicyObjectType(), attrs)
 }
 
 func MapToConnectivityPolicy(flattenedConnectivityPolicy types.List) *core.ConnectivityPolicy {

--- a/octopusdeploy_framework/schemas/environment.go
+++ b/octopusdeploy_framework/schemas/environment.go
@@ -246,7 +246,7 @@ func JiraExtensionSettingsObjectType() map[string]attr.Type {
 }
 
 func MapJiraExtensionSettings(jiraExtensionSettings *environments.JiraExtensionSettings) attr.Value {
-	return types.ObjectValueMust(JiraExtensionSettingsObjectType(), map[string]attr.Value{
+	return util.ObjectValue(JiraExtensionSettingsObjectType(), map[string]attr.Value{
 		"environment_type": types.StringValue(jiraExtensionSettings.JiraEnvironmentType),
 	})
 }
@@ -258,7 +258,7 @@ func JiraServiceManagementExtensionSettingsObjectType() map[string]attr.Type {
 }
 
 func MapJiraServiceManagementExtensionSettings(jiraServiceManagementExtensionSettings *environments.JiraServiceManagementExtensionSettings) attr.Value {
-	return types.ObjectValueMust(JiraServiceManagementExtensionSettingsObjectType(), map[string]attr.Value{
+	return util.ObjectValue(JiraServiceManagementExtensionSettingsObjectType(), map[string]attr.Value{
 		"is_enabled": types.BoolValue(jiraServiceManagementExtensionSettings.IsChangeControlled()),
 	})
 }
@@ -270,7 +270,7 @@ func ServiceNowExtensionSettingsObjectType() map[string]attr.Type {
 }
 
 func MapServiceNowExtensionSettings(serviceNowExtensionSettings *environments.ServiceNowExtensionSettings) attr.Value {
-	return types.ObjectValueMust(ServiceNowExtensionSettingsObjectType(), map[string]attr.Value{
+	return util.ObjectValue(ServiceNowExtensionSettingsObjectType(), map[string]attr.Value{
 		"is_enabled": types.BoolValue(serviceNowExtensionSettings.IsChangeControlled()),
 	})
 }

--- a/octopusdeploy_framework/schemas/feed.go
+++ b/octopusdeploy_framework/schemas/feed.go
@@ -8,7 +8,7 @@ import (
 )
 
 func FlattenFeed(feed *feeds.FeedResource) attr.Value {
-	return types.ObjectValueMust(FeedObjectType(), map[string]attr.Value{
+	return util.ObjectValue(FeedObjectType(), map[string]attr.Value{
 		"access_key":                               types.StringValue(feed.AccessKey),
 		"api_version":                              types.StringValue(feed.APIVersion),
 		"delete_unreleased_packages_after_days":    types.Int64Value(int64(feed.DeleteUnreleasedPackagesAfterDays)),

--- a/octopusdeploy_framework/schemas/git_credential.go
+++ b/octopusdeploy_framework/schemas/git_credential.go
@@ -66,7 +66,7 @@ func gitCredentialRepositoryRestrictionAttribute() resourceSchema.SingleNestedAt
 		Optional: true,
 		Computed: true,
 		Default: objectdefault.StaticValue(
-			types.ObjectValueMust(
+			util.ObjectValue(
 				map[string]attr.Type{
 					"enabled":              types.BoolType,
 					"allowed_repositories": types.SetType{ElemType: types.StringType},

--- a/octopusdeploy_framework/schemas/library_variable_set.go
+++ b/octopusdeploy_framework/schemas/library_variable_set.go
@@ -143,7 +143,7 @@ func FlattenTemplates(actionTemplateParameters []actiontemplates.ActionTemplateP
 			"label":            util.Ternary(actionTemplateParams.Label != "", types.StringValue(actionTemplateParams.Label), types.StringNull()),
 			"name":             types.StringValue(actionTemplateParams.Name),
 		}
-		actionTemplateList = append(actionTemplateList, types.ObjectValueMust(TemplateObjectType(), attrs))
+		actionTemplateList = append(actionTemplateList, util.ObjectValue(TemplateObjectType(), attrs))
 	}
 	return types.ListValueMust(types.ObjectType{AttrTypes: TemplateObjectType()}, actionTemplateList)
 }

--- a/octopusdeploy_framework/schemas/process_step.go
+++ b/octopusdeploy_framework/schemas/process_step.go
@@ -207,7 +207,7 @@ func resourceActionContainerAttribute() resourceSchema.SingleNestedAttribute {
 		Optional: true,
 		Computed: true,
 		Default: objectdefault.StaticValue(
-			types.ObjectValueMust(
+			util.ObjectValue(
 				map[string]attr.Type{
 					"feed_id":    types.StringType,
 					"image":      types.StringType,

--- a/octopusdeploy_framework/schemas/runbook_retention_policy.go
+++ b/octopusdeploy_framework/schemas/runbook_retention_policy.go
@@ -74,7 +74,7 @@ func MapFromRunbookRetentionPolicy(retentionPolicy *runbooks.RunbookRetentionPol
 			types.StringNull()),
 	}
 
-	return types.ObjectValueMust(GetRunbookRetentionPolicyObjectType(), attrs)
+	return util.ObjectValue(GetRunbookRetentionPolicyObjectType(), attrs)
 }
 
 func MapToRunbookRetentionPolicy(policy types.List) (*runbooks.RunbookRetentionPolicy, error) {

--- a/octopusdeploy_framework/schemas/runbook_retention_policy_legacy.go
+++ b/octopusdeploy_framework/schemas/runbook_retention_policy_legacy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -61,7 +62,7 @@ func MapFromLegacyRunbookRetentionPolicy(retentionPolicy *runbooks.RunbookRetent
 		legacyRunbookRetentionPolicySchemeAttributeNames.ShouldKeepForever: types.BoolValue(retentionPolicy.Strategy == runbooks.RunbookRetentionStrategyForever),
 	}
 
-	return types.ObjectValueMust(GetLegacyRunbookRetentionPolicyObjectType(), attrs)
+	return util.ObjectValue(GetLegacyRunbookRetentionPolicyObjectType(), attrs)
 }
 
 func MapToLegacyRunbookRetentionPolicy(flattenedRunbookRetentionPolicy types.List) *runbooks.RunbookRetentionPolicy {

--- a/octopusdeploy_framework/schemas/script_modules.go
+++ b/octopusdeploy_framework/schemas/script_modules.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 )
 
 type ScriptModuleSchema struct{}
@@ -108,7 +109,7 @@ func FlattenScriptModule(scriptModule *variables.ScriptModule) attr.Value {
 		"variable_set_id": types.StringValue(scriptModule.VariableSetID),
 	}
 
-	return types.ObjectValueMust(ScriptModuleObjectType(), attrs)
+	return util.ObjectValue(ScriptModuleObjectType(), attrs)
 }
 
 func ScriptObjectType() types.ObjectType {
@@ -191,7 +192,7 @@ func MapFromScriptModuleToState(data *ScriptModuleResourceModel) *variables.Scri
 
 func flattenScript(scriptModule *variables.ScriptModule) []attr.Value {
 	return []attr.Value{
-		types.ObjectValueMust(map[string]attr.Type{
+		util.ObjectValue(map[string]attr.Type{
 			"body":   types.StringType,
 			"syntax": types.StringType,
 		}, map[string]attr.Value{

--- a/octopusdeploy_framework/schemas/tenant.go
+++ b/octopusdeploy_framework/schemas/tenant.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -62,7 +63,7 @@ func FlattenTenant(tenant *tenants.Tenant) attr.Value {
 	}
 	var tenantTagsSet, _ = types.SetValue(types.StringType, tenantTags)
 
-	return types.ObjectValueMust(TenantObjectType(), map[string]attr.Value{
+	return util.ObjectValue(TenantObjectType(), map[string]attr.Value{
 		"cloned_from_tenant_id": types.StringValue(tenant.ClonedFromTenantID),
 		"description":           types.StringValue(tenant.Description),
 		"id":                    types.StringValue(tenant.GetID()),

--- a/octopusdeploy_framework/schemas/tenant_projects.go
+++ b/octopusdeploy_framework/schemas/tenant_projects.go
@@ -111,7 +111,7 @@ func MapTenantToTenantProject(tenant *tenants.Tenant, projectID string) attr.Val
 
 	environmentIdList, _ := types.ListValue(types.StringType, environmentIDs)
 
-	return types.ObjectValueMust(TenantProjectType(), map[string]attr.Value{
+	return util.ObjectValue(TenantProjectType(), map[string]attr.Value{
 		"id":              types.StringValue(util.BuildCompositeId(tenant.SpaceID, tenant.ID, projectID)),
 		"tenant_id":       types.StringValue(tenant.ID),
 		"project_id":      types.StringValue(projectID),

--- a/octopusdeploy_framework/schemas/user.go
+++ b/octopusdeploy_framework/schemas/user.go
@@ -247,7 +247,7 @@ func MapIdentityClaims(claims map[string]users.IdentityClaim) []attr.Value {
 			"name":                 types.StringValue(key),
 			"value":                types.StringValue(claim.Value),
 		}
-		claimsList = append(claimsList, types.ObjectValueMust(IdentityClaimObjectType(), claimMap))
+		claimsList = append(claimsList, util.ObjectValue(IdentityClaimObjectType(), claimMap))
 	}
 	return claimsList
 }
@@ -259,7 +259,7 @@ func MapIdentities(identities []users.Identity) []attr.Value {
 			"provider": types.StringValue(identity.IdentityProviderName),
 			"claim":    types.SetValueMust(types.ObjectType{AttrTypes: IdentityClaimObjectType()}, MapIdentityClaims(identity.Claims)),
 		}
-		identitiesList = append(identitiesList, types.ObjectValueMust(IdentityObjectType(), identityMap))
+		identitiesList = append(identitiesList, util.ObjectValue(IdentityObjectType(), identityMap))
 	}
 	return identitiesList
 }

--- a/octopusdeploy_framework/schemas/variable_prompt_options.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options.go
@@ -99,7 +99,7 @@ func MapFromVariablePromptOptions(variablePromptOptions *variables.VariablePromp
 		)
 	}
 
-	return types.ObjectValueMust(VariablePromptOptionsObjectType(), attrs)
+	return util.ObjectValue(VariablePromptOptionsObjectType(), attrs)
 }
 
 func MapFromDisplaySettings(displaySettings *resources.DisplaySettings) attr.Value {
@@ -121,7 +121,7 @@ func MapFromDisplaySettings(displaySettings *resources.DisplaySettings) attr.Val
 		)
 	}
 
-	return types.ObjectValueMust(
+	return util.ObjectValue(
 		VariableDisplaySettingsObjectType(),
 		attrs,
 	)
@@ -130,7 +130,7 @@ func MapFromDisplaySettings(displaySettings *resources.DisplaySettings) attr.Val
 func MapFromSelectOptions(selectOptions []*resources.SelectOption) []attr.Value {
 	options := make([]attr.Value, 0, len(selectOptions))
 	for _, option := range selectOptions {
-		options = append(options, types.ObjectValueMust(
+		options = append(options, util.ObjectValue(
 			VariableSelectOptionsObjectType(),
 			map[string]attr.Value{
 				VariableSchemaAttributeNames.Value:       types.StringValue(option.Value),

--- a/octopusdeploy_framework/schemas/variable_prompt_options.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options.go
@@ -107,18 +107,18 @@ func MapFromDisplaySettings(displaySettings *resources.DisplaySettings) attr.Val
 		return nil
 	}
 
+	// select_option must always be present, even when null. A "Select" control type
+	// carrying no options is valid both in configuration and in server responses, and
+	// omitting the key here makes ObjectValueMust below panic.
 	attrs := map[string]attr.Value{
-		VariableSchemaAttributeNames.ControlType: types.StringValue(string(displaySettings.ControlType)),
+		VariableSchemaAttributeNames.ControlType:  types.StringValue(string(displaySettings.ControlType)),
+		VariableSchemaAttributeNames.SelectOption: types.ListNull(types.ObjectType{AttrTypes: VariableSelectOptionsObjectType()}),
 	}
-	if displaySettings.ControlType == resources.ControlTypeSelect {
-		if len(displaySettings.SelectOptions) > 0 {
-			attrs[VariableSchemaAttributeNames.SelectOption] = types.ListValueMust(
-				types.ObjectType{AttrTypes: VariableSelectOptionsObjectType()},
-				MapFromSelectOptions(displaySettings.SelectOptions),
-			)
-		}
-	} else {
-		attrs[VariableSchemaAttributeNames.SelectOption] = types.ListNull(types.ObjectType{AttrTypes: VariableSelectOptionsObjectType()})
+	if displaySettings.ControlType == resources.ControlTypeSelect && len(displaySettings.SelectOptions) > 0 {
+		attrs[VariableSchemaAttributeNames.SelectOption] = types.ListValueMust(
+			types.ObjectType{AttrTypes: VariableSelectOptionsObjectType()},
+			MapFromSelectOptions(displaySettings.SelectOptions),
+		)
 	}
 
 	return types.ObjectValueMust(

--- a/octopusdeploy_framework/schemas/variable_prompt_options_test.go
+++ b/octopusdeploy_framework/schemas/variable_prompt_options_test.go
@@ -130,6 +130,34 @@ func TestFlattenPromptedVariableDisplaySettingsWithNilInput(t *testing.T) {
 	require.Empty(t, result)
 }
 
+func TestFlattenPromptedDisplaySettingsWithSelectAndNoOptions(t *testing.T) {
+	// A "Select" control type carrying no options used to omit the select_option
+	// attribute entirely, panicking in ObjectValueMust. See issue #166.
+	result := MapFromDisplaySettings(resources.NewDisplaySettings(resources.ControlTypeSelect, nil))
+	require.NotNil(t, result)
+
+	obj, ok := result.(types.Object)
+	require.True(t, ok)
+
+	selectOption, ok := obj.Attributes()[VariableSchemaAttributeNames.SelectOption]
+	require.True(t, ok, "select_option must be present even when there are no options")
+	require.True(t, selectOption.IsNull())
+}
+
+func TestFlattenPromptedDisplaySettingsWithSelectAndOptions(t *testing.T) {
+	displaySettings := resources.NewDisplaySettings(resources.ControlTypeSelect, []*resources.SelectOption{
+		{Value: "Value-1", DisplayName: "Name-1"},
+	})
+
+	obj, ok := MapFromDisplaySettings(displaySettings).(types.Object)
+	require.True(t, ok)
+
+	selectOption, ok := obj.Attributes()[VariableSchemaAttributeNames.SelectOption].(types.List)
+	require.True(t, ok)
+	require.False(t, selectOption.IsNull())
+	require.Len(t, selectOption.Elements(), 1)
+}
+
 func TestFlattenPromptedVariableSettingsWithNilInput(t *testing.T) {
 	result := MapFromVariablePromptOptions(nil, types.ListNull(types.ObjectType{AttrTypes: VariablePromptOptionsObjectType()}))
 	require.Empty(t, result)

--- a/octopusdeploy_framework/schemas/variable_scope.go
+++ b/octopusdeploy_framework/schemas/variable_scope.go
@@ -62,7 +62,7 @@ func MapFromVariableScope(variableScope variables.VariableScope) attr.Value {
 		variableScopeFieldNames.TenantTags:   util.Ternary(variableScope.TenantTags != nil, util.FlattenStringList(variableScope.TenantTags), types.ListNull(types.StringType)),
 	}
 
-	return types.ObjectValueMust(
+	return util.ObjectValue(
 		VariableScopeObjectType(),
 		flattenedScopes,
 	)

--- a/octopusdeploy_framework/schemas/workers.go
+++ b/octopusdeploy_framework/schemas/workers.go
@@ -134,7 +134,7 @@ func FlattenWorker(worker *machines.Worker) attr.Value {
 		dotnetPlatform = util.StringOrNull(endpoint.DotNetCorePlatform)
 	}
 
-	return types.ObjectValueMust(WorkerObjectType(), map[string]attr.Value{
+	return util.ObjectValue(WorkerObjectType(), map[string]attr.Value{
 		"id":                  types.StringValue(worker.GetID()),
 		"space_id":            types.StringValue(worker.SpaceID),
 		"name":                types.StringValue(worker.Name),

--- a/octopusdeploy_framework/util/object_value.go
+++ b/octopusdeploy_framework/util/object_value.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// ObjectValue builds an object from the supplied attribute types and values, filling
+// any attribute that the caller did not supply with a null of its declared type.
+//
+// types.ObjectValueMust panics when an attribute declared in the object type is absent
+// from the value map, and that panic reaches users as a provider crash during plan or
+// apply rather than as a diagnostic. A mapper reaches this state when a value only
+// applies to some variants of a resource and the branch that handles the other variants
+// skips the key, which is what caused the crash in issue #166.
+//
+// Attributes present in attrs but absent from attrTypes are left in place so that
+// ObjectValueMust still rejects them. Those indicate a genuine mismatch between a
+// mapper and its object type, rather than an attribute that does not apply.
+func ObjectValue(attrTypes map[string]attr.Type, attrs map[string]attr.Value) basetypes.ObjectValue {
+	complete := make(map[string]attr.Value, len(attrTypes))
+	for name, value := range attrs {
+		complete[name] = value
+	}
+
+	for name, attrType := range attrTypes {
+		if _, ok := complete[name]; !ok {
+			complete[name] = NullValueOf(attrType)
+		}
+	}
+
+	return types.ObjectValueMust(attrTypes, complete)
+}
+
+// NullValueOf returns a null value of the supplied type. It handles nested collection
+// and object types, so callers do not have to name the concrete null constructor.
+func NullValueOf(attrType attr.Type) attr.Value {
+	ctx := context.Background()
+
+	value, err := attrType.ValueFromTerraform(ctx, tftypes.NewValue(attrType.TerraformType(ctx), nil))
+	if err != nil {
+		// The framework's own types never fail to produce a null value. A custom type
+		// that does is a programming error, and silently substituting something else
+		// would hide it.
+		panic(fmt.Sprintf("unable to build a null value for type %s: %s", attrType, err))
+	}
+
+	return value
+}

--- a/octopusdeploy_framework/util/object_value_test.go
+++ b/octopusdeploy_framework/util/object_value_test.go
@@ -1,0 +1,91 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func nestedObjectType() map[string]attr.Type {
+	return map[string]attr.Type{
+		"value":        types.StringType,
+		"display_name": types.StringType,
+	}
+}
+
+func sampleObjectType() map[string]attr.Type {
+	return map[string]attr.Type{
+		"control_type": types.StringType,
+		"enabled":      types.BoolType,
+		"select_option": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: nestedObjectType()},
+		},
+		"tags": types.SetType{ElemType: types.StringType},
+	}
+}
+
+func TestObjectValueFillsMissingAttributesWithNull(t *testing.T) {
+	result := ObjectValue(sampleObjectType(), map[string]attr.Value{
+		"control_type": types.StringValue("Select"),
+	})
+
+	attrs := result.Attributes()
+	require.Len(t, attrs, 4)
+	require.Equal(t, types.StringValue("Select"), attrs["control_type"])
+	require.True(t, attrs["enabled"].IsNull())
+	require.True(t, attrs["select_option"].IsNull())
+	require.True(t, attrs["tags"].IsNull())
+}
+
+func TestObjectValueKeepsSuppliedAttributes(t *testing.T) {
+	selectOptions := types.ListValueMust(
+		types.ObjectType{AttrTypes: nestedObjectType()},
+		[]attr.Value{
+			types.ObjectValueMust(nestedObjectType(), map[string]attr.Value{
+				"value":        types.StringValue("Value-1"),
+				"display_name": types.StringValue("Name-1"),
+			}),
+		},
+	)
+
+	result := ObjectValue(sampleObjectType(), map[string]attr.Value{
+		"control_type":  types.StringValue("Select"),
+		"enabled":       types.BoolValue(true),
+		"select_option": selectOptions,
+		"tags":          types.SetValueMust(types.StringType, []attr.Value{types.StringValue("a")}),
+	})
+
+	attrs := result.Attributes()
+	require.Equal(t, types.BoolValue(true), attrs["enabled"])
+	require.Equal(t, selectOptions, attrs["select_option"])
+	require.False(t, attrs["tags"].IsNull())
+}
+
+func TestObjectValueDoesNotMutateCallerMap(t *testing.T) {
+	attrs := map[string]attr.Value{"control_type": types.StringValue("Select")}
+
+	ObjectValue(sampleObjectType(), attrs)
+
+	require.Len(t, attrs, 1, "the supplied map should be left untouched")
+}
+
+func TestObjectValueStillRejectsUndeclaredAttributes(t *testing.T) {
+	require.Panics(t, func() {
+		ObjectValue(sampleObjectType(), map[string]attr.Value{
+			"control_type": types.StringValue("Select"),
+			"not_declared": types.StringValue("boom"),
+		})
+	}, "an attribute absent from the object type is a mapper bug and should stay loud")
+}
+
+func TestNullValueOfNestedTypes(t *testing.T) {
+	for name, attrType := range sampleObjectType() {
+		t.Run(name, func(t *testing.T) {
+			value := NullValueOf(attrType)
+			require.True(t, value.IsNull())
+			require.Equal(t, attrType, value.Type(nil))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #245. Builds on #244, which fixes the crash that prompted this. The first commit here is #244's; review that one first, or merge it first and this diff shrinks to the second commit.

## Why

`types.ObjectValueMust` panics when an attribute declared in the object type is missing from the value map. The panic reaches users as a plugin crash during plan or apply rather than as a diagnostic, which is how #166 presented. A mapper gets into that state when a value applies to only some variants of a resource and the branch handling the other variants skips the key.

The other way in is quieter. Adding an attribute to a `*ObjectType()` function is a one-line change that looks safe, and it silently turns every hand-written value map for that type into a crash. Nothing catches it at compile time.

## What this does

`util.ObjectValue` fills any declared attribute the caller did not supply with a null of its declared type, then builds the object. `util.NullValueOf` produces that null for any `attr.Type`, including nested collections and objects, so callers do not have to name the concrete constructor.

Attributes present in the value map but absent from the object type are left in place, so `ObjectValueMust` still rejects them. That case is a real mismatch between a mapper and its type rather than an attribute that does not apply, and silently dropping it would hide a bug.

The 21 call sites under `octopusdeploy_framework/schemas/` now use the helper. Those are the shared mappers, so one missing attribute there can affect several resources at once. Resource-level call sites are unchanged, and can move later if this direction looks right.

For maps that were already complete, which is all of them today, behaviour is identical.

## The tradeoff

This turns a missing attribute into a null instead of a crash. That is correct when the attribute genuinely does not apply, which is the #166 case and the common one. It is less good if a mapper simply forgets to populate something, since the result is a null in state rather than a loud failure.

I went this way because the alternative, migrating mappers to the diagnostic-returning `types.ObjectValue`, changes the signature of most of the schemas package. `resource_project_flatten.go:245` already does that and is worth copying for mappers that return diagnostics anyway, but it is a much larger change to make everywhere at once. Happy to go that way instead if you prefer.

## Verification

`util.ObjectValue` and `util.NullValueOf` have unit tests covering missing attributes, supplied attributes, nested list and set types, that the caller's map is not mutated, and that an undeclared attribute still panics.

I ran the acceptance suite for the areas these mappers touch against a local Octopus instance: environments, feeds, tenants, tenant variables, users, user roles, script modules, workers, worker pools, git credentials, library variable sets, and variables. 63 tests pass.

Two tests fail, and both fail the same way on the base branch without this change: `TestTeamResource_UpgradeFromSDK_ToPluginFramework_WithUserRole` reports `Octopus API error: An exception has been raised that is likely due to a transient failure`, and `TestTenantProjectResource_UpgradeFromSDK_ToPluginFramework` fails a pre-apply plan check at step 2. Both are SDK-to-framework upgrade tests that pull an older provider release, and neither touches the code changed here.

`go build ./...` and `go vet` are clean for the changed packages.

