### PR TITLE
fix: scope external feed create release trigger to its space_id

### DIFF
--- a/docs/resources/external_feed_create_release_trigger.md
+++ b/docs/resources/external_feed_create_release_trigger.md
@@ -70,3 +70,5 @@ Import is supported using the following syntax:
 ```shell
 terraform import [options] octopusdeploy_external_feed_create_release_trigger.<name> <trigger-id>
 ```
+
+The import ID carries no space, so the trigger is looked up in the space the provider is configured for. To import a trigger from another space, configure the provider for that space.

--- a/octopusdeploy/resource_external_feed_create_release_trigger.go
+++ b/octopusdeploy/resource_external_feed_create_release_trigger.go
@@ -2,6 +2,7 @@ package octopusdeploy
 
 import (
 	"context"
+	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"log"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/filters"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -65,7 +67,7 @@ func resourceExternalFeedCreateReleaseTriggerCreate(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 
-	resource, err := client.ProjectTriggers.Add(projectTrigger)
+	resource, err := triggers.Add(client, projectTrigger)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -83,17 +85,26 @@ func resourceExternalFeedCreateReleaseTriggerRead(ctx context.Context, d *schema
 	id := d.Id()
 
 	client := m.(*client.Client)
-	projectTrigger, err := client.ProjectTriggers.GetByID(id)
+	spaceId := d.Get("space_id").(string)
+	spaceId = util.Ternary(len(spaceId) > 0, spaceId, client.GetSpaceID())
+
+	projectTrigger, err := triggers.GetById(client, spaceId, id)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("unable to read external feed create release trigger (%s) in space %s: %w", id, spaceId, err))
 	}
 	if projectTrigger == nil {
 		d.SetId("")
 		return nil
 	}
 
-	action := projectTrigger.Action.(*actions.CreateReleaseAction)
-	filter := projectTrigger.Filter.(*filters.FeedTriggerFilter)
+	action, ok := projectTrigger.Action.(*actions.CreateReleaseAction)
+	if !ok {
+		return diag.Errorf("project trigger (%s) in space %s is not a create release trigger", id, spaceId)
+	}
+	filter, ok := projectTrigger.Filter.(*filters.FeedTriggerFilter)
+	if !ok {
+		return diag.Errorf("project trigger (%s) in space %s is not an external feed trigger", id, spaceId)
+	}
 
 	d.Set("name", projectTrigger.Name)
 	d.Set("space_id", projectTrigger.SpaceID)
@@ -114,7 +125,7 @@ func resourceExternalFeedCreateReleaseTriggerUpdate(ctx context.Context, d *sche
 	}
 	projectTrigger.ID = d.Id() // set ID so Octopus API knows which project trigger to update
 
-	resource, err := client.ProjectTriggers.Update(projectTrigger)
+	resource, err := triggers.Update(client, projectTrigger)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -126,9 +137,12 @@ func resourceExternalFeedCreateReleaseTriggerUpdate(ctx context.Context, d *sche
 
 func resourceExternalFeedCreateReleaseTriggerDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client.Client)
-	err := client.ProjectTriggers.DeleteByID(d.Id())
+	spaceId := d.Get("space_id").(string)
+	spaceId = util.Ternary(len(spaceId) > 0, spaceId, client.GetSpaceID())
+
+	err := triggers.DeleteById(client, spaceId, d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("unable to delete external feed create release trigger (%s) in space %s: %w", d.Id(), spaceId, err))
 	}
 
 	d.SetId("")

--- a/octopusdeploy/resource_external_feed_create_release_trigger_test.go
+++ b/octopusdeploy/resource_external_feed_create_release_trigger_test.go
@@ -1,0 +1,175 @@
+package octopusdeploy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/filters"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	providerSpaceID = "Spaces-1"
+	triggerSpaceID  = "Spaces-2"
+	triggerID       = "ProjectTriggers-1"
+)
+
+// recordingTransport serves the canned root document that client construction
+// needs and records every other request so a test can assert which space the
+// provider actually addressed.
+type recordingTransport struct {
+	requests      []string
+	triggerBody   string
+	triggerStatus int
+}
+
+func (t *recordingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	path := request.URL.Path
+
+	if !strings.Contains(path, "projecttriggers") {
+		return jsonResponse(http.StatusOK, constants.ApiReplyRoot), nil
+	}
+
+	t.requests = append(t.requests, request.Method+" "+path)
+
+	return jsonResponse(t.triggerStatus, t.triggerBody), nil
+}
+
+func jsonResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		// The SDK skips decoding entirely when ContentLength is zero.
+		ContentLength: int64(len(body)),
+	}
+}
+
+// newTestClientForSpace builds a client bound to spaceID, backed by transport.
+func newTestClientForSpace(t *testing.T, transport *recordingTransport, spaceID string) *client.Client {
+	t.Helper()
+
+	apiURL, err := url.Parse("http://localhost:8080")
+	require.NoError(t, err)
+
+	octopusClient, err := client.NewClientForTool(
+		&http.Client{Transport: transport},
+		apiURL,
+		"API-TESTTESTTESTTEST0",
+		spaceID,
+		"terraform-provider-octopusdeploy-test",
+	)
+	require.NoError(t, err)
+
+	return octopusClient
+}
+
+func newTestTriggerBody(t *testing.T) string {
+	t.Helper()
+
+	project := &projects.Project{SpaceID: triggerSpaceID}
+	project.ID = "Projects-1"
+
+	trigger := triggers.NewProjectTrigger(
+		"test-trigger",
+		"",
+		false,
+		project,
+		actions.NewCreateReleaseAction("Channels-1"),
+		filters.NewFeedTriggerFilter([]packages.DeploymentActionSlugPackage{
+			{DeploymentActionSlug: "test-action"},
+		}),
+	)
+	trigger.ID = triggerID
+
+	body, err := json.Marshal(trigger)
+	require.NoError(t, err)
+
+	return string(body)
+}
+
+func newTestTriggerResourceData(t *testing.T) *schema.ResourceData {
+	t.Helper()
+
+	resourceData := schema.TestResourceDataRaw(t, getExternalFeedCreateReleaseTriggerSchema(), map[string]interface{}{
+		"name":       "test-trigger",
+		"space_id":   triggerSpaceID,
+		"project_id": "Projects-1",
+		"channel_id": "Channels-1",
+	})
+	resourceData.SetId(triggerID)
+
+	return resourceData
+}
+
+// The provider is configured for one space while the resource declares another.
+// Read has to address the resource's space, not the provider's, or refreshing a
+// trigger outside the provider's space fails with "Resource is not found or it
+// doesn't exist in the current space context".
+func TestExternalFeedCreateReleaseTriggerReadUsesResourceSpace(t *testing.T) {
+	transport := &recordingTransport{
+		triggerBody:   newTestTriggerBody(t),
+		triggerStatus: http.StatusOK,
+	}
+
+	octopusClient := newTestClientForSpace(t, transport, providerSpaceID)
+	resourceData := newTestTriggerResourceData(t)
+
+	diags := resourceExternalFeedCreateReleaseTriggerRead(context.Background(), resourceData, octopusClient)
+
+	require.False(t, diags.HasError(), "read returned diagnostics: %v", diags)
+	require.Equal(t, []string{"GET /api/" + triggerSpaceID + "/projecttriggers/" + triggerID}, transport.requests)
+	require.Equal(t, "test-trigger", resourceData.Get("name"))
+	require.Equal(t, triggerSpaceID, resourceData.Get("space_id"))
+}
+
+func TestExternalFeedCreateReleaseTriggerDeleteUsesResourceSpace(t *testing.T) {
+	transport := &recordingTransport{
+		triggerBody:   "",
+		triggerStatus: http.StatusOK,
+	}
+
+	octopusClient := newTestClientForSpace(t, transport, providerSpaceID)
+	resourceData := newTestTriggerResourceData(t)
+
+	diags := resourceExternalFeedCreateReleaseTriggerDelete(context.Background(), resourceData, octopusClient)
+
+	require.False(t, diags.HasError(), "delete returned diagnostics: %v", diags)
+	require.Equal(t, []string{"DELETE /api/" + triggerSpaceID + "/projecttriggers/" + triggerID}, transport.requests)
+	require.Empty(t, resourceData.Id())
+}
+
+// With no space_id set the resource keeps falling back to the space the
+// provider was configured for.
+func TestExternalFeedCreateReleaseTriggerReadFallsBackToProviderSpace(t *testing.T) {
+	transport := &recordingTransport{
+		triggerBody:   newTestTriggerBody(t),
+		triggerStatus: http.StatusOK,
+	}
+
+	octopusClient := newTestClientForSpace(t, transport, providerSpaceID)
+
+	resourceData := schema.TestResourceDataRaw(t, getExternalFeedCreateReleaseTriggerSchema(), map[string]interface{}{
+		"name":       "test-trigger",
+		"project_id": "Projects-1",
+		"channel_id": "Channels-1",
+	})
+	resourceData.SetId(triggerID)
+
+	diags := resourceExternalFeedCreateReleaseTriggerRead(context.Background(), resourceData, octopusClient)
+
+	require.False(t, diags.HasError(), "read returned diagnostics: %v", diags)
+	require.Equal(t, []string{"GET /api/" + providerSpaceID + "/projecttriggers/" + triggerID}, transport.requests)
+}

--- a/octopusdeploy_framework/resource_external_feed_create_release_trigger_test.go
+++ b/octopusdeploy_framework/resource_external_feed_create_release_trigger_test.go
@@ -94,6 +94,53 @@ func TestAccOctopusDeployExternalFeedCreateReleaseTriggerUpdate(t *testing.T) {
 	})
 }
 
+// Refreshing a trigger that lives outside the provider's space used to fail
+// with "Resource is not found or it doesn't exist in the current space
+// context", because read addressed the provider's space instead of the
+// resource's space_id.
+func TestAccOctopusDeployExternalFeedCreateReleaseTriggerOutsideProviderSpace(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	prefix := "octopusdeploy_external_feed_create_release_trigger." + localName
+
+	lifecycleLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	lifecycleName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectGroupLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectGroupName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectDescription := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	channelLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	channelName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	channelDescription := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	triggerName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	space := NewTestSpace(t)
+
+	config := testAccExternalFeedCreateReleaseTriggerCrossSpace(space.ID, localName, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, channelLocalName, channelName, channelDescription, triggerName)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccExternalFeedCreateReleaseTriggerCheckDestroy(space),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccExternalFeedCreateReleaseTriggerExists(space, prefix),
+					resource.TestCheckResourceAttr(prefix, "name", triggerName),
+					resource.TestCheckResourceAttr(prefix, "space_id", space.ID),
+				),
+				Config: config,
+			},
+			{
+				// The refresh in this step is what used to fail.
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccOctopusDeployExternalFeedCreateReleaseTriggerWithPrimaryPackage(t *testing.T) {
 	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	prefix := "octopusdeploy_external_feed_create_release_trigger." + localName
@@ -205,7 +252,14 @@ func testAccExternalFeedCreateReleaseTriggerWithPrimaryPackage(spaceID, localNam
 }
 
 func testAccExternalFeedCreateReleaseTriggerDependencies(spaceID, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, channelLocalName, channelName, channelDescription string) string {
-	return providerSpaceConfig(spaceID) + fmt.Sprintf(`
+	return providerSpaceConfig(spaceID) + testAccExternalFeedCreateReleaseTriggerDependencyResources(spaceID, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, channelLocalName, channelName, channelDescription)
+}
+
+// testAccExternalFeedCreateReleaseTriggerDependencyResources omits the provider
+// block so a caller can leave the provider on the default space while every
+// resource targets spaceID.
+func testAccExternalFeedCreateReleaseTriggerDependencyResources(spaceID, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, channelLocalName, channelName, channelDescription string) string {
+	return fmt.Sprintf(`
 	resource "octopusdeploy_lifecycle" "%s" {
 		space_id = "%s"
 		name     = "%s"
@@ -235,6 +289,19 @@ func testAccExternalFeedCreateReleaseTriggerDependencies(spaceID, lifecycleLocal
 		projectGroupLocalName, spaceID, projectGroupName,
 		projectLocalName, spaceID, projectDescription, lifecycleLocalName, projectName, projectGroupLocalName,
 		channelLocalName, spaceID, channelDescription, channelName, projectLocalName)
+}
+
+// testAccExternalFeedCreateReleaseTriggerCrossSpace configures the trigger in
+// spaceID without pinning the provider to it, so the provider stays on the
+// default space.
+func testAccExternalFeedCreateReleaseTriggerCrossSpace(spaceID, localName, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, channelLocalName, channelName, channelDescription, triggerName string) string {
+	return testAccExternalFeedCreateReleaseTriggerDependencyResources(spaceID, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, channelLocalName, channelName, channelDescription) + fmt.Sprintf(`
+	resource "octopusdeploy_external_feed_create_release_trigger" "%s" {
+		name       = "%s"
+		space_id   = "%s"
+		project_id = octopusdeploy_project.%s.id
+		channel_id = octopusdeploy_channel.%s.id
+	}`, localName, triggerName, spaceID, projectLocalName, channelLocalName)
 }
 
 func testAccExternalFeedCreateReleaseTriggerExists(space *TestSpace, prefix string) resource.TestCheckFunc {

--- a/templates/resources/external_feed_create_release_trigger.md.tmpl
+++ b/templates/resources/external_feed_create_release_trigger.md.tmpl
@@ -20,4 +20,6 @@ description: |-
 Import is supported using the following syntax:
 
 {{ codefile "shell" (printf "%s%s%s" "examples/resources/" .Name "/import.sh") }}
+
+The import ID carries no space, so the trigger is looked up in the space the provider is configured for. To import a trigger from another space, configure the provider for that space.
 {{- end }}


### PR DESCRIPTION
Fixes #25.

## Problem

`octopusdeploy_external_feed_create_release_trigger` applies cleanly into a non-default space, then fails on the next `terraform plan`:

```
Octopus API error: Resource is not found or it doesn't exist in the current space context
```

Read and Delete called `client.ProjectTriggers.GetByID` / `DeleteByID`. Those resolve their path from the URI template of the space the *provider* was configured for. The resource read its own `space_id`, but only passed it to the project lookup, so it never reached the trigger's API path.

Create and Update were unaffected, because the SDK builds explicit space paths for them (`pkg/triggers/project_trigger_service.go:84,115`). That is why the resource creates fine and only breaks at refresh.

## Change

In `octopusdeploy/resource_external_feed_create_release_trigger.go`:

* Read and Delete resolve the space from `space_id`, falling back to the provider's space when it isn't set, and call `triggers.GetById` / `triggers.DeleteById`. Same approach `resource_project_scheduled_trigger.go` took in 3bab2cf2.
* Create and Update move to `triggers.Add` / `triggers.Update`. No behaviour change, but it clears the last `client.ProjectTriggers.*` call out of the file, so the space-bound idiom isn't left there to be copied.
* The two type assertions in Read are checked now. They were unreachable while Read was failing. Once Read works, an unexpected trigger type would panic the provider.
* Error messages name the space that was queried.

## Tests

`octopusdeploy/resource_external_feed_create_release_trigger_test.go` adds unit tests built on a recording HTTP transport: the provider client is bound to `Spaces-1` while the resource declares `Spaces-2`, and the tests assert the request path. Reverting the fix makes them fail with `/api/Spaces-1/...`. They cover Read, Delete, and the fallback when `space_id` is unset. No live server is needed, so these still run on fork PRs, where the integration workflow's secrets aren't available.

`TestAccOctopusDeployExternalFeedCreateReleaseTriggerOutsideProviderSpace` leaves the provider on the default space, creates the trigger in a test space, and follows the apply with a `PlanOnly` refresh step. It uses the existing `NewTestSpace` harness.

No schema change and no state migration. `space_id` already existed on this resource.

## Not in this PR

The same defect exists in two other resources, and neither is a matching one-line change:

* `octopusdeploy_framework/resource_git_trigger.go:100,130,165` has the same space bug. It also assigns `err` from `ProjectTriggers.Update` at `:149` without checking it, and the error branch at `:102` is dead code, because `ProcessApiErrorV2` returns `nil` for every non-404. Cross-space git triggers are being dropped from state silently today.
* `octopusdeploy/resource_project_deployment_target_trigger.go:121,165`, plus `:85`, where `client.Projects.GetByID` breaks Create and Update as well. That resource has no `space_id` attribute at all, so fixing it means adding one and regenerating docs.

I'm happy to follow up on both if that's useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
