### PR TITLE
fix: sync tenant_tags with the server

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -22,7 +22,7 @@ This resource manages tenants in Octopus Deploy.
 - `description` (String) The description of this tenant.
 - `is_disabled` (Boolean) The disabled status of this tenant.
 - `space_id` (String) The space ID associated with this tenant.
-- `tenant_tags` (Set of String) A list of tenant tags associated with this resource.
+- `tenant_tags` (Set of String) A list of tenant tags associated with this resource. Set this to an empty list to remove every tag from the tenant. Removing the attribute from your configuration instead leaves the existing tags in place and unmanaged.
 
 ### Read-Only
 

--- a/octopusdeploy_framework/resource_tenant.go
+++ b/octopusdeploy_framework/resource_tenant.go
@@ -9,10 +9,10 @@ import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -105,6 +105,10 @@ func (r *tenantTypeResource) Update(ctx context.Context, req resource.UpdateRequ
 	tflog.Debug(ctx, fmt.Sprintf("updating tenant '%s'", data.ID.ValueString()))
 
 	tenantFromApi, err := tenants.GetByID(r.Config.Client, data.SpaceID.ValueString(), data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("unable to load tenant", err.Error())
+		return
+	}
 
 	tenant, err := mapStateToTenant(ctx, data)
 	tenant.ID = state.ID.ValueString()
@@ -154,12 +158,14 @@ func mapStateToTenant(ctx context.Context, data *schemas.TenantModel) (*tenants.
 	tenant.IsDisabled = data.IsDisabled.ValueBool()
 	tenant.SpaceID = data.SpaceID.ValueString()
 
-	convertedTenantTags, diags := util.SetToStringArray(ctx, data.TenantTags)
-	if diags.HasError() {
-		tflog.Error(ctx, fmt.Sprintf("Error converting tenant tags: %v\n", diags))
-	}
+	if !data.TenantTags.IsUnknown() {
+		convertedTenantTags, diags := util.SetToStringArray(ctx, data.TenantTags)
+		if diags.HasError() {
+			tflog.Error(ctx, fmt.Sprintf("Error converting tenant tags: %v\n", diags))
+		}
 
-	tenant.TenantTags = convertedTenantTags
+		tenant.TenantTags = convertedTenantTags
+	}
 
 	return tenant, nil
 }
@@ -172,12 +178,28 @@ func mapTenantToState(ctx context.Context, data *schemas.TenantModel, tenant *te
 	data.SpaceID = types.StringValue(tenant.SpaceID)
 	data.Name = types.StringValue(tenant.Name)
 
-	convertedTenantTags, diags := util.SetToStringArray(ctx, data.TenantTags)
-	if diags.HasError() {
-		tflog.Error(ctx, fmt.Sprintf("Error converting tenant tags: %v\n", diags))
+	data.TenantTags = flattenTenantTags(tenant.TenantTags, data.TenantTags)
+}
+
+// flattenTenantTags maps the tags the API returned onto state. A null set stays
+// null so an attribute that was never set stays unset, but an existing empty set
+// is kept empty rather than collapsing to null - every tenant without tags holds
+// an empty set in state today, and flipping that to null would show up as a diff
+// for every one of them.
+func flattenTenantTags(tags []string, current types.Set) types.Set {
+	if len(tags) == 0 {
+		if current.IsNull() {
+			return types.SetNull(types.StringType)
+		}
+		return types.SetValueMust(types.StringType, []attr.Value{})
 	}
 
-	data.TenantTags = basetypes.SetValue(util.FlattenStringList(convertedTenantTags))
+	values := make([]attr.Value, 0, len(tags))
+	for _, tag := range tags {
+		values = append(values, types.StringValue(tag))
+	}
+
+	return types.SetValueMust(types.StringType, values)
 }
 
 func (*tenantTypeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/octopusdeploy_framework/resource_tenant_test.go
+++ b/octopusdeploy_framework/resource_tenant_test.go
@@ -5,7 +5,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
@@ -75,6 +77,138 @@ func testAccTenantBasic(lifecycleLocalName string, lifecycleName string, project
 		project_id   = "${octopusdeploy_project.%s.id}"
 		environment_ids = ["${octopusdeploy_environment.%s.id}"]
 	}`, localName, description, name, isDisabled, localName, projectLocalName, environmentLocalName)
+}
+
+// Covers https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/236:
+// tags written in config have to reach the server, tags changed on the server have
+// to show up as drift, and an empty list has to clear them.
+func TestAccTenantTags(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	resourceName := "octopusdeploy_tenant." + localName
+	firstTag := localName + "/first"
+	secondTag := localName + "/second"
+
+	var tenantID string
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccTenantCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantWithTags(localName, "[octopusdeploy_tag.first.canonical_tag_name]"),
+				Check: resource.ComposeTestCheckFunc(
+					testTenantExists(resourceName),
+					captureTenantID(resourceName, &tenantID),
+					resource.TestCheckResourceAttr(resourceName, "tenant_tags.#", "1"),
+					testTenantTagsOnServer(resourceName, firstTag),
+				),
+			},
+			{
+				Config: testAccTenantWithTags(localName, "[octopusdeploy_tag.second.canonical_tag_name]"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tenant_tags.#", "1"),
+					testTenantTagsOnServer(resourceName, secondTag),
+				),
+			},
+			{
+				// Change the tags behind Terraform's back. The refresh has to notice
+				// and the apply has to put them back.
+				PreConfig: func() { setTenantTagsOutOfBand(t, &tenantID, firstTag) },
+				Config:    testAccTenantWithTags(localName, "[octopusdeploy_tag.second.canonical_tag_name]"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tenant_tags.#", "1"),
+					testTenantTagsOnServer(resourceName, secondTag),
+				),
+			},
+			{
+				Config: testAccTenantWithTags(localName, "[]"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tenant_tags.#", "0"),
+					testTenantTagsOnServer(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccTenantWithTags(localName string, tenantTags string) string {
+	return fmt.Sprintf(`
+		resource "octopusdeploy_tag_set" "%[1]s" {
+		  name = "%[1]s"
+		}
+
+		resource "octopusdeploy_tag" "first" {
+		  name        = "first"
+		  color       = "#6e6e6e"
+		  description = "First tenant tag"
+		  tag_set_id  = octopusdeploy_tag_set.%[1]s.id
+		}
+
+		resource "octopusdeploy_tag" "second" {
+		  name        = "second"
+		  color       = "#6e6e6e"
+		  description = "Second tenant tag"
+		  tag_set_id  = octopusdeploy_tag_set.%[1]s.id
+		}
+
+		resource "octopusdeploy_tenant" "%[1]s" {
+		  name        = "%[1]s"
+		  description = "Tenant tag test"
+
+		  tenant_tags = %[2]s
+		}
+	`, localName, tenantTags)
+}
+
+func captureTenantID(prefix string, tenantID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[prefix]
+		if !ok {
+			return fmt.Errorf("Not found: %s", prefix)
+		}
+
+		*tenantID = rs.Primary.ID
+
+		return nil
+	}
+}
+
+func setTenantTagsOutOfBand(t *testing.T, tenantID *string, tags ...string) {
+	tenant, err := tenants.GetByID(octoClient, octoClient.GetSpaceID(), *tenantID)
+	if err != nil {
+		t.Fatalf("unable to load tenant (%s) to change its tags out of band: %s", *tenantID, err)
+	}
+
+	tenant.TenantTags = tags
+	if _, err := tenants.Update(octoClient, tenant); err != nil {
+		t.Fatalf("unable to change the tags on tenant (%s) out of band: %s", *tenantID, err)
+	}
+}
+
+func testTenantTagsOnServer(prefix string, expected ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[prefix]
+		if !ok {
+			return fmt.Errorf("Not found: %s", prefix)
+		}
+
+		tenant, err := tenants.GetByID(octoClient, octoClient.GetSpaceID(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		actual := append([]string{}, tenant.TenantTags...)
+		want := append([]string{}, expected...)
+		sort.Strings(actual)
+		sort.Strings(want)
+
+		if strings.Join(actual, ",") != strings.Join(want, ",") {
+			return fmt.Errorf("expected tenant tags %v on the server, got %v", want, actual)
+		}
+
+		return nil
+	}
 }
 
 func testTenantExists(prefix string) resource.TestCheckFunc {

--- a/octopusdeploy_framework/resource_tenant_unit_test.go
+++ b/octopusdeploy_framework/resource_tenant_unit_test.go
@@ -1,0 +1,69 @@
+package octopusdeploy_framework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFlattenTenantTags(t *testing.T) {
+	emptySet := types.SetValueMust(types.StringType, []attr.Value{})
+	populatedSet := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("Region/US")})
+
+	cases := []struct {
+		name     string
+		tags     []string
+		current  types.Set
+		expected types.Set
+	}{
+		{
+			name:     "tags from the api win over state",
+			tags:     []string{"Region/EU"},
+			current:  populatedSet,
+			expected: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("Region/EU")}),
+		},
+		{
+			name:     "tags from the api populate an empty set",
+			tags:     []string{"Region/US"},
+			current:  emptySet,
+			expected: populatedSet,
+		},
+		{
+			name:     "no tags keeps an empty set empty",
+			tags:     nil,
+			current:  emptySet,
+			expected: emptySet,
+		},
+		{
+			name:     "no tags clears a populated set",
+			tags:     nil,
+			current:  populatedSet,
+			expected: emptySet,
+		},
+		{
+			name:     "no tags keeps a null set null",
+			tags:     nil,
+			current:  types.SetNull(types.StringType),
+			expected: types.SetNull(types.StringType),
+		},
+		{
+			name:     "no tags resolves an unknown set to empty",
+			tags:     []string{},
+			current:  types.SetUnknown(types.StringType),
+			expected: emptySet,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := flattenTenantTags(tc.tags, tc.current)
+			if !actual.Equal(tc.expected) {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+			if actual.IsUnknown() {
+				t.Error("flattenTenantTags must never return an unknown value")
+			}
+		})
+	}
+}

--- a/octopusdeploy_framework/schemas/tenant.go
+++ b/octopusdeploy_framework/schemas/tenant.go
@@ -156,7 +156,7 @@ func (t TenantSchema) GetResourceSchema() resourceSchema.Schema {
 			"name":     GetNameResourceSchema(true),
 			"space_id": GetSpaceIdResourceSchema("tenant"),
 			"tenant_tags": resourceSchema.SetAttribute{
-				Description: "A list of tenant tags associated with this resource.",
+				Description: "A list of tenant tags associated with this resource. Set this to an empty list to remove every tag from the tenant. Removing the attribute from your configuration instead leaves the existing tags in place and unmanaged.",
 				ElementType: types.StringType,
 				Optional:    true,
 				Computed:    true,


### PR DESCRIPTION
Fixes #236.

## The bug

`mapTenantToState` took the tags from the model it was about to write into, not from the tenant the API returned:

```go
convertedTenantTags, diags := util.SetToStringArray(ctx, data.TenantTags)
...
data.TenantTags = basetypes.SetValue(util.FlattenStringList(convertedTenantTags))
```

`data` is prior state on `Read` and the plan on `Create`/`Update`, so `Read` copied state onto itself and the `tenant *tenants.Tenant` argument was never consulted for tags. Drift detection was structurally impossible: change a tenant's tags in the Octopus UI and the next plan is clean.

This came in with e688aa78, which stopped an "inconsistent result after apply" error by ignoring the server rather than by fixing the mapping.

## The fix

Read the tags from the API response through a small `flattenTenantTags` helper.

The helper keeps an existing empty set empty instead of collapsing it to null. That matters for the upgrade: `FlattenStringList(nil)` returns an empty list, so every tenant without tags holds `[]` in state today. Using `util.FlattenStringSet` here, as suggested on the issue, would return `SetNull` whenever the API returns no tags, turning `[]` into `null` for all of them.

Two smaller things in the same file:

- `mapStateToTenant` skips the conversion when the set is unknown, which stops a bogus diagnostic on create.
- The error from `tenants.GetByID` in `Update` was shadowed by the next assignment and never checked, so a failed lookup dereferenced a nil tenant on `tenantFromApi.ProjectEnvironments`.

## On clearing tags

`Tenant.TenantTags` is tagged `json:"TenantTags,omitempty"` and `util.SetToStringArray` returns a non-nil empty slice, so `tenant_tags = []` leaves the field out of the PUT body entirely. That looks like it should mean tags can never be cleared, and `resource_channel.go` carries a `newclient.UpdateRequest.Clear("TenantTags")` for what appears to be the same problem.

It turned out not to apply here. I wrote the clearing path, then checked it against a real instance: clearing already works, because the tenants endpoint replaces the whole document and an absent `TenantTags` is treated as empty. So the clearing code came back out and this PR is the read path only. The acceptance test covers the clear case so we'd find out if that ever changes.

## Testing

`TestFlattenTenantTags` covers the null / empty / populated / unknown matrix and needs no Octopus instance.

`TestAccTenantTags` runs create with a tag, change to a different tag, change the tags out of band and confirm the apply puts them back, then clear with `[]`. It asserts server-side state at every step, since state-only assertions would have passed against the bug.

Against this branch:

```
--- PASS: TestAccTenantBasic (9.40s)
--- PASS: TestAccTenantTags (13.47s)
```

Against `main` with only the new test applied, the drift step fails as expected:

```
resource_tenant_test.go:93: Step 3/4 error: Check failed: Check 2/2 error:
  expected tenant tags [rcdbyorjczxhdecluven/second] on the server, got [rcdbyorjczxhdecluven/first]
```

`TestAccDataSourceTenants` and `TestAccChannelTenantTagRemoval` also pass.

## Known limitation

`tenant_tags` stays `Optional + Computed` with `UseStateForUnknown`, so deleting the attribute from your configuration leaves the existing tags in place rather than removing them. Set `tenant_tags = []` to clear. The attribute description now says so.

Making config authoritative would mean dropping `Computed`, which forces a diff on every existing configuration. That felt like a separate conversation rather than something to slip into a bug fix; happy to open an issue for it if you want it revisited.
