### PR TITLE
fix: let process resources be imported from another space

### DIFF
--- a/docs/resources/process.md
+++ b/docs/resources/process.md
@@ -257,4 +257,8 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import [options] octopusdeploy_process.<name> <process-id>
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process.<name> "<space-id>:<process-id>"
 ```

--- a/docs/resources/process_child_step.md
+++ b/docs/resources/process_child_step.md
@@ -181,4 +181,8 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import [options] octopusdeploy_process_child_step.<name> "<process-id>:<parent-step-id>:<child-step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_child_step.<name> "<space-id>:<process-id>:<parent-step-id>:<child-step-id>"
 ```

--- a/docs/resources/process_child_steps_order.md
+++ b/docs/resources/process_child_steps_order.md
@@ -106,4 +106,8 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import [options] octopusdeploy_process_child_steps_order.<name> "<process-id>:<parent-step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_child_steps_order.<name> "<space-id>:<process-id>:<parent-step-id>"
 ```

--- a/docs/resources/process_step.md
+++ b/docs/resources/process_step.md
@@ -212,4 +212,8 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import [options] octopusdeploy_process_step.<name> "<process-id>:<step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_step.<name> "<space-id>:<process-id>:<step-id>"
 ```

--- a/docs/resources/process_steps_order.md
+++ b/docs/resources/process_steps_order.md
@@ -95,4 +95,8 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import [options] octopusdeploy_process_steps_order.<name> <process-id>
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_steps_order.<name> "<space-id>:<process-id>"
 ```

--- a/docs/resources/process_templated_child_step.md
+++ b/docs/resources/process_templated_child_step.md
@@ -213,4 +213,8 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import [options] octopusdeploy_process_templated_child_step.<name> "<process-id>:<parent-step-id>:<child-step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_templated_child_step.<name> "<space-id>:<process-id>:<parent-step-id>:<child-step-id>"
 ```

--- a/docs/resources/process_templated_step.md
+++ b/docs/resources/process_templated_step.md
@@ -194,4 +194,8 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import [options] octopusdeploy_process_templated_step.<name> "<process-id>:<step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_templated_step.<name> "<space-id>:<process-id>:<step-id>"
 ```

--- a/examples/resources/octopusdeploy_process/import.sh
+++ b/examples/resources/octopusdeploy_process/import.sh
@@ -1,1 +1,5 @@
 terraform import [options] octopusdeploy_process.<name> <process-id>
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process.<name> "<space-id>:<process-id>"

--- a/examples/resources/octopusdeploy_process_child_step/import.sh
+++ b/examples/resources/octopusdeploy_process_child_step/import.sh
@@ -1,1 +1,5 @@
 terraform import [options] octopusdeploy_process_child_step.<name> "<process-id>:<parent-step-id>:<child-step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_child_step.<name> "<space-id>:<process-id>:<parent-step-id>:<child-step-id>"

--- a/examples/resources/octopusdeploy_process_child_steps_order/import.sh
+++ b/examples/resources/octopusdeploy_process_child_steps_order/import.sh
@@ -1,1 +1,5 @@
 terraform import [options] octopusdeploy_process_child_steps_order.<name> "<process-id>:<parent-step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_child_steps_order.<name> "<space-id>:<process-id>:<parent-step-id>"

--- a/examples/resources/octopusdeploy_process_step/import.sh
+++ b/examples/resources/octopusdeploy_process_step/import.sh
@@ -1,1 +1,5 @@
 terraform import [options] octopusdeploy_process_step.<name> "<process-id>:<step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_step.<name> "<space-id>:<process-id>:<step-id>"

--- a/examples/resources/octopusdeploy_process_steps_order/import.sh
+++ b/examples/resources/octopusdeploy_process_steps_order/import.sh
@@ -1,1 +1,5 @@
 terraform import [options] octopusdeploy_process_steps_order.<name> <process-id>
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_steps_order.<name> "<space-id>:<process-id>"

--- a/examples/resources/octopusdeploy_process_templated_child_step/import.sh
+++ b/examples/resources/octopusdeploy_process_templated_child_step/import.sh
@@ -1,1 +1,5 @@
 terraform import [options] octopusdeploy_process_templated_child_step.<name> "<process-id>:<parent-step-id>:<child-step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_templated_child_step.<name> "<space-id>:<process-id>:<parent-step-id>:<child-step-id>"

--- a/examples/resources/octopusdeploy_process_templated_step/import.sh
+++ b/examples/resources/octopusdeploy_process_templated_step/import.sh
@@ -1,1 +1,5 @@
 terraform import [options] octopusdeploy_process_templated_step.<name> "<process-id>:<step-id>"
+
+# Resources in a space other than the provider's can be imported by prefixing
+# the identifier with that space:
+terraform import [options] octopusdeploy_process_templated_step.<name> "<space-id>:<process-id>:<step-id>"

--- a/octopusdeploy_framework/process_wrapper.go
+++ b/octopusdeploy_framework/process_wrapper.go
@@ -33,6 +33,43 @@ type processWrapper interface { // Better name?
 	GetSteps() []*deployments.DeploymentStep
 }
 
+// spaceIdentifierPrefix is the prefix every Octopus space ID carries. Space IDs
+// never contain a colon, so an import identifier can be checked for a leading
+// space without depending on how many segments the rest of it has.
+const spaceIdentifierPrefix = "Spaces-"
+
+// splitImportSpaceID pulls an optional leading space off an import identifier and
+// returns it alongside the remaining segments. An identifier that does not start
+// with a space comes back unchanged with an empty space, so the identifiers
+// documented before spaces were supported keep working.
+func splitImportSpaceID(importID string) (string, []string) {
+	identifiers := strings.Split(importID, ":")
+
+	if len(identifiers) > 1 && strings.HasPrefix(identifiers[0], spaceIdentifierPrefix) {
+		return identifiers[0], identifiers[1:]
+	}
+
+	return "", identifiers
+}
+
+// describeSpaceScopedFailure explains which space was searched. The API answers a
+// lookup in the wrong space the same way it answers one for something that does
+// not exist, which is hard to act on when the space came from the provider rather
+// than from anything the practitioner wrote.
+func describeSpaceScopedFailure(client *client.Client, spaceId string, resourceId string, cause error) string {
+	searched := spaceId
+	source := "the import identifier"
+	if searched == "" {
+		searched = client.GetSpaceID()
+		source = "the provider"
+	}
+
+	return fmt.Sprintf(
+		"Could not find '%s' in space '%s' (taken from %s). If it belongs to another space, either configure the provider with that space_id or prefix the import identifier with the space, for example '%s2:%s'. Underlying error: %s",
+		resourceId, searched, source, spaceIdentifierPrefix, resourceId, cause,
+	)
+}
+
 func findDeploymentStepByID(steps []*deployments.DeploymentStep, stepID string) (*deployments.DeploymentStep, bool) {
 	for _, step := range steps {
 		if step.ID == stepID {
@@ -81,7 +118,7 @@ func loadProcessWrapper(client *client.Client, spaceId string, projectId string,
 	// Load corresponding project to check if it's version controlled
 	project, projectError := projects.GetByID(client, spaceId, projectId)
 	if projectError != nil {
-		diags.AddError("Unable to load project for the process", projectError.Error())
+		diags.AddError("Unable to load project for the process", describeSpaceScopedFailure(client, spaceId, projectId, projectError))
 		return nil, diags
 	}
 

--- a/octopusdeploy_framework/process_wrapper_unit_test.go
+++ b/octopusdeploy_framework/process_wrapper_unit_test.go
@@ -1,0 +1,68 @@
+package octopusdeploy_framework
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitImportSpaceID(t *testing.T) {
+	cases := []struct {
+		name          string
+		importID      string
+		expectedSpace string
+		expectedRest  []string
+	}{
+		{
+			name:         "a bare process keeps working",
+			importID:     "deploymentprocess-Projects-123",
+			expectedRest: []string{"deploymentprocess-Projects-123"},
+		},
+		{
+			name:         "a process and step keep working",
+			importID:     "deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000001",
+			expectedRest: []string{"deploymentprocess-Projects-123", "00000000-0000-0000-0000-000000000001"},
+		},
+		{
+			name:          "a leading space is taken off a process",
+			importID:      "Spaces-2:deploymentprocess-Projects-123",
+			expectedSpace: "Spaces-2",
+			expectedRest:  []string{"deploymentprocess-Projects-123"},
+		},
+		{
+			name:          "a leading space is taken off a process and step",
+			importID:      "Spaces-2:deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000001",
+			expectedSpace: "Spaces-2",
+			expectedRest:  []string{"deploymentprocess-Projects-123", "00000000-0000-0000-0000-000000000001"},
+		},
+		{
+			name:          "a leading space is taken off a process, parent and child",
+			importID:      "Spaces-12:deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010:00000000-0000-0000-0000-000000000012",
+			expectedSpace: "Spaces-12",
+			expectedRest:  []string{"deploymentprocess-Projects-123", "00000000-0000-0000-0000-000000000010", "00000000-0000-0000-0000-000000000012"},
+		},
+		{
+			name:         "a space on its own is not treated as a prefix",
+			importID:     "Spaces-2",
+			expectedRest: []string{"Spaces-2"},
+		},
+		{
+			name:         "a runbook process is not mistaken for a space",
+			importID:     "runbookprocess-Projects-123",
+			expectedRest: []string{"runbookprocess-Projects-123"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			space, rest := splitImportSpaceID(tc.importID)
+
+			if space != tc.expectedSpace {
+				t.Errorf("expected space %q, got %q", tc.expectedSpace, space)
+			}
+
+			if strings.Join(rest, ":") != strings.Join(tc.expectedRest, ":") {
+				t.Errorf("expected remainder %v, got %v", tc.expectedRest, rest)
+			}
+		})
+	}
+}

--- a/octopusdeploy_framework/resource_process.go
+++ b/octopusdeploy_framework/resource_process.go
@@ -40,12 +40,27 @@ func (r *processResource) Configure(_ context.Context, req resource.ConfigureReq
 }
 
 func (r *processResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	process, diags := loadProcessWrapperByProcessId(r.Config.Client, r.Config.SpaceID, request.ID)
+	spaceId, identifiers := splitImportSpaceID(request.ID)
+
+	if len(identifiers) != 1 {
+		response.Diagnostics.AddError(
+			"Incorrect Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: ProcessId or SpaceId:ProcessId (e.g. deploymentprocess-Projects-123 or Spaces-2:deploymentprocess-Projects-123). Got: %q", request.ID),
+		)
+		return
+	}
+
+	if spaceId == "" {
+		spaceId = r.Config.SpaceID
+	}
+
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, identifiers[0])
 	if len(diags) > 0 {
 		response.Diagnostics.Append(diags...)
 		return
 	}
 
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("space_id"), process.GetSpaceID())...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("project_id"), process.GetProjectID())...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), process.GetID())...)
 }

--- a/octopusdeploy_framework/resource_process_child_step.go
+++ b/octopusdeploy_framework/resource_process_child_step.go
@@ -3,7 +3,6 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
@@ -40,16 +39,19 @@ func (r *processChildStepResource) Configure(_ context.Context, req resource.Con
 }
 
 func (r *processChildStepResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	identifiers := strings.Split(request.ID, ":")
+	spaceId, identifiers := splitImportSpaceID(request.ID)
 
 	if len(identifiers) != 3 {
 		response.Diagnostics.AddError(
 			"Incorrect Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: ProcessId:ParentStepId:ChildStepId (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010:00000000-0000-0000-0000-000000000012). Got: %q", request.ID),
+			fmt.Sprintf("Expected import identifier with format: ProcessId:ParentStepId:ChildStepId, optionally prefixed with a space (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010:00000000-0000-0000-0000-000000000012 or Spaces-2:deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010:00000000-0000-0000-0000-000000000012). Got: %q", request.ID),
 		)
 		return
 	}
 
+	if spaceId != "" {
+		response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("space_id"), spaceId)...)
+	}
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("process_id"), identifiers[0])...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("parent_id"), identifiers[1])...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), identifiers[2])...)

--- a/octopusdeploy_framework/resource_process_child_steps_order.go
+++ b/octopusdeploy_framework/resource_process_child_steps_order.go
@@ -3,6 +3,7 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"strings"
 )
 
 var (
@@ -42,24 +42,27 @@ func (r *processChildStepsOrderResource) Configure(_ context.Context, req resour
 }
 
 func (r *processChildStepsOrderResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	identifiers := strings.Split(request.ID, ":")
+	spaceId, identifiers := splitImportSpaceID(request.ID)
 
 	if len(identifiers) != 2 {
 		response.Diagnostics.AddError(
 			"Incorrect Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: ProcessId:ParentStepId (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010). Got: %q", request.ID),
+			fmt.Sprintf("Expected import identifier with format: ProcessId:ParentStepId, optionally prefixed with a space (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010 or Spaces-2:deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010). Got: %q", request.ID),
 		)
 		return
 	}
 
 	processId := identifiers[0]
 	parentStepId := identifiers[1]
+	if spaceId == "" {
+		spaceId = r.Config.SpaceID
+	}
 
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("process_id"), processId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("parent_id"), parentStepId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), parentStepId)...)
 
-	process, diags := loadProcessWrapperByProcessId(r.Config.Client, r.Config.SpaceID, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		response.Diagnostics.Append(diags...)
 		return
@@ -81,6 +84,7 @@ func (r *processChildStepsOrderResource) ImportState(ctx context.Context, reques
 	}
 	children, _ := types.ListValue(types.StringType, actions)
 
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("space_id"), process.GetSpaceID())...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("process_id"), processId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("parent_id"), parentStepId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), parentStepId)...)

--- a/octopusdeploy_framework/resource_process_import_test.go
+++ b/octopusdeploy_framework/resource_process_import_test.go
@@ -1,0 +1,127 @@
+package octopusdeploy_framework
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// Covers https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/47.
+// A process that lives outside the provider's space cannot be imported by its bare
+// identifier, because the lookup resolves against the client's space. Prefixing the
+// identifier with the space makes it importable, and the failure without one says so.
+func TestAccProcessImportFromAnotherSpace(t *testing.T) {
+	spaceName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	config := testAccProcessInSpaceConfiguration(spaceName, localName)
+
+	orderResource := "octopusdeploy_process_steps_order." + localName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(orderResource, "process_id"),
+					resource.TestCheckResourceAttrSet(orderResource, "space_id"),
+				),
+			},
+			{
+				// Without the space the process cannot be found, and the diagnostic
+				// has to explain which space was searched.
+				Config:            config,
+				ResourceName:      orderResource,
+				ImportState:       true,
+				ImportStateIdFunc: processIdFromState(orderResource, false),
+				ExpectError:       regexp.MustCompile(`(?s)Could not find.*If it belongs to another space`),
+			},
+			{
+				Config:            config,
+				ResourceName:      orderResource,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: processIdFromState(orderResource, true),
+			},
+		},
+	})
+}
+
+// processIdFromState builds the import identifier for the steps order resource,
+// optionally prefixed with the space it lives in.
+func processIdFromState(resourceAddress string, qualifyWithSpace bool) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		rs, ok := state.RootModule().Resources[resourceAddress]
+		if !ok {
+			return "", fmt.Errorf("resource %q not found in state", resourceAddress)
+		}
+
+		processId := rs.Primary.Attributes["process_id"]
+		if !qualifyWithSpace {
+			return processId, nil
+		}
+
+		return fmt.Sprintf("%s:%s", rs.Primary.Attributes["space_id"], processId), nil
+	}
+}
+
+func testAccProcessInSpaceConfiguration(spaceName string, localName string) string {
+	return fmt.Sprintf(`
+		resource "octopusdeploy_space" "%[2]s" {
+		  name                  = "%[1]s"
+		  is_default            = false
+		  is_task_queue_stopped = true
+		  description           = "Space for the process import test"
+		  space_managers_teams  = ["teams-administrators"]
+		}
+
+		data "octopusdeploy_lifecycles" "%[2]s" {
+		  ids          = null
+		  partial_name = "Default Lifecycle"
+		  space_id     = octopusdeploy_space.%[2]s.id
+		  skip         = 0
+		  take         = 1
+		}
+
+		resource "octopusdeploy_project_group" "%[2]s" {
+		  space_id = octopusdeploy_space.%[2]s.id
+		  name     = "%[1]s"
+		}
+
+		resource "octopusdeploy_project" "%[2]s" {
+		  space_id         = octopusdeploy_space.%[2]s.id
+		  name             = "%[1]s"
+		  lifecycle_id     = data.octopusdeploy_lifecycles.%[2]s.lifecycles[0].id
+		  project_group_id = octopusdeploy_project_group.%[2]s.id
+		}
+
+		resource "octopusdeploy_process" "%[2]s" {
+		  space_id   = octopusdeploy_space.%[2]s.id
+		  project_id = octopusdeploy_project.%[2]s.id
+		}
+
+		resource "octopusdeploy_process_step" "%[2]s" {
+		  space_id   = octopusdeploy_space.%[2]s.id
+		  process_id = octopusdeploy_process.%[2]s.id
+		  name       = "%[1]s"
+		  type       = "Octopus.Script"
+		  properties = {
+		    "Octopus.Action.TargetRoles" = "role-one"
+		  }
+		  execution_properties = {
+		    "Octopus.Action.Script.ScriptBody" = "."
+		  }
+		}
+
+		resource "octopusdeploy_process_steps_order" "%[2]s" {
+		  space_id   = octopusdeploy_space.%[2]s.id
+		  process_id = octopusdeploy_process.%[2]s.id
+		  steps      = [octopusdeploy_process_step.%[2]s.id]
+		}
+	`, spaceName, localName)
+}

--- a/octopusdeploy_framework/resource_process_step.go
+++ b/octopusdeploy_framework/resource_process_step.go
@@ -44,16 +44,19 @@ func (r *processStepResource) Configure(_ context.Context, req resource.Configur
 }
 
 func (r *processStepResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	identifiers := strings.Split(request.ID, ":")
+	spaceId, identifiers := splitImportSpaceID(request.ID)
 
 	if len(identifiers) != 2 {
 		response.Diagnostics.AddError(
 			"Incorrect Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: ProcessId:StepId (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000001). Got: %q", request.ID),
+			fmt.Sprintf("Expected import identifier with format: ProcessId:StepId, optionally prefixed with a space (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000001 or Spaces-2:deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000001). Got: %q", request.ID),
 		)
 		return
 	}
 
+	if spaceId != "" {
+		response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("space_id"), spaceId)...)
+	}
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("process_id"), identifiers[0])...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), identifiers[1])...)
 }

--- a/octopusdeploy_framework/resource_process_steps_order.go
+++ b/octopusdeploy_framework/resource_process_steps_order.go
@@ -41,9 +41,22 @@ func (r *processStepsOrderResource) Configure(_ context.Context, req resource.Co
 }
 
 func (r *processStepsOrderResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	processId := request.ID
+	spaceId, segments := splitImportSpaceID(request.ID)
 
-	process, diags := loadProcessWrapperByProcessId(r.Config.Client, r.Config.SpaceID, processId)
+	if len(segments) != 1 {
+		response.Diagnostics.AddError(
+			"Incorrect Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: ProcessId or SpaceId:ProcessId (e.g. deploymentprocess-Projects-123 or Spaces-2:deploymentprocess-Projects-123). Got: %q", request.ID),
+		)
+		return
+	}
+
+	processId := segments[0]
+	if spaceId == "" {
+		spaceId = r.Config.SpaceID
+	}
+
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		response.Diagnostics.Append(diags...)
 		return
@@ -61,6 +74,7 @@ func (r *processStepsOrderResource) ImportState(ctx context.Context, request res
 	response.Diagnostics.Append(stepDiagnostics...)
 
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), processId)...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("space_id"), process.GetSpaceID())...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("process_id"), processId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("steps"), importedSteps)...)
 }

--- a/octopusdeploy_framework/resource_process_templated_child_step.go
+++ b/octopusdeploy_framework/resource_process_templated_child_step.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
@@ -45,17 +44,17 @@ func (r *processTemplatedChildStepResource) Configure(_ context.Context, req res
 }
 
 func (r *processTemplatedChildStepResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	identifiers := strings.Split(request.ID, ":")
+	spaceId, identifiers := splitImportSpaceID(request.ID)
 
 	if len(identifiers) != 3 {
 		response.Diagnostics.AddError(
 			"Incorrect Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: ProcessId:ParentStepId:ChildStepId (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010:00000000-0000-0000-0000-000000000012). Got: %q", request.ID),
+			fmt.Sprintf("Expected import identifier with format: ProcessId:ParentStepId:ChildStepId, optionally prefixed with a space (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010:00000000-0000-0000-0000-000000000012 or Spaces-2:deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000010:00000000-0000-0000-0000-000000000012). Got: %q", request.ID),
 		)
 		return
 	}
 
-	spaceId := "" // Client's space is used for imported resources
+	// An identifier without a space falls back to the client's space
 	processId := identifiers[0]
 	parentId := identifiers[1]
 	actionId := identifiers[2]
@@ -98,6 +97,7 @@ func (r *processTemplatedChildStepResource) ImportState(ctx context.Context, req
 	}
 
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), actionId)...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("space_id"), process.GetSpaceID())...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("process_id"), processId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("parent_id"), parentId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("template_id"), templateId.Value)...)

--- a/octopusdeploy_framework/resource_process_templated_step.go
+++ b/octopusdeploy_framework/resource_process_templated_step.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
@@ -49,17 +48,17 @@ func (r *processTemplatedStepResource) Configure(_ context.Context, req resource
 }
 
 func (r *processTemplatedStepResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	identifiers := strings.Split(request.ID, ":")
+	spaceId, identifiers := splitImportSpaceID(request.ID)
 
 	if len(identifiers) != 2 {
 		response.Diagnostics.AddError(
 			"Incorrect Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: ProcessId:StepId (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000001). Got: %q", request.ID),
+			fmt.Sprintf("Expected import identifier with format: ProcessId:StepId, optionally prefixed with a space (e.g. deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000001 or Spaces-2:deploymentprocess-Projects-123:00000000-0000-0000-0000-000000000001). Got: %q", request.ID),
 		)
 		return
 	}
 
-	spaceId := "" // Client's space is used for imported resources
+	// An identifier without a space falls back to the client's space
 	processId := identifiers[0]
 	stepId := identifiers[1]
 	tflog.Info(ctx, fmt.Sprintf("importing templated process step (%s) from process (%s)", stepId, processId))
@@ -101,6 +100,7 @@ func (r *processTemplatedStepResource) ImportState(ctx context.Context, request 
 	}
 
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), stepId)...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("space_id"), process.GetSpaceID())...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("process_id"), processId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("template_id"), templateId.Value)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("template_version"), version)...)


### PR DESCRIPTION
Fixes #47.

## What the issue reported, and what is actually left

#47 says importing `octopusdeploy_process_steps_order` fails with:

```
Error: Unable to load project for the process
SpaceID is not found
```

That error cannot happen on current code. `client.NewClientWithCredentials` resolves the default space itself when it is built without one (go-octopusdeploy `pkg/client/octopusdeploy.go:257-264`), and `projects.GetByID` falls back to the client's space, so `MissingSpaceIDError` never fires. Probing a live instance with an unscoped client:

```
client.GetSpaceID() with empty spaceID = "Spaces-1"
projects.GetByID(client, "", Projects-110)                        -> ok
GetDeploymentProcessByID(client, "", deploymentprocess-Projects-110) -> ok
```

So the original report was fixed by a dependency somewhere along the way. What remains is narrower: a process belonging to a space other than the provider's cannot be imported at all.

```
created space Spaces-150
project Projects-111 in Spaces-150
projects.GetByID(client, "", Projects-111) failed:
  Resource is not found or it doesn't exist in the current space context.
```

The import identifier carries no space and nothing else knows one, so the lookup goes to the provider's space and finds nothing.

I also checked whether the space could simply be discovered instead of supplied, which would have avoided touching the identifier format. It cannot:

```
GET /api/projects/Projects-112                              -> 404
GET /api/Spaces-1/projects/Projects-112                     -> 404
GET /api/Spaces-151/projects/Projects-112                   -> 200
GET /api/deploymentprocesses/deploymentprocess-Projects-112 -> 404
```

Every lookup is space scoped. Carrying the space in the identifier is the only route.

## The change

Import identifiers now accept an optional leading space:

```
terraform import octopusdeploy_process_steps_order.x Spaces-2:deploymentprocess-Projects-123
terraform import octopusdeploy_process_step.x        Spaces-2:deploymentprocess-Projects-123:<step-id>
```

The bare forms keep working and still resolve against the provider's space, so nothing that works today stops working.

The space is recognised by its `Spaces-` prefix rather than by counting segments. Segment counting would have made a two part identifier mean one thing for one resource and something else for another, and it would have been easy to get wrong at a glance. A prefix check is unambiguous: space IDs always start with `Spaces-` and never contain a colon, while process IDs start with `deploymentprocess-` or `runbookprocess-` and step IDs are GUIDs. One helper, `splitImportSpaceID`, does this for all seven process resources.

Two smaller things:

- Import now writes `space_id` to state wherever the process is loaded during import, instead of leaving it for the following read to fill in.
- A failed lookup now says which space was searched and where that space came from. The API answers a lookup in the wrong space exactly as it answers one for a resource that does not exist, which gave the practitioner nothing to act on.

## Testing

`TestSplitImportSpaceID` covers the parser, including that a bare `Spaces-2` is not mistaken for a prefix and that `runbookprocess-` identifiers are left alone. No Octopus instance needed.

`TestAccProcessImportFromAnotherSpace` builds a project and process inside a second space, then imports the steps order two ways with an unscoped provider: the bare identifier has to fail with the new diagnostic, and the space qualified one has to import cleanly under `ImportStateVerify`.

```
--- PASS: TestAccProcessImportFromAnotherSpace (15.28s)
--- PASS: TestAccOctopusDeployProcessStepsOrder (16.63s)
--- PASS: TestAccOctopusDeployProcessStepRunScript (15.83s)
--- PASS: TestAccOctopusDeployProcessTemplatedStep (15.48s)
--- PASS: TestAccOctopusDeployProcessTemplatedChildStep (16.02s)
--- PASS: TestAccOctopusDeployProcessReplace (17.44s)
ok  	github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework	174.887s
```

## Note for reviewers

The commenter on #47 who hit this on `octopusdeploy_static_worker_pool` is seeing the same class of problem, but that resource lives in the SDK tree and is imported by passthrough, so it is not covered here. Any resource imported by a bare ID under an unscoped provider has the same limitation. Happy to take that on separately if it is wanted.
