### PR TITLE
fix: compare string slices as multisets in StringSlicesEqual

### DIFF
--- a/octopusdeploy_framework/util/util.go
+++ b/octopusdeploy_framework/util/util.go
@@ -368,19 +368,22 @@ func SliceFind[T any](slice []T, predicate func(T) bool) *T {
 	return nil
 }
 
-// StringSlicesEqual compares two string slices for equality (ignoring order)
+// StringSlicesEqual compares two string slices for equality (ignoring order).
+// Values must appear the same number of times in both slices, so slices that
+// share the same distinct values but repeat them differently are not equal.
 func StringSlicesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	aMap := make(map[string]bool)
+	counts := make(map[string]int, len(a))
 	for _, item := range a {
-		aMap[item] = true
+		counts[item]++
 	}
 
 	for _, item := range b {
-		if !aMap[item] {
+		counts[item]--
+		if counts[item] < 0 {
 			return false
 		}
 	}

--- a/octopusdeploy_framework/util/util_test.go
+++ b/octopusdeploy_framework/util/util_test.go
@@ -1,0 +1,34 @@
+package util
+
+import "testing"
+
+func TestStringSlicesEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []string
+		b        []string
+		expected bool
+	}{
+		{"both empty", []string{}, []string{}, true},
+		{"both nil", nil, nil, true},
+		{"same order", []string{"a", "b"}, []string{"a", "b"}, true},
+		{"different order", []string{"a", "b"}, []string{"b", "a"}, true},
+		{"different length", []string{"a"}, []string{"a", "b"}, false},
+		{"different values", []string{"a", "b"}, []string{"a", "c"}, false},
+		{"same duplicate counts", []string{"a", "a", "b"}, []string{"b", "a", "a"}, true},
+		{"different duplicate counts", []string{"a", "a", "b"}, []string{"a", "b", "b"}, false},
+		{"duplicate against distinct", []string{"a", "a"}, []string{"a", "b"}, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual := StringSlicesEqual(test.a, test.b); actual != test.expected {
+				t.Errorf("StringSlicesEqual(%v, %v) = %v, expected %v", test.a, test.b, actual, test.expected)
+			}
+
+			if actual := StringSlicesEqual(test.b, test.a); actual != test.expected {
+				t.Errorf("StringSlicesEqual(%v, %v) = %v, expected %v", test.b, test.a, actual, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #255.

`util.StringSlicesEqual` guarded on length and then checked set membership, so two slices holding the same distinct values with different repeat counts compared as equal:

```go
util.StringSlicesEqual([]string{"a", "a", "b"}, []string{"a", "b", "b"}) // returned true
```

Writing the test turned up a second problem: the check was asymmetric. `(["a","b"], ["a","a"])` returned true while the reverse returned false, because only one of the two slices was turned into a map. Counting occurrences fixes both.

**Callers**

* `octopusdeploy_framework/schemas/planmodifiers/order_insensitive_list.go:49`, the order-insensitive plan modifier attached to every `octopusdeploy_variable` scope field.
* `octopusdeploy_framework/resource_team.go:216-219`, comparing environment, project group, project and tenant IDs on scoped user roles.

Neither caller sees duplicate IDs in practice, so no user-visible behavior changes. No schema change, no state migration, no docs regeneration.

**Testing**

New table-driven test at `octopusdeploy_framework/util/util_test.go` covering ordering, duplicate counts and argument symmetry. It fails on main and passes here. `go build ./...`, `go vet`, and the `util` and `schemas` package tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
