### PR TITLE
fix: stop lifecycle read panicking on phase retention

### DIFF
--- a/octopusdeploy_framework/resource_lifecycle.go
+++ b/octopusdeploy_framework/resource_lifecycle.go
@@ -268,24 +268,45 @@ func (r *lifecycleTypeResource) Delete(ctx context.Context, req resource.DeleteR
 
 func handleUnitCasing(lifecycleFromGo *lifecycles.Lifecycle, lifecycleInState *lifecycles.Lifecycle) {
 	// Set state to the casing provided in the desired state, as the Api will always return capitalised units
-	lifecycleFromGo.ReleaseRetentionPolicy = updateUnitsFromGoToMatchStateCasing(lifecycleFromGo.ReleaseRetentionPolicy, lifecycleInState.ReleaseRetentionPolicy.Unit)
-	lifecycleFromGo.TentacleRetentionPolicy = updateUnitsFromGoToMatchStateCasing(lifecycleFromGo.TentacleRetentionPolicy, lifecycleInState.TentacleRetentionPolicy.Unit)
-
-	if len(lifecycleInState.Phases) == 0 {
-		return
-	}
+	lifecycleFromGo.ReleaseRetentionPolicy = updateUnitsFromGoToMatchStateCasing(lifecycleFromGo.ReleaseRetentionPolicy, retentionUnit(lifecycleInState.ReleaseRetentionPolicy))
+	lifecycleFromGo.TentacleRetentionPolicy = updateUnitsFromGoToMatchStateCasing(lifecycleFromGo.TentacleRetentionPolicy, retentionUnit(lifecycleInState.TentacleRetentionPolicy))
 
 	for i, phaseFromGo := range lifecycleFromGo.Phases {
+		// The server can return more phases than state knows about, and a phase in
+		// state carries no retention at all when the configuration leaves it out.
+		if i >= len(lifecycleInState.Phases) {
+			break
+		}
+
+		phaseInState := lifecycleInState.Phases[i]
+		if phaseInState == nil {
+			continue
+		}
+
 		if phaseFromGo.ReleaseRetentionPolicy != nil && phaseFromGo.ReleaseRetentionPolicy.Unit != "" {
-			phaseFromGo.ReleaseRetentionPolicy = updateUnitsFromGoToMatchStateCasing(phaseFromGo.ReleaseRetentionPolicy, lifecycleInState.Phases[i].ReleaseRetentionPolicy.Unit)
+			phaseFromGo.ReleaseRetentionPolicy = updateUnitsFromGoToMatchStateCasing(phaseFromGo.ReleaseRetentionPolicy, retentionUnit(phaseInState.ReleaseRetentionPolicy))
 		}
 		if phaseFromGo.TentacleRetentionPolicy != nil && phaseFromGo.TentacleRetentionPolicy.Unit != "" {
-			phaseFromGo.TentacleRetentionPolicy = updateUnitsFromGoToMatchStateCasing(phaseFromGo.TentacleRetentionPolicy, lifecycleInState.Phases[i].TentacleRetentionPolicy.Unit)
+			phaseFromGo.TentacleRetentionPolicy = updateUnitsFromGoToMatchStateCasing(phaseFromGo.TentacleRetentionPolicy, retentionUnit(phaseInState.TentacleRetentionPolicy))
 		}
 	}
 }
 
+// retentionUnit reads the unit from a retention policy that may not be there. An
+// empty unit matches nothing, so the value the API returned is left as it is.
+func retentionUnit(retentionPeriod *core.RetentionPeriod) string {
+	if retentionPeriod == nil {
+		return ""
+	}
+
+	return retentionPeriod.Unit
+}
+
 func updateUnitsFromGoToMatchStateCasing(retentionPeriodFromGo *core.RetentionPeriod, unitInState string) *core.RetentionPeriod {
+	if retentionPeriodFromGo == nil {
+		return nil
+	}
+
 	if strings.EqualFold(retentionPeriodFromGo.Unit, unitInState) {
 		replacementForRetentionFromGo := core.RetentionPeriod{
 			QuantityToKeep:    retentionPeriodFromGo.QuantityToKeep,

--- a/octopusdeploy_framework/resource_lifecycle_retention_test.go
+++ b/octopusdeploy_framework/resource_lifecycle_retention_test.go
@@ -5,8 +5,10 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccLifecycleRetentionUpdates(t *testing.T) {
@@ -198,6 +200,75 @@ func TestAccLifecycleWithPhaseInheritingRetentions(t *testing.T) {
 			},
 		},
 	})
+}
+
+// Regression test for https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/224.
+// A phase that has a retention policy on the server but none in state used to panic
+// in handleUnitCasing. That combination is what upgrading from v1.14 leaves behind:
+// the old release_retention_policy block is gone from the schema, so state has no
+// phase retention, while the server still holds the policy the old provider wrote.
+func TestAccLifecyclePhaseRetentionMissingFromState(t *testing.T) {
+	lifecycleName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	phaseName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	lifecycleResource := "octopusdeploy_lifecycle." + lifecycleName
+
+	var lifecycleID string
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccLifecycleCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: lifecycle_phaseAndNoRetention(lifecycleName, phaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecycleExists(lifecycleResource),
+					captureLifecycleID(lifecycleResource, &lifecycleID),
+					resource.TestCheckResourceAttr(lifecycleResource, "phase.0.release_retention_with_strategy.#", "0"),
+					resource.TestCheckResourceAttr(lifecycleResource, "phase.0.tentacle_retention_with_strategy.#", "0"),
+				),
+			},
+			{
+				PreConfig: func() { setPhaseRetentionOutOfBand(t, &lifecycleID) },
+				Config:    lifecycle_phaseAndNoRetention(lifecycleName, phaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecycleExists(lifecycleResource),
+					resource.TestCheckResourceAttr(lifecycleResource, "phase.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func captureLifecycleID(resourceAddress string, lifecycleID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceAddress]
+		if !ok {
+			return fmt.Errorf("lifecycle resource %q not found in state", resourceAddress)
+		}
+
+		*lifecycleID = rs.Primary.ID
+
+		return nil
+	}
+}
+
+func setPhaseRetentionOutOfBand(t *testing.T, lifecycleID *string) {
+	lifecycle, err := octoClient.Lifecycles.GetByID(*lifecycleID)
+	if err != nil {
+		t.Fatalf("unable to load lifecycle (%s) to change its phase retention out of band: %s", *lifecycleID, err)
+	}
+
+	if len(lifecycle.Phases) == 0 {
+		t.Fatalf("expected lifecycle (%s) to have a phase", *lifecycleID)
+	}
+
+	lifecycle.Phases[0].ReleaseRetentionPolicy = core.CountBasedRetentionPeriod(3, core.RetentionUnitDays)
+	lifecycle.Phases[0].TentacleRetentionPolicy = core.CountBasedRetentionPeriod(3, core.RetentionUnitDays)
+
+	if _, err := octoClient.Lifecycles.Update(lifecycle); err != nil {
+		t.Fatalf("unable to set the phase retention on lifecycle (%s) out of band: %s", *lifecycleID, err)
+	}
 }
 
 func lifecycle_noRetention(lifecycleName string) string {


### PR DESCRIPTION
Fixes #224.

## The crash

`handleUnitCasing` took the retention unit straight off the state's phase without checking there was one:

```go
if phaseFromGo.ReleaseRetentionPolicy != nil && phaseFromGo.ReleaseRetentionPolicy.Unit != "" {
    phaseFromGo.ReleaseRetentionPolicy = updateUnitsFromGoToMatchStateCasing(phaseFromGo.ReleaseRetentionPolicy, lifecycleInState.Phases[i].ReleaseRetentionPolicy.Unit)
}
```

The guard covers the server's pointer. The state's pointer is dereferenced unconditionally, and `expandPhases` leaves it nil whenever `release_retention_with_strategy` is absent from the configuration.

That is the position an upgrade from v1.14 leaves you in. The old `release_retention_policy` block is gone from the schema, so state has no phase retention, while the server still holds the policy the earlier provider wrote. The guard passes, the dereference panics, and `terraform apply` dies during read.

Two more problems in the same loop:

- `lifecycleInState.Phases[i]` is indexed by the count of phases the *server* returned. The early return above it only catches the case where state has no phases at all, not where the two counts differ, so the index can run off the end of the slice.
- `updateUnitsFromGoToMatchStateCasing` dereferences its argument immediately. The two top level calls survive only because `setInitialRetention` backfills those policies first. Nothing backfills the phases.

## The fix

Guard both state side dereferences through a small `retentionUnit` helper that returns an empty string for a missing policy. An empty unit matches nothing, so the value the API returned is left alone, which is the right outcome when state has no casing to preserve.

Bound the loop by the number of phases in state instead of relying on the early return, and skip a nil phase.

`updateUnitsFromGoToMatchStateCasing` now returns nil unchanged rather than dereferencing it.

## Testing

`TestAccLifecyclePhaseRetentionMissingFromState` creates a lifecycle with a phase and no phase retention, then gives that phase a retention policy on the server through the SDK, leaving state without one. That is the same state-nil against server-non-nil shape the upgrade produces, without needing an old provider binary to set it up.

Against `main` the new test reproduces the reported stack exactly:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework.handleUnitCasing(...)
	octopusdeploy_framework/resource_lifecycle.go:280
github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework.(*lifecycleTypeResource).Read(...)
	octopusdeploy_framework/resource_lifecycle.go:176
```

With the fix it passes, and so does the rest of the lifecycle suite:

```
--- PASS: TestAccLifecyclePhaseRetentionMissingFromState (9.64s)
--- PASS: TestAccLifecycleRetentionUpdates
--- PASS: TestAccLifecycleWithPhaseInheritingRetentions
--- PASS: TestAccLifecycleRetentionUnit_caseInsensitive
--- PASS: TestAccLifecycleComplex_usingNewRetention
--- PASS: TestAccLifecycleBasic
--- PASS: TestAccLifecycleWithUpdate
(plus the 16 space default retention tests)
ok  	github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework	226.125s
```

`handleUnitCasing` is shared by the deprecated and current read paths, so both are covered by the change.
