### PR TITLE
fix: look up step templates by id and name correctly

### DIFF
--- a/octopusdeploy_framework/datasource_step_template.go
+++ b/octopusdeploy_framework/datasource_step_template.go
@@ -2,9 +2,12 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"fmt"
+	"math"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -12,6 +15,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// actionTemplatesCollectionUriTemplate is the collection half of the SDK's action template
+// URI template. The SDK's own template also carries a {/id} path segment, which turns the
+// request into a single-resource lookup that cannot be decoded as a collection, so we keep
+// a collection-only copy here. actiontemplates.Query carries the `uri` tags the expansion
+// needs; actiontemplates.ActionTemplateSearch does not, which is why it cannot be used to
+// filter (see TestActionTemplatesCollectionUriTemplate).
+const actionTemplatesCollectionUriTemplate = "/api/{spaceId}/actiontemplates{?skip,take,ids,partialName}"
 
 type stepTemplateDataSource struct {
 	*Config
@@ -33,61 +44,82 @@ func (d *stepTemplateDataSource) Configure(_ context.Context, req datasource.Con
 }
 
 func (d *stepTemplateDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var err error
 	var data schemas.StepTemplateTypeDataSourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	search := actiontemplates.ActionTemplateSearch{
-		ID:   data.ID.ValueString(),
-		Name: data.Name.ValueString(),
-	}
+	id := data.ID.ValueString()
+	name := data.Name.ValueString()
+	spaceID := data.SpaceID.ValueString()
 
-	if (data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "") && (data.Name.IsNull() || data.Name.IsUnknown() || data.Name.ValueString() == "") {
+	if id == "" && name == "" {
 		resp.Diagnostics.AddError("Invalid Step Template", "Either the 'id' or 'name' attribute must be specified.")
 		return
 	}
 
-	util.DatasourceReading(ctx, "step_template", search)
+	util.DatasourceReading(ctx, "step_template", map[string]string{"id": id, "name": name, "space_id": spaceID})
 
-	actionTemplates, err := actiontemplates.Get(d.Config.Client, data.SpaceID.ValueString(), search)
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to load step template", err.Error())
-		return
-	}
-
-	actionTemplateMatch := findActionTemplateByName(actionTemplates.Items, data.Name.ValueString())
-
-	resp.Diagnostics.Append(mapStepTemplateToDatasourceModel(&data, actionTemplateMatch)...)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func findActionTemplateByName(actionTemplates []*actiontemplates.ActionTemplate, name string) *actiontemplates.ActionTemplate {
-	// If there was no name specified, the ID must have been specified, so return the first match
-	if name == "" {
-		return actionTemplates[0]
-	}
-
-	// Otherwise, find the first match by name
-	for _, at := range actionTemplates {
-		if at.Name == name {
-			return at
+	var actionTemplate *actiontemplates.ActionTemplate
+	var err error
+	if id != "" {
+		actionTemplate, err = actiontemplates.GetByID(d.Config.Client, spaceID, id)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to load step template", err.Error())
+			return
+		}
+		if name != "" && actionTemplate.Name != name {
+			resp.Diagnostics.AddError(
+				"Step Template not found",
+				fmt.Sprintf("step template '%s' is named '%s', which does not match the requested name '%s'", id, actionTemplate.Name, name))
+			return
+		}
+	} else {
+		actionTemplate, err = findStepTemplateByName(d.Config.Client, spaceID, name)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to load step template", err.Error())
+			return
+		}
+		if actionTemplate == nil {
+			resp.Diagnostics.AddError("Step Template not found", fmt.Sprintf("no step template found with the name '%s'", name))
+			return
 		}
 	}
 
-	return nil
+	resp.Diagnostics.Append(mapStepTemplateToDatasourceModel(&data, actionTemplate)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// findStepTemplateByName returns the step template with the given name, or nil if the space
+// has none. The API offers no exact-name filter, so the name narrows the result set through
+// partialName and the exact match is made here.
+func findStepTemplateByName(client newclient.Client, spaceID string, name string) (*actiontemplates.ActionTemplate, error) {
+	query := actiontemplates.Query{
+		PartialName: name,
+		Take:        math.MaxInt32,
+	}
+
+	actionTemplates, err := newclient.GetByQuery[actiontemplates.ActionTemplate](client, actionTemplatesCollectionUriTemplate, spaceID, query)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, at := range actionTemplates.Items {
+		if at.Name == name {
+			return at, nil
+		}
+	}
+
+	return nil, nil
 }
 
 func mapStepTemplateToDatasourceModel(data *schemas.StepTemplateTypeDataSourceModel, at *actiontemplates.ActionTemplate) diag.Diagnostics {
 	resp := diag.Diagnostics{}
 
-	if at != nil {
-		stepTemplate, dg := convertStepTemplateAttributes(at)
-		resp.Append(dg...)
-		data.StepTemplate = stepTemplate
-	}
+	stepTemplate, dg := convertStepTemplateAttributes(at)
+	resp.Append(dg...)
+	data.StepTemplate = stepTemplate
 
 	return resp
 }

--- a/octopusdeploy_framework/datasource_step_template_test.go
+++ b/octopusdeploy_framework/datasource_step_template_test.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -21,8 +22,83 @@ func TestAccDataSourceStepTemplates(t *testing.T) {
 				Config: createTestAccDataSourceStepTemplateConfig(),
 			},
 			{
-				Check:  resource.TestCheckResourceAttr(prefix, "step_template.name", "Hello World"),
-				Config: testAccDataSourceStepTemplateConfig(localName),
+				Check: resource.TestCheckResourceAttr(prefix, "step_template.name", "Hello World"),
+				// The template stays in the config: dropping it here destroys the very
+				// template the data source reads.
+				Config: createTestAccDataSourceStepTemplateConfig() + "\n" + testAccDataSourceStepTemplateConfig(localName),
+			},
+		},
+	})
+}
+
+// The API returns 30 step templates per page by default. Looking up by name used to filter
+// the first page in memory, so a template that sorted past it was invisible; looking up by ID
+// ignored the ID and returned whichever template happened to come back first.
+func TestAccDataSourceStepTemplateLookupBeyondFirstPage(t *testing.T) {
+	prefix := fmt.Sprintf("zz-%s", acctest.RandStringFromCharSet(20, acctest.CharSetAlpha))
+	lastName := fmt.Sprintf("%s-%02d", prefix, stepTemplatePageTestCount-1)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceStepTemplatePaginationConfig(prefix),
+				Check: resource.ComposeTestCheckFunc(
+					// An ID lookup returns the template that was asked for, not the first one.
+					resource.TestCheckResourceAttrPair(
+						"data.octopusdeploy_step_template.by_id", "step_template.id",
+						"octopusdeploy_step_template.page.5", "id"),
+					resource.TestCheckResourceAttr("data.octopusdeploy_step_template.by_id", "step_template.name",
+						fmt.Sprintf("%s-05", prefix)),
+					// A name that sorts onto the second page still resolves.
+					resource.TestCheckResourceAttr("data.octopusdeploy_step_template.by_name", "step_template.name", lastName),
+				),
+			},
+		},
+	})
+}
+
+// One more than the server's default page size of 30.
+const stepTemplatePageTestCount = 31
+
+func testAccDataSourceStepTemplatePaginationConfig(prefix string) string {
+	return fmt.Sprintf(`resource "octopusdeploy_step_template" "page" {
+  count           = %d
+  action_type     = "Octopus.Script"
+  name            = format("%s-%%02d", count.index)
+  step_package_id = "Octopus.Script"
+  packages        = []
+  parameters      = []
+  properties      = {
+    "Octopus.Action.Script.ScriptBody"   = "echo \"hello\"",
+    "Octopus.Action.Script.ScriptSource" = "Inline",
+    "Octopus.Action.Script.Syntax"       = "PowerShell"
+  }
+}
+
+data "octopusdeploy_step_template" "by_name" {
+  name       = format("%s-%%02d", %d)
+  depends_on = [octopusdeploy_step_template.page]
+}
+
+data "octopusdeploy_step_template" "by_id" {
+  id = octopusdeploy_step_template.page[5].id
+}`, stepTemplatePageTestCount, prefix, prefix, stepTemplatePageTestCount-1)
+}
+
+func TestAccDataSourceStepTemplateNotFound(t *testing.T) {
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`data "octopusdeploy_step_template" "missing" {
+					name = "%s"
+				}`, name),
+				ExpectError: regexp.MustCompile("Step Template not found"),
 			},
 		},
 	})
@@ -30,7 +106,8 @@ func TestAccDataSourceStepTemplates(t *testing.T) {
 
 func testAccDataSourceStepTemplateConfig(localName string) string {
 	return fmt.Sprintf(`data "octopusdeploy_step_template" "%s" {
-		name = "Hello World"
+		name       = "Hello World"
+		depends_on = [octopusdeploy_step_template.steptemplate_hello_world]
 	}`, localName)
 }
 

--- a/octopusdeploy_framework/datasource_step_template_uri_test.go
+++ b/octopusdeploy_framework/datasource_step_template_uri_test.go
@@ -1,0 +1,57 @@
+package octopusdeploy_framework
+
+import (
+	"math"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/uritemplates"
+	"github.com/stretchr/testify/require"
+)
+
+// The step template data source filters server side, which only works when the query struct
+// carries `uri` tags matching the variables in the URI template. actiontemplates.Query does;
+// actiontemplates.ActionTemplateSearch does not, and silently degrades to fetching the first
+// page unfiltered. These tests fail loudly if either of those facts changes in the SDK.
+func TestActionTemplatesCollectionUriTemplateSendsFilters(t *testing.T) {
+	query := actiontemplates.Query{
+		PartialName: "Hello World",
+		Take:        math.MaxInt32,
+	}
+
+	uri := expandActionTemplatesCollectionUri(t, query, "Spaces-1")
+
+	require.Contains(t, uri, "partialName=Hello%20World")
+	require.Contains(t, uri, "take=2147483647")
+	require.Contains(t, uri, "/api/Spaces-1/actiontemplates")
+}
+
+func TestActionTemplatesCollectionUriTemplateHasNoIdPathSegment(t *testing.T) {
+	// A {/id} segment would expand into a single-resource path that cannot be decoded as a
+	// collection, so the collection template must not carry one.
+	require.NotContains(t, actionTemplatesCollectionUriTemplate, "{/id}")
+}
+
+func TestActionTemplateSearchCannotFilterServerSide(t *testing.T) {
+	search := actiontemplates.ActionTemplateSearch{
+		ID:   "ActionTemplates-1",
+		Name: "Hello World",
+	}
+
+	uri := expandActionTemplatesCollectionUri(t, search, "Spaces-1")
+
+	require.Equal(t, "/api/Spaces-1/actiontemplates", uri)
+}
+
+func expandActionTemplatesCollectionUri(t *testing.T, query any, spaceID string) string {
+	t.Helper()
+
+	values, ok := uritemplates.Struct2map(query)
+	require.True(t, ok)
+	values["spaceId"] = spaceID
+
+	uri, err := uritemplates.NewUriTemplateCache().Expand(actionTemplatesCollectionUriTemplate, values)
+	require.NoError(t, err)
+
+	return uri
+}


### PR DESCRIPTION
Fixes the step template data source, which has never filtered anything server side.

Partially addresses #10. That issue asks for name, partial_name and take on step template queries. #83 added a `name` attribute and closed #84, but the filter it added does not reach the server, so lookup by name only works by accident. This PR fixes lookup. A follow-up will add the plural `octopusdeploy_step_templates` data source for `partial_name` and `take`.

## The bug

`datasource_step_template.go` passed `actiontemplates.ActionTemplateSearch` to `actiontemplates.Get`. That struct carries only `json` tags, and URI template expansion reads `uri` tags. `uritemplates.Struct2map` falls back to the Go field names, so it produces `ID` and `Name`, while the template only declares `skip`, `take`, `ids` and `partialName`. Neither filter is ever sent.

What actually happened on every read: fetch the server's default page of 30 templates, then filter it in memory.

Two bugs followed from that. Lookup by name silently returned nothing, because a template that sorted past the first page never matched, and `mapStepTemplateToDatasourceModel` left `step_template` null without raising an error. Any space with more than 30 step templates hits this.

Lookup by id returned the wrong template. With `name` empty, `findActionTemplateByName` returned `actionTemplates[0]`, which is the first template on the page rather than the one that was asked for. On an empty result set the same line panicked with an index out of range.

## The fix

An id lookup now goes through `actiontemplates.GetByID`.

A name lookup narrows server side with `actiontemplates.Query`, which carries the `uri` tags the expansion needs, then matches exactly on the way back. The API has no exact-name filter, so `partialName` does the narrowing and the equality check happens in the provider.

The query goes through a provider-owned collection-only URI template:

```go
const actionTemplatesCollectionUriTemplate = "/api/{spaceId}/actiontemplates{?skip,take,ids,partialName}"
```

The SDK's own template also carries a `{/id}` path segment. Expanding that turns the request into a single-resource lookup whose response cannot be decoded as a collection, which would trade the current wrong-answer bug for a panic. The collection-only copy keeps that segment out of reach. `take` is `math.MaxInt32`, which the server honours in one request. Verified against 2025.x, where the default page is 30 and `take=2147483647` returns all of them.

A miss is now an error on both paths rather than a null.

## Breaking change

An id lookup returns a different template than it did before, namely the one that was asked for. Anyone reading `step_template.version` or `step_template.name` off an id lookup will see state change on the next plan. That is the bug being fixed, but it is a visible change.

A name that matches nothing now fails the plan instead of returning a null object.

## Tests

`datasource_step_template_uri_test.go` covers the expansion itself: the query struct's filters survive it, the const has no `{/id}`, and `ActionTemplateSearch` expands to a bare unfiltered path. That last one pins the root cause, and will fail if the SDK ever adds the missing tags.

`TestAccDataSourceStepTemplateLookupBeyondFirstPage` creates 31 templates and asserts that an id lookup returns the requested template and that a name sorting onto the second page resolves. Against the unfixed code it fails as expected:

```
Attribute 'step_template.id' expected "ActionTemplates-169", got "ActionTemplates-157"
Attribute 'step_template.name' not found
```

`TestAccDataSourceStepTemplateNotFound` asserts the error rather than a silent null.

`TestAccDataSourceStepTemplates` needed repair. Its second step dropped the step template resource from the config, so the post-apply plan re-read a data source whose template had just been destroyed. It passed only because a missing template was silent. The resource now stays in the config.

All 16 tests matching `StepTemplate` pass against a local 2025.x instance.

## Upstream

`ActionTemplateSearch` in go-octopusdeploy is missing its `uri` tags. Worth fixing there too, but this PR does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
