### PR TITLE
fix: keep template display_settings null when the config omits it

### DIFF
--- a/octopusdeploy_framework/resource_project_flatten.go
+++ b/octopusdeploy_framework/resource_project_flatten.go
@@ -74,7 +74,7 @@ func flattenProject(ctx context.Context, project *projects.Project, state *proje
 		model.VersioningStrategy = flattenVersioningStrategy(project.VersioningStrategy)
 	}
 
-	model.Template = flattenTemplates(project.Templates)
+	model.Template = flattenTemplates(project.Templates, state.Template)
 
 	diags := processPersistenceSettings(ctx, project, model)
 
@@ -279,30 +279,76 @@ func flattenServiceNowExtensionSettings(settings *projects.ServiceNowExtensionSe
 	return types.ListValueMust(types.ObjectType{AttrTypes: getServiceNowExtensionSettingsAttrTypes()}, []attr.Value{obj})
 }
 
-func flattenTemplates(templates []actiontemplates.ActionTemplateParameter) types.List {
+func flattenTemplates(templates []actiontemplates.ActionTemplateParameter, prior types.List) types.List {
 	if len(templates) == 0 {
 		return types.ListNull(types.ObjectType{AttrTypes: getTemplateAttrTypes()})
 	}
 
+	priorDisplaySettings := priorTemplateDisplaySettings(prior, len(templates))
+
 	templateList := make([]attr.Value, 0, len(templates))
-	for _, template := range templates {
+	for i, template := range templates {
+		displaySettings := types.MapValueMust(
+			types.StringType,
+			util.ConvertMapStringToMapAttrValue(template.DisplaySettings),
+		)
+
+		// display_settings is optional and not computed, so a map the configuration
+		// leaves out has to still be null once the server round trip is done. The
+		// server cannot tell an absent map from an empty one, so the planned (or
+		// previously stored) value decides which of the two to write back.
+		if len(template.DisplaySettings) == 0 && displaySettingsWasNull(priorDisplaySettings, i) {
+			displaySettings = types.MapNull(types.StringType)
+		}
 
 		obj := types.ObjectValueMust(getTemplateAttrTypes(), map[string]attr.Value{
-			"id":            types.StringValue(template.Resource.ID),
-			"name":          types.StringValue(template.Name),
-			"label":         util.StringOrNull(template.Label),
-			"help_text":     util.StringOrNull(template.HelpText),
-			"default_value": util.StringOrNull(template.DefaultValue.Value),
-			"display_settings": types.MapValueMust(
-				types.StringType,
-				util.ConvertMapStringToMapAttrValue(template.DisplaySettings),
-			),
+			"id":               types.StringValue(template.Resource.ID),
+			"name":             types.StringValue(template.Name),
+			"label":            util.StringOrNull(template.Label),
+			"help_text":        util.StringOrNull(template.HelpText),
+			"default_value":    util.StringOrNull(template.DefaultValue.Value),
+			"display_settings": displaySettings,
 		})
 
 		templateList = append(templateList, obj)
 	}
 
 	return types.ListValueMust(types.ObjectType{AttrTypes: getTemplateAttrTypes()}, templateList)
+}
+
+// priorTemplateDisplaySettings reads display_settings out of the planned or
+// previously stored template list. It returns nil when that list cannot be lined
+// up element for element with the templates the server returned, which is the case
+// on import and whenever the two lengths differ.
+func priorTemplateDisplaySettings(prior types.List, count int) []types.Map {
+	if prior.IsNull() || prior.IsUnknown() || len(prior.Elements()) != count {
+		return nil
+	}
+
+	displaySettings := make([]types.Map, 0, count)
+	for _, element := range prior.Elements() {
+		object, ok := element.(types.Object)
+		if !ok {
+			return nil
+		}
+
+		value, ok := object.Attributes()["display_settings"].(types.Map)
+		if !ok {
+			return nil
+		}
+
+		displaySettings = append(displaySettings, value)
+	}
+
+	return displaySettings
+}
+
+func displaySettingsWasNull(priorDisplaySettings []types.Map, index int) bool {
+	if index >= len(priorDisplaySettings) {
+		return true
+	}
+
+	return priorDisplaySettings[index].IsNull()
 }
 
 func flattenAutoDeployReleaseOverrides(overrides []projects.AutoDeployReleaseOverride) types.List {

--- a/octopusdeploy_framework/resource_project_flatten_test.go
+++ b/octopusdeploy_framework/resource_project_flatten_test.go
@@ -1,0 +1,122 @@
+package octopusdeploy_framework
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func templateWithDisplaySettings(name string, displaySettings map[string]string) actiontemplates.ActionTemplateParameter {
+	defaultValue := core.NewPropertyValue("", false)
+	return actiontemplates.ActionTemplateParameter{
+		Name:            name,
+		DefaultValue:    &defaultValue,
+		DisplaySettings: displaySettings,
+	}
+}
+
+func priorTemplateList(t *testing.T, displaySettings ...attr.Value) types.List {
+	t.Helper()
+
+	elements := make([]attr.Value, 0, len(displaySettings))
+	for i, ds := range displaySettings {
+		elements = append(elements, types.ObjectValueMust(getTemplateAttrTypes(), map[string]attr.Value{
+			"id":               types.StringNull(),
+			"name":             types.StringValue(string(rune('a' + i))),
+			"label":            types.StringNull(),
+			"help_text":        types.StringNull(),
+			"default_value":    types.StringNull(),
+			"display_settings": ds,
+		}))
+	}
+
+	return types.ListValueMust(types.ObjectType{AttrTypes: getTemplateAttrTypes()}, elements)
+}
+
+func displaySettingsAt(t *testing.T, list types.List, index int) types.Map {
+	t.Helper()
+
+	require.Greater(t, len(list.Elements()), index)
+	object, ok := list.Elements()[index].(types.Object)
+	require.True(t, ok)
+
+	value, ok := object.Attributes()["display_settings"].(types.Map)
+	require.True(t, ok)
+
+	return value
+}
+
+func TestFlattenTemplatesDisplaySettings(t *testing.T) {
+	emptyMap := types.MapValueMust(types.StringType, map[string]attr.Value{})
+	populatedMap := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"Octopus.ControlType": types.StringValue("SingleLineText"),
+	})
+
+	t.Run("server returns no display settings and prior is null", func(t *testing.T) {
+		templates := []actiontemplates.ActionTemplateParameter{templateWithDisplaySettings("a", nil)}
+
+		flattened := flattenTemplates(templates, priorTemplateList(t, types.MapNull(types.StringType)))
+
+		require.True(t, displaySettingsAt(t, flattened, 0).IsNull())
+	})
+
+	t.Run("server returns no display settings and prior is an empty map", func(t *testing.T) {
+		templates := []actiontemplates.ActionTemplateParameter{templateWithDisplaySettings("a", map[string]string{})}
+
+		flattened := flattenTemplates(templates, priorTemplateList(t, emptyMap))
+
+		require.Equal(t, emptyMap, displaySettingsAt(t, flattened, 0))
+	})
+
+	t.Run("server returns display settings", func(t *testing.T) {
+		templates := []actiontemplates.ActionTemplateParameter{
+			templateWithDisplaySettings("a", map[string]string{"Octopus.ControlType": "SingleLineText"}),
+		}
+
+		flattened := flattenTemplates(templates, priorTemplateList(t, types.MapNull(types.StringType)))
+
+		require.Equal(t, populatedMap, displaySettingsAt(t, flattened, 0))
+	})
+
+	t.Run("prior list is null, as it is on import", func(t *testing.T) {
+		templates := []actiontemplates.ActionTemplateParameter{templateWithDisplaySettings("a", nil)}
+
+		flattened := flattenTemplates(templates, types.ListNull(types.ObjectType{AttrTypes: getTemplateAttrTypes()}))
+
+		require.True(t, displaySettingsAt(t, flattened, 0).IsNull())
+	})
+
+	t.Run("prior list length does not match the server response", func(t *testing.T) {
+		templates := []actiontemplates.ActionTemplateParameter{
+			templateWithDisplaySettings("a", nil),
+			templateWithDisplaySettings("b", nil),
+		}
+
+		flattened := flattenTemplates(templates, priorTemplateList(t, emptyMap))
+
+		require.True(t, displaySettingsAt(t, flattened, 0).IsNull())
+		require.True(t, displaySettingsAt(t, flattened, 1).IsNull())
+	})
+
+	t.Run("prior values are mirrored per element", func(t *testing.T) {
+		templates := []actiontemplates.ActionTemplateParameter{
+			templateWithDisplaySettings("a", nil),
+			templateWithDisplaySettings("b", map[string]string{}),
+		}
+
+		flattened := flattenTemplates(templates, priorTemplateList(t, types.MapNull(types.StringType), emptyMap))
+
+		require.True(t, displaySettingsAt(t, flattened, 0).IsNull())
+		require.Equal(t, emptyMap, displaySettingsAt(t, flattened, 1))
+	})
+
+	t.Run("no templates", func(t *testing.T) {
+		flattened := flattenTemplates(nil, types.ListNull(types.ObjectType{AttrTypes: getTemplateAttrTypes()}))
+
+		require.True(t, flattened.IsNull())
+	})
+}

--- a/octopusdeploy_framework/resource_project_test.go
+++ b/octopusdeploy_framework/resource_project_test.go
@@ -155,6 +155,111 @@ func testAccProjectBasic(lifecycleLocalName string, lifecycleName string, projec
 		}`, localName, description, lifecycleLocalName, name, projectGroupLocalName, templates)
 }
 
+func TestAccProjectTemplateWithoutDisplaySettings(t *testing.T) {
+	lifecycleLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	lifecycleName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectGroupLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectGroupName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	description := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	prefix := "octopusdeploy_project." + localName
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccProjectCheckDestroy,
+			testAccProjectGroupCheckDestroy,
+			testAccLifecycleCheckDestroy,
+		),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				// A template that omits display_settings must stay null in state.
+				Config: testAccProjectWithTemplateDisplaySettings(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists(),
+					resource.TestCheckResourceAttr(prefix, "template.#", "1"),
+					resource.TestCheckNoResourceAttr(prefix, "template.0.display_settings.%"),
+				),
+			},
+			{
+				// An explicit empty map must stay an empty map.
+				Config: testAccProjectWithTemplateDisplaySettings(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description, "display_settings = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists(),
+					resource.TestCheckResourceAttr(prefix, "template.0.display_settings.%", "0"),
+				),
+			},
+			{
+				// Populated display settings are unaffected.
+				Config: testAccProjectWithTemplateDisplaySettings(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description, `display_settings = { "Octopus.ControlType" = "SingleLineText" }`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists(),
+					resource.TestCheckResourceAttr(prefix, "template.0.display_settings.Octopus.ControlType", "SingleLineText"),
+				),
+			},
+			{
+				// Back to omitted, this time alongside a dynamic block that also omits it.
+				Config: testAccProjectWithDynamicTemplates(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, localName, name, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists(),
+					resource.TestCheckResourceAttr(prefix, "template.#", "3"),
+					resource.TestCheckNoResourceAttr(prefix, "template.0.display_settings.%"),
+					resource.TestCheckNoResourceAttr(prefix, "template.1.display_settings.%"),
+					resource.TestCheckNoResourceAttr(prefix, "template.2.display_settings.%"),
+				),
+			},
+		},
+	})
+}
+
+func testAccProjectWithTemplateDisplaySettings(lifecycleLocalName string, lifecycleName string, projectGroupLocalName string, projectGroupName string, localName string, name string, description string, displaySettings string) string {
+	projectGroup := internaltest.NewProjectGroupTestOptions()
+	projectGroup.LocalName = projectGroupLocalName
+	projectGroup.Resource.Name = projectGroupName
+
+	return fmt.Sprintf(testAccLifecycle(lifecycleLocalName, lifecycleName)+"\n"+
+		internaltest.ProjectGroupConfiguration(projectGroup)+"\n"+
+		`resource "octopusdeploy_project" "%s" {
+			description      = "%s"
+			lifecycle_id     = octopusdeploy_lifecycle.%s.id
+			name             = "%s"
+			project_group_id = octopusdeploy_project_group.%s.id
+
+			template {
+				name = "static"
+				%s
+			}
+		}`, localName, description, lifecycleLocalName, name, projectGroupLocalName, displaySettings)
+}
+
+func testAccProjectWithDynamicTemplates(lifecycleLocalName string, lifecycleName string, projectGroupLocalName string, projectGroupName string, localName string, name string, description string) string {
+	projectGroup := internaltest.NewProjectGroupTestOptions()
+	projectGroup.LocalName = projectGroupLocalName
+	projectGroup.Resource.Name = projectGroupName
+
+	return fmt.Sprintf(testAccLifecycle(lifecycleLocalName, lifecycleName)+"\n"+
+		internaltest.ProjectGroupConfiguration(projectGroup)+"\n"+
+		`resource "octopusdeploy_project" "%s" {
+			description      = "%s"
+			lifecycle_id     = octopusdeploy_lifecycle.%s.id
+			name             = "%s"
+			project_group_id = octopusdeploy_project_group.%s.id
+
+			template {
+				name = "static"
+			}
+
+			dynamic "template" {
+				for_each = ["dynamic-one", "dynamic-two"]
+				content {
+					name = template.value
+				}
+			}
+		}`, localName, description, lifecycleLocalName, name, projectGroupLocalName)
+}
+
 func testAccProjectCheckDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "octopusdeploy_project" {


### PR DESCRIPTION
Fixes #247.

### The problem

A `template` block that leaves out `display_settings` fails apply:

```
Error: Provider produced inconsistent result after apply

When applying changes to octopusdeploy_project.example, provider
"provider[\"registry.terraform.io/hashicorp/octopusdeploy\"]" produced an
unexpected new value: .template[0].display_settings: was null, but now
cty.MapValEmpty(cty.String).
```

`display_settings` is `Optional` and not `Computed` (`octopusdeploy_framework/schemas/project.go:164-168`), so a map the configuration omits has to still be null when apply finishes. `flattenTemplates` built it no matter what, and `util.ConvertMapStringToMapAttrValue` hands back an empty non-nil map when given nil, so state got `{}` instead.

### The change

`flattenTemplates` now takes the planned template list (the state list on read) and writes null for an empty server map when the prior value was null. The Octopus API cannot tell an absent `DisplaySettings` from an empty one, so the prior value is the only thing that can decide which of the two to write back. That keeps `display_settings = {}` working for anyone who sets it explicitly, which matters for conditional HCL like `var.enabled ? { ... } : {}` inside a `dynamic "template"` block.

When the two lists cannot be lined up element for element, which happens on import and whenever the lengths differ, an empty server map becomes null. That matches the shape of a configuration that omits the attribute.

No schema change, so no state migration and no docs regeneration. The other optional attributes in the block already go through `util.StringOrNull` and are untouched.

### Tests

`TestFlattenTemplatesDisplaySettings` in the new `octopusdeploy_framework/resource_project_flatten_test.go` is a plain unit test over seven cases: prior null, prior empty, populated server map, import, length mismatch, per element mirroring, and no templates. It runs in CI without an Octopus instance.

`TestAccProjectTemplateWithoutDisplaySettings` covers the round trip: omitted, then explicit `{}`, then populated, then omitted again alongside a `dynamic "template"` block.

Acceptance tests do not run in CI for a fork PR, so here is the local run against Octopus Server 2026.3.9539.

Before the fix:

```
=== RUN   TestAccProjectTemplateWithoutDisplaySettings
    resource_project_test.go:168: Step 1/4 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply
        ...
        unexpected new value: .template[0].display_settings: was null, but now
        cty.MapValEmpty(cty.String).
--- FAIL: TestAccProjectTemplateWithoutDisplaySettings (7.65s)
```

After:

```
=== RUN   TestAccProjectTemplateWithoutDisplaySettings
--- PASS: TestAccProjectTemplateWithoutDisplaySettings (14.77s)
=== RUN   TestAccProjectBasic
--- PASS: TestAccProjectBasic (5.72s)
=== RUN   TestAccProjectWithUpdate
--- PASS: TestAccProjectWithUpdate (10.55s)
```

### On #187

#187 reports the same headline with a different tail: `.template: block count changed from 2 to 1`. I could not reproduce that on current main. Expand and flatten are 1:1, the API rejects duplicate template parameter names with a 400 rather than merging them, and an acceptance probe covering create, no-op, grow, shrink and reorder with a static plus dynamic block came back clean. This PR does not claim to fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
