### PR TITLE
feat: add space_id to project deployment target trigger

### DIFF
--- a/docs/resources/project_deployment_target_trigger.md
+++ b/docs/resources/project_deployment_target_trigger.md
@@ -35,6 +35,7 @@ resource "octopusdeploy_project_deployment_target_trigger" "example" {
 - `event_groups` (List of String) Apply event group filters to restrict which deployment targets will actually cause the trigger to fire, and consequently, which deployment targets will be automatically deployed to.
 - `roles` (List of String) Apply event role filters to restrict which deployment targets will actually cause the trigger to fire, and consequently, which deployment targets will be automatically deployed to.
 - `should_redeploy` (Boolean) Enable to re-deploy to the deployment targets even if they are already up-to-date with the current deployment.
+- `space_id` (String) The space ID associated with the project to attach the trigger. Defaults to the space the provider is configured for.
 
 ### Read-Only
 

--- a/octopusdeploy/resource_project_deployment_target_trigger.go
+++ b/octopusdeploy/resource_project_deployment_target_trigger.go
@@ -8,10 +8,20 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/filters"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// projectDeploymentTargetTriggerSpaceID resolves the space the trigger lives
+// in, falling back to the space the provider was configured for when the
+// resource doesn't set one.
+func projectDeploymentTargetTriggerSpaceID(d *schema.ResourceData, client *client.Client) string {
+	spaceId := d.Get("space_id").(string)
+	return util.Ternary(len(spaceId) > 0, spaceId, client.GetSpaceID())
+}
 
 func resourceProjectDeploymentTargetTrigger() *schema.Resource {
 	return &schema.Resource{
@@ -82,7 +92,7 @@ func buildProjectDeploymentTargetTriggerResource(d *schema.ResourceData, client 
 		filter.Environments = getSliceFromTerraformTypeList(attr)
 	}
 
-	project, err := client.Projects.GetByID(projectID)
+	project, err := projects.GetByID(client, projectDeploymentTargetTriggerSpaceID(d, client), projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -100,10 +110,12 @@ func resourceProjectDeploymentTargetTriggerCreate(ctx context.Context, d *schema
 		return diag.FromErr(err)
 	}
 
-	resource, err := client.ProjectTriggers.Add(projectTrigger)
+	resource, err := triggers.Add(client, projectTrigger)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	d.Set("space_id", resource.SpaceID)
 
 	if isEmpty(resource.GetID()) {
 		log.Println("ID is nil")
@@ -118,9 +130,11 @@ func resourceProjectDeploymentTargetTriggerRead(ctx context.Context, d *schema.R
 	id := d.Id()
 
 	client := m.(*client.Client)
-	resource, err := client.ProjectTriggers.GetByID(id)
+	spaceId := projectDeploymentTargetTriggerSpaceID(d, client)
+
+	resource, err := triggers.GetById(client, spaceId, id)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("unable to read project deployment target trigger (%s) in space %s: %w", id, spaceId, err))
 	}
 	if resource == nil {
 		d.SetId("")
@@ -129,9 +143,16 @@ func resourceProjectDeploymentTargetTriggerRead(ctx context.Context, d *schema.R
 
 	logResource("project_trigger", m)
 
-	action := resource.Action.(*actions.AutoDeployAction)
-	filter := resource.Filter.(*filters.DeploymentTargetFilter)
+	action, ok := resource.Action.(*actions.AutoDeployAction)
+	if !ok {
+		return diag.Errorf("project trigger (%s) in space %s is not an auto deploy trigger", id, spaceId)
+	}
+	filter, ok := resource.Filter.(*filters.DeploymentTargetFilter)
+	if !ok {
+		return diag.Errorf("project trigger (%s) in space %s is not a deployment target trigger", id, spaceId)
+	}
 
+	d.Set("space_id", resource.SpaceID)
 	d.Set("environment_ids", filter.Environments)
 	d.Set("event_groups", filter.EventGroups)
 	d.Set("event_categories", filter.EventCategories)
@@ -150,11 +171,12 @@ func resourceProjectDeploymentTargetTriggerUpdate(ctx context.Context, d *schema
 	}
 	projectTrigger.ID = d.Id() // set ID so Octopus API knows which project trigger to update
 
-	resource, err := client.ProjectTriggers.Update(projectTrigger)
+	resource, err := triggers.Update(client, projectTrigger)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	d.Set("space_id", resource.SpaceID)
 	d.SetId(resource.GetID())
 
 	return nil
@@ -162,9 +184,11 @@ func resourceProjectDeploymentTargetTriggerUpdate(ctx context.Context, d *schema
 
 func resourceProjectDeploymentTargetTriggerDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client.Client)
-	err := client.ProjectTriggers.DeleteByID(d.Id())
+	spaceId := projectDeploymentTargetTriggerSpaceID(d, client)
+
+	err := triggers.DeleteById(client, spaceId, d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("unable to delete project deployment target trigger (%s) in space %s: %w", d.Id(), spaceId, err))
 	}
 
 	d.SetId("")

--- a/octopusdeploy/resource_project_deployment_target_trigger_test.go
+++ b/octopusdeploy/resource_project_deployment_target_trigger_test.go
@@ -1,0 +1,156 @@
+package octopusdeploy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/filters"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	targetTriggerProviderSpaceID = "Spaces-1"
+	targetTriggerSpaceID         = "Spaces-2"
+	targetTriggerID              = "ProjectTriggers-1"
+)
+
+// targetTriggerTransport serves the canned root document that client
+// construction needs and records every other request, so a test can assert
+// which space the provider actually addressed.
+type targetTriggerTransport struct {
+	requests []string
+	body     string
+}
+
+func (t *targetTriggerTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if !strings.Contains(request.URL.Path, "projecttriggers") {
+		return targetTriggerResponse(constants.ApiReplyRoot), nil
+	}
+
+	t.requests = append(t.requests, request.Method+" "+request.URL.Path)
+
+	return targetTriggerResponse(t.body), nil
+}
+
+func targetTriggerResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		// The SDK skips decoding entirely when ContentLength is zero.
+		ContentLength: int64(len(body)),
+	}
+}
+
+func newTargetTriggerClient(t *testing.T, transport *targetTriggerTransport) *client.Client {
+	t.Helper()
+
+	apiURL, err := url.Parse("http://localhost:8080")
+	require.NoError(t, err)
+
+	octopusClient, err := client.NewClientForTool(
+		&http.Client{Transport: transport},
+		apiURL,
+		"API-TESTTESTTESTTEST0",
+		targetTriggerProviderSpaceID,
+		"terraform-provider-octopusdeploy-test",
+	)
+	require.NoError(t, err)
+
+	return octopusClient
+}
+
+func newTargetTriggerBody(t *testing.T) string {
+	t.Helper()
+
+	project := &projects.Project{SpaceID: targetTriggerSpaceID}
+	project.ID = "Projects-1"
+
+	trigger := triggers.NewProjectTrigger(
+		"test-trigger",
+		"",
+		false,
+		project,
+		actions.NewAutoDeployAction(false),
+		filters.NewDeploymentTargetFilter(
+			[]string{"Environments-1"},
+			[]string{"MachineHealthy"},
+			[]string{"Machine"},
+			[]string{"web-server"},
+		),
+	)
+	trigger.ID = targetTriggerID
+
+	body, err := json.Marshal(trigger)
+	require.NoError(t, err)
+
+	return string(body)
+}
+
+func newTargetTriggerResourceData(t *testing.T, spaceID string) *schema.ResourceData {
+	t.Helper()
+
+	raw := map[string]interface{}{
+		"name":       "test-trigger",
+		"project_id": "Projects-1",
+	}
+	if spaceID != "" {
+		raw["space_id"] = spaceID
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, getProjectDeploymentTargetTriggerSchema(), raw)
+	resourceData.SetId(targetTriggerID)
+
+	return resourceData
+}
+
+// The provider is configured for one space while the resource declares
+// another. Read has to address the resource's space, not the provider's.
+func TestProjectDeploymentTargetTriggerReadUsesResourceSpace(t *testing.T) {
+	transport := &targetTriggerTransport{body: newTargetTriggerBody(t)}
+	octopusClient := newTargetTriggerClient(t, transport)
+	resourceData := newTargetTriggerResourceData(t, targetTriggerSpaceID)
+
+	diags := resourceProjectDeploymentTargetTriggerRead(context.Background(), resourceData, octopusClient)
+
+	require.False(t, diags.HasError(), "read returned diagnostics: %v", diags)
+	require.Equal(t, []string{"GET /api/" + targetTriggerSpaceID + "/projecttriggers/" + targetTriggerID}, transport.requests)
+	require.Equal(t, targetTriggerSpaceID, resourceData.Get("space_id"))
+	require.Equal(t, "test-trigger", resourceData.Get("name"))
+}
+
+func TestProjectDeploymentTargetTriggerDeleteUsesResourceSpace(t *testing.T) {
+	transport := &targetTriggerTransport{}
+	octopusClient := newTargetTriggerClient(t, transport)
+	resourceData := newTargetTriggerResourceData(t, targetTriggerSpaceID)
+
+	diags := resourceProjectDeploymentTargetTriggerDelete(context.Background(), resourceData, octopusClient)
+
+	require.False(t, diags.HasError(), "delete returned diagnostics: %v", diags)
+	require.Equal(t, []string{"DELETE /api/" + targetTriggerSpaceID + "/projecttriggers/" + targetTriggerID}, transport.requests)
+	require.Empty(t, resourceData.Id())
+}
+
+// Configurations written before space_id existed leave it unset, and must keep
+// addressing the space the provider was configured for.
+func TestProjectDeploymentTargetTriggerReadFallsBackToProviderSpace(t *testing.T) {
+	transport := &targetTriggerTransport{body: newTargetTriggerBody(t)}
+	octopusClient := newTargetTriggerClient(t, transport)
+	resourceData := newTargetTriggerResourceData(t, "")
+
+	diags := resourceProjectDeploymentTargetTriggerRead(context.Background(), resourceData, octopusClient)
+
+	require.False(t, diags.HasError(), "read returned diagnostics: %v", diags)
+	require.Equal(t, []string{"GET /api/" + targetTriggerProviderSpaceID + "/projecttriggers/" + targetTriggerID}, transport.requests)
+}

--- a/octopusdeploy/schema_project_deployment_target_trigger.go
+++ b/octopusdeploy/schema_project_deployment_target_trigger.go
@@ -2,11 +2,23 @@ package octopusdeploy
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func getProjectDeploymentTargetTriggerSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": getNameSchema(true),
+		"space_id": {
+			Description: "The space ID associated with the project to attach the trigger. Defaults to the space the provider is configured for.",
+			Optional:    true,
+			// Computed so that omitting the attribute takes the value the
+			// server reports rather than producing a diff on every plan, and
+			// ForceNew because a trigger cannot be moved between spaces.
+			Computed:         true,
+			ForceNew:         true,
+			Type:             schema.TypeString,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+		},
 		"project_id": {
 			Description: "The ID of the project to attach the trigger.",
 			Required:    true,

--- a/octopusdeploy_framework/resource_project_deployment_target_trigger_test.go
+++ b/octopusdeploy_framework/resource_project_deployment_target_trigger_test.go
@@ -161,6 +161,46 @@ func TestAccOctopusDeployProjectDeploymentTargetTriggerImport(t *testing.T) {
 	})
 }
 
+// Before space_id existed on this resource, every call went to the space the
+// provider was configured for, so a trigger could not be managed anywhere else.
+func TestAccOctopusDeployProjectDeploymentTargetTriggerOutsideProviderSpace(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	prefix := "octopusdeploy_project_deployment_target_trigger." + localName
+
+	lifecycleLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	lifecycleName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectGroupLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectGroupName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	projectDescription := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	triggerName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	space := NewTestSpace(t)
+
+	config := testAccProjectDeploymentTargetTriggerCrossSpace(space.ID, localName, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, triggerName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(prefix, "name", triggerName),
+					resource.TestCheckResourceAttr(prefix, "space_id", space.ID),
+				),
+				Config: config,
+			},
+			{
+				// The refresh in this step is what used to fail.
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccProjectDeploymentTargetTriggerBasic(localName, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, triggerName string) string {
 	return testAccProjectDeploymentTargetTriggerDependencies(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription) + fmt.Sprintf(`
 	resource "octopusdeploy_project_deployment_target_trigger" "%s" {
@@ -199,6 +239,41 @@ func testAccProjectDeploymentTargetTriggerWithFilters(localName, lifecycleLocalN
 	}`, environmentLocalName, environmentName, environmentDescription, localName, triggerName, projectLocalName, environmentLocalName)
 }
 
+// testAccProjectDeploymentTargetTriggerCrossSpace puts every resource in
+// spaceID without pinning the provider to it, so the provider stays on the
+// default space.
+func testAccProjectDeploymentTargetTriggerCrossSpace(spaceID, localName, lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, triggerName string) string {
+	return fmt.Sprintf(`
+	resource "octopusdeploy_lifecycle" "%s" {
+		space_id = "%s"
+		name     = "%s"
+	}
+
+	resource "octopusdeploy_project_group" "%s" {
+		space_id = "%s"
+		name     = "%s"
+	}
+
+	resource "octopusdeploy_project" "%s" {
+		space_id         = "%s"
+		description      = "%s"
+		lifecycle_id     = octopusdeploy_lifecycle.%s.id
+		name             = "%s"
+		project_group_id = octopusdeploy_project_group.%s.id
+	}
+
+	resource "octopusdeploy_project_deployment_target_trigger" "%s" {
+		name         = "%s"
+		space_id     = "%s"
+		project_id   = octopusdeploy_project.%s.id
+		event_groups = ["Machine"]
+	}`,
+		lifecycleLocalName, spaceID, lifecycleName,
+		projectGroupLocalName, spaceID, projectGroupName,
+		projectLocalName, spaceID, projectDescription, lifecycleLocalName, projectName, projectGroupLocalName,
+		localName, triggerName, spaceID, projectLocalName)
+}
+
 func testAccProjectDeploymentTargetTriggerDependencies(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription string) string {
 	return fmt.Sprintf(`
 	resource "octopusdeploy_lifecycle" "%s" {
@@ -214,7 +289,7 @@ func testAccProjectDeploymentTargetTriggerDependencies(lifecycleLocalName, lifec
 		lifecycle_id     = octopusdeploy_lifecycle.%s.id
 		name             = "%s"
 		project_group_id = octopusdeploy_project_group.%s.id
-	}`, 
+	}`,
 		lifecycleLocalName, lifecycleName,
 		projectGroupLocalName, projectGroupName,
 		projectLocalName, projectDescription, lifecycleLocalName, projectName, projectGroupLocalName)


### PR DESCRIPTION
Fixes #262. Same underlying cause as #25, fixed for the external feed trigger in #259 and for the git trigger in #266, but this one needed a new attribute rather than a change of client call.

## Problem

`octopusdeploy_project_deployment_target_trigger` had no `space_id` attribute at all, unlike every other trigger resource. Every API call therefore used the space the provider was configured for:

* `octopusdeploy/resource_project_deployment_target_trigger.go:85` `client.Projects.GetByID(projectID)` in the shared build function, so Create and Update both looked the project up in the wrong space
* `:121` (Read) `client.ProjectTriggers.GetByID(id)`
* `:165` (Delete) `client.ProjectTriggers.DeleteByID(d.Id())`

The resource only worked when the provider was already pointed at the target space, and there was no way to tell it otherwise.

## Change

Adds an optional `space_id` and threads it through the project lookup, read and delete, falling back to the provider's space when it isn't set so existing configurations keep working unchanged.

The attribute is `Computed` as well as `Optional`. Read writes the server's value back, so without `Computed` a configuration that omits `space_id` would show a diff on every plan. It is also `ForceNew`, because a trigger cannot be moved between spaces and an in-place update could not do what the plan claimed. Create and Update write the value into state so an imported trigger matches an applied one.

Create, Update and Delete move to the package level `triggers` helpers. The action and filter type assertions in Read are checked rather than left to panic the provider.

## Tests

`octopusdeploy/resource_project_deployment_target_trigger_test.go` adds unit tests using a recording HTTP transport: the provider client is bound to `Spaces-1` while the resource declares `Spaces-2`, asserting the request path for Read and Delete, plus the fallback when `space_id` is unset. Reverting the change makes the first two fail with `/api/Spaces-1/...`. These need no live server, so they run on fork PRs where the integration workflow's secrets aren't available.

`TestAccOctopusDeployProjectDeploymentTargetTriggerOutsideProviderSpace` leaves the provider on the default space, creates the trigger and its project in a test space, and follows the apply with a `PlanOnly` refresh.

All five acceptance tests for this resource pass against a local 2025.x instance, including the existing Basic, Update, WithFilters and Import cases.

## Note on scope

Read still does not populate `project_id`, which predates this change. I have left it alone rather than widen the diff, but it means an imported trigger has no `project_id` in state. Happy to fix that here or separately if you would like.

Docs regenerated with `make docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
