### PR TITLE
fix: scope git trigger to its space_id and surface update failures

### DIFF
--- a/octopusdeploy_framework/resource_git_trigger.go
+++ b/octopusdeploy_framework/resource_git_trigger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/filters"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
@@ -68,10 +69,16 @@ func (r *gitTriggerResource) Create(ctx context.Context, req resource.CreateRequ
 
 	projectTrigger := triggers.NewProjectTrigger(data.Name.ValueString(), data.Description.ValueString(), data.IsDisabled.ValueBool(), project, action, filter)
 
-	createdGitTrigger, err := client.ProjectTriggers.Add(projectTrigger)
+	createdGitTrigger, err := triggers.Add(client, projectTrigger)
 
 	if err != nil {
 		resp.Diagnostics.AddError("unable to create Git trigger", err.Error())
+		return
+	}
+
+	createdFilter, ok := createdGitTrigger.Filter.(*filters.GitTriggerFilter)
+	if !ok {
+		resp.Diagnostics.AddError("unable to create Git trigger", fmt.Sprintf("project trigger (%s) is not a Git trigger", createdGitTrigger.GetID()))
 		return
 	}
 
@@ -80,7 +87,7 @@ func (r *gitTriggerResource) Create(ctx context.Context, req resource.CreateRequ
 	data.ProjectId = types.StringValue(createdGitTrigger.ProjectID)
 	data.SpaceId = types.StringValue(createdGitTrigger.SpaceID)
 	data.IsDisabled = types.BoolValue(createdGitTrigger.IsDisabled)
-	data.Sources = convertGitTriggerSourcesToList(createdGitTrigger.Filter.(*filters.GitTriggerFilter).Sources)
+	data.Sources = convertGitTriggerSourcesToList(createdFilter.Sources)
 
 	tflog.Info(ctx, fmt.Sprintf("Git trigger created (%s)", data.ID))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -97,11 +104,19 @@ func (r *gitTriggerResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	client := r.Config.Client
 
-	gitTrigger, err := client.ProjectTriggers.GetByID(data.ID.ValueString())
+	spaceId := gitTriggerSpaceID(client, data)
+
+	gitTrigger, err := triggers.GetById(client, spaceId, data.ID.ValueString())
 	if err != nil {
 		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "error retrieving Git Trigger"); err != nil {
 			resp.Diagnostics.AddError("unable to load Git Trigger", err.Error())
 		}
+		return
+	}
+
+	filter, ok := gitTrigger.Filter.(*filters.GitTriggerFilter)
+	if !ok {
+		resp.Diagnostics.AddError("unable to load Git Trigger", fmt.Sprintf("project trigger (%s) in space %s is not a Git trigger", data.ID.ValueString(), spaceId))
 		return
 	}
 
@@ -110,7 +125,7 @@ func (r *gitTriggerResource) Read(ctx context.Context, req resource.ReadRequest,
 	data.ProjectId = types.StringValue(gitTrigger.ProjectID)
 	data.SpaceId = types.StringValue(gitTrigger.SpaceID)
 	data.IsDisabled = types.BoolValue(gitTrigger.IsDisabled)
-	data.Sources = convertGitTriggerSourcesToList(gitTrigger.Filter.(*filters.GitTriggerFilter).Sources)
+	data.Sources = convertGitTriggerSourcesToList(filter.Sources)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -127,7 +142,9 @@ func (r *gitTriggerResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	client := r.Config.Client
 
-	gitTrigger, err := client.ProjectTriggers.GetByID(data.ID.ValueString())
+	spaceId := gitTriggerSpaceID(client, data)
+
+	gitTrigger, err := triggers.GetById(client, spaceId, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load Git Trigger", err.Error())
 		return
@@ -146,7 +163,25 @@ func (r *gitTriggerResource) Update(ctx context.Context, req resource.UpdateRequ
 	updatedGitTrigger := triggers.NewProjectTrigger(data.Name.ValueString(), data.Description.ValueString(), data.IsDisabled.ValueBool(), project, action, filter)
 	updatedGitTrigger.ID = gitTrigger.ID
 
-	updatedGitTrigger, err = client.ProjectTriggers.Update(updatedGitTrigger)
+	updatedGitTrigger, err = triggers.Update(client, updatedGitTrigger)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to update Git Trigger", err.Error())
+		return
+	}
+
+	updatedFilter, ok := updatedGitTrigger.Filter.(*filters.GitTriggerFilter)
+	if !ok {
+		resp.Diagnostics.AddError("unable to update Git Trigger", fmt.Sprintf("project trigger (%s) in space %s is not a Git trigger", updatedGitTrigger.GetID(), spaceId))
+		return
+	}
+
+	data.ID = types.StringValue(updatedGitTrigger.GetID())
+	data.Name = types.StringValue(updatedGitTrigger.Name)
+	data.ProjectId = types.StringValue(updatedGitTrigger.ProjectID)
+	data.SpaceId = types.StringValue(updatedGitTrigger.SpaceID)
+	data.IsDisabled = types.BoolValue(updatedGitTrigger.IsDisabled)
+	data.Sources = convertGitTriggerSourcesToList(updatedFilter.Sources)
+
 	tflog.Info(ctx, fmt.Sprintf("Git Trigger updated (%s)", data.ID))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -162,10 +197,19 @@ func (r *gitTriggerResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	client := r.Config.Client
 
-	if err := client.ProjectTriggers.DeleteByID(data.ID.ValueString()); err != nil {
+	spaceId := gitTriggerSpaceID(client, &data)
+
+	if err := triggers.DeleteById(client, spaceId, data.ID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("unable to delete Git Trigger", err.Error())
 		return
 	}
+}
+
+// gitTriggerSpaceID resolves the space the trigger lives in, falling back to
+// the space the provider was configured for when the resource doesn't set one.
+func gitTriggerSpaceID(client *client.Client, data *schemas.GitTriggerResourceModel) string {
+	spaceId := data.SpaceId.ValueString()
+	return util.Ternary(len(spaceId) > 0, spaceId, client.GetSpaceID())
 }
 
 func convertListToGitTriggerSources(list types.List) []filters.GitTriggerSource {

--- a/octopusdeploy_framework/resource_git_trigger_test.go
+++ b/octopusdeploy_framework/resource_git_trigger_test.go
@@ -1,0 +1,214 @@
+package octopusdeploy_framework
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/filters"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	gitTriggerProviderSpaceID = "Spaces-1"
+	gitTriggerSpaceIDValue    = "Spaces-2"
+	gitTriggerIDValue         = "ProjectTriggers-1"
+)
+
+// gitTriggerRecordingTransport serves the canned root document that client
+// construction needs and records every other request, so a test can assert
+// which space the provider actually addressed.
+type gitTriggerRecordingTransport struct {
+	requests []string
+	body     string
+	// failUpdate makes the trigger PUT return a server error.
+	failUpdate bool
+}
+
+func (t *gitTriggerRecordingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	switch {
+	case strings.Contains(request.URL.Path, "projecttriggers"):
+		t.requests = append(t.requests, request.Method+" "+request.URL.Path)
+
+		if t.failUpdate && request.Method == http.MethodPut {
+			return gitTriggerErrorResponse(), nil
+		}
+
+		return gitTriggerResponse(http.StatusOK, t.body), nil
+	case strings.Contains(request.URL.Path, "/projects/"):
+		return gitTriggerResponse(http.StatusOK, `{"Id":"Projects-1","SpaceId":"`+gitTriggerSpaceIDValue+`","Name":"test-project","LifecycleId":"Lifecycles-1","ProjectGroupId":"ProjectGroups-1"}`), nil
+	default:
+		return gitTriggerResponse(http.StatusOK, constants.ApiReplyRoot), nil
+	}
+}
+
+func gitTriggerResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		// The SDK skips decoding entirely when ContentLength is zero.
+		ContentLength: int64(len(body)),
+	}
+}
+
+func gitTriggerErrorResponse() *http.Response {
+	return gitTriggerResponse(http.StatusInternalServerError, `{"ErrorMessage":"something went wrong"}`)
+}
+
+func newGitTriggerResource(t *testing.T, transport *gitTriggerRecordingTransport) *gitTriggerResource {
+	t.Helper()
+
+	apiURL, err := url.Parse("http://localhost:8080")
+	require.NoError(t, err)
+
+	octopusClient, err := client.NewClientForTool(
+		&http.Client{Transport: transport},
+		apiURL,
+		"API-TESTTESTTESTTEST0",
+		gitTriggerProviderSpaceID,
+		"terraform-provider-octopusdeploy-test",
+	)
+	require.NoError(t, err)
+
+	return &gitTriggerResource{Config: &Config{Client: octopusClient}}
+}
+
+func newGitTriggerBody(t *testing.T) string {
+	t.Helper()
+
+	project := &projects.Project{SpaceID: gitTriggerSpaceIDValue}
+	project.ID = "Projects-1"
+
+	trigger := triggers.NewProjectTrigger(
+		"test-trigger",
+		"",
+		false,
+		project,
+		actions.NewCreateReleaseAction("Channels-1"),
+		filters.NewGitTriggerFilter([]filters.GitTriggerSource{{
+			DeploymentActionSlug: "test-action",
+			GitDependencyName:    "",
+			IncludeFilePaths:     []string{"include/me"},
+			ExcludeFilePaths:     []string{"exclude/me"},
+		}}),
+	)
+	trigger.ID = gitTriggerIDValue
+
+	body, err := json.Marshal(trigger)
+	require.NoError(t, err)
+
+	return string(body)
+}
+
+// gitTriggerState builds resource state holding a trigger that declares
+// spaceID, whatever space the provider itself is pointed at.
+func gitTriggerState(t *testing.T, ctx context.Context, spaceID string) tfsdk.State {
+	t.Helper()
+
+	schemaResponse := &resource.SchemaResponse{}
+	(&gitTriggerResource{}).Schema(ctx, resource.SchemaRequest{}, schemaResponse)
+
+	state := tfsdk.State{
+		Schema: schemaResponse.Schema,
+		Raw:    tftypes.NewValue(schemaResponse.Schema.Type().TerraformType(ctx), nil),
+	}
+
+	sources := types.ListValueMust(types.ObjectType{AttrTypes: sourcesObjectType()}, []attr.Value{})
+
+	diags := state.Set(ctx, &schemas.GitTriggerResourceModel{
+		Name:        types.StringValue("test-trigger"),
+		Description: types.StringValue(""),
+		SpaceId:     types.StringValue(spaceID),
+		ProjectId:   types.StringValue("Projects-1"),
+		ChannelId:   types.StringValue("Channels-1"),
+		Sources:     sources,
+		IsDisabled:  types.BoolValue(false),
+		ResourceModel: schemas.ResourceModel{
+			ID: types.StringValue(gitTriggerIDValue),
+		},
+	})
+	require.False(t, diags.HasError(), "setting state: %v", diags)
+
+	return state
+}
+
+// The provider is configured for one space while the resource declares
+// another. Read has to address the resource's space, not the provider's.
+func TestGitTriggerReadUsesResourceSpace(t *testing.T) {
+	ctx := context.Background()
+
+	transport := &gitTriggerRecordingTransport{body: newGitTriggerBody(t)}
+	gitTrigger := newGitTriggerResource(t, transport)
+
+	state := gitTriggerState(t, ctx, gitTriggerSpaceIDValue)
+	response := &resource.ReadResponse{State: state}
+
+	gitTrigger.Read(ctx, resource.ReadRequest{State: state}, response)
+
+	require.False(t, response.Diagnostics.HasError(), "read returned diagnostics: %v", response.Diagnostics)
+	require.Equal(t, []string{"GET /api/" + gitTriggerSpaceIDValue + "/projecttriggers/" + gitTriggerIDValue}, transport.requests)
+}
+
+func TestGitTriggerDeleteUsesResourceSpace(t *testing.T) {
+	ctx := context.Background()
+
+	transport := &gitTriggerRecordingTransport{}
+	gitTrigger := newGitTriggerResource(t, transport)
+
+	state := gitTriggerState(t, ctx, gitTriggerSpaceIDValue)
+	response := &resource.DeleteResponse{State: state}
+
+	gitTrigger.Delete(ctx, resource.DeleteRequest{State: state}, response)
+
+	require.False(t, response.Diagnostics.HasError(), "delete returned diagnostics: %v", response.Diagnostics)
+	require.Equal(t, []string{"DELETE /api/" + gitTriggerSpaceIDValue + "/projecttriggers/" + gitTriggerIDValue}, transport.requests)
+}
+
+// A failed update used to be reported as a success, because the error from the
+// update call was assigned and never checked before state was written.
+func TestGitTriggerUpdateReportsFailure(t *testing.T) {
+	ctx := context.Background()
+
+	transport := &gitTriggerRecordingTransport{body: newGitTriggerBody(t), failUpdate: true}
+	gitTrigger := newGitTriggerResource(t, transport)
+
+	state := gitTriggerState(t, ctx, gitTriggerSpaceIDValue)
+	response := &resource.UpdateResponse{State: state}
+
+	gitTrigger.Update(ctx, resource.UpdateRequest{Plan: tfsdk.Plan(state), State: state}, response)
+
+	require.True(t, response.Diagnostics.HasError(), "a failed update must surface a diagnostic")
+}
+
+// With no space_id set the resource keeps falling back to the space the
+// provider was configured for.
+func TestGitTriggerReadFallsBackToProviderSpace(t *testing.T) {
+	ctx := context.Background()
+
+	transport := &gitTriggerRecordingTransport{body: newGitTriggerBody(t)}
+	gitTrigger := newGitTriggerResource(t, transport)
+
+	state := gitTriggerState(t, ctx, "")
+	response := &resource.ReadResponse{State: state}
+
+	gitTrigger.Read(ctx, resource.ReadRequest{State: state}, response)
+
+	require.False(t, response.Diagnostics.HasError(), "read returned diagnostics: %v", response.Diagnostics)
+	require.Equal(t, []string{"GET /api/" + gitTriggerProviderSpaceID + "/projecttriggers/" + gitTriggerIDValue}, transport.requests)
+}


### PR DESCRIPTION
Fixes #261. Same root cause as #25, which was fixed for the external feed trigger in #259.

## Reads and deletes ignored `space_id`

`octopusdeploy_framework/resource_git_trigger.go` called the space-bound `ProjectTriggers` service in Read (`:100`), Update (`:130`) and Delete (`:165`). Those resolve their path from the URI template of the space the provider was configured for. The resource has a `space_id` attribute and Create used it for the project lookup, but it never reached the trigger's own API path.

Read, Update and Delete now resolve the space from `space_id`, falling back to the provider's space when it isn't set, and call `triggers.GetById` / `triggers.DeleteById`. Create and Update move to `triggers.Add` / `triggers.Update` so no space-bound call is left in the file.

## The failure was silent

Read pairs the lookup with `errors.ProcessApiErrorV2`, which maps a 404 to `resp.State.RemoveResource`. A git trigger outside the provider's space was therefore not reported as an error. It was dropped from state, and the next plan proposed creating a trigger that already existed in Octopus. Applying that produced a duplicate release trigger.

Nothing changes in that helper here. See #263, which is about `ProcessApiErrorV2` returning `nil` for non-404 errors more generally.

## Update discarded its own error

```go
updatedGitTrigger, err = client.ProjectTriggers.Update(updatedGitTrigger)
tflog.Info(ctx, fmt.Sprintf("Git Trigger updated (%s)", data.ID))

resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
```

The `err` was assigned and never checked, `updatedGitTrigger` was unused, and state was written from the plan. A failed update was reported to the user as a success. Update now checks the error and populates state from the response.

## Also

The two bare filter type assertions (`:83` in Create, `:113` in Read) would panic the provider rather than return a diagnostic if the server returned a different filter type. They are checked now, along with the one added in Update.

## Tests

This resource had no test file at all. `octopusdeploy_framework/resource_git_trigger_test.go` adds unit tests driving the resource's `Read`, `Update` and `Delete` methods directly against a recording HTTP transport:

* Read and Delete address `Spaces-2` when the provider client is bound to `Spaces-1`. Reverting the fix makes both fail with `/api/Spaces-1/...`.
* Read falls back to the provider's space when `space_id` is empty.
* A server error on update produces a diagnostic. Reverting the fix makes this one fail, since the old code reported success.

No live server is needed, so these run on fork PRs where the integration workflow's secrets aren't available.

I did not add acceptance coverage. A git trigger needs a project whose deployment process has a matching action slug and git dependency, which is a fair amount of fixture work, and I would rather not guess at how you would want that set up. Happy to add it if you want it in this PR.

No schema change and no state migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
