### PR TITLE
ci: guard against space-bound client accessors in resources

### DIFF
--- a/.github/space-bound-accessor-allowlist.txt
+++ b/.github/space-bound-accessor-allowlist.txt
@@ -1,0 +1,19 @@
+# Files still calling the space-bound client accessors,
+# client.<Service>.GetByID(id) / client.<Service>.DeleteByID(id).
+#
+# Those resolve their path from the space the provider was configured for, so a
+# resource that has its own space_id ends up reading and deleting in the wrong
+# space. See https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/25
+#
+# Prefer the package level helpers, which take the space explicitly:
+#
+#   triggers.GetById(client, spaceID, id)
+#   triggers.DeleteById(client, spaceID, id)
+#   projects.GetByID(client, spaceID, id)
+#
+# Take a file off this list when its calls are converted. Nothing new should be
+# added to it.
+octopusdeploy/resource_external_feed_create_release_trigger.go
+octopusdeploy/resource_project_deployment_target_trigger.go
+octopusdeploy/resource_team.go
+octopusdeploy_framework/resource_git_trigger.go

--- a/.github/workflows/prevent-space-bound-accessors.yml
+++ b/.github/workflows/prevent-space-bound-accessors.yml
@@ -1,0 +1,43 @@
+name: Prevent space-bound client accessors
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  detect-space-bound-accessors:
+    name: Prevent Space-Bound Accessors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for space-bound GetByID and DeleteByID calls
+        run: |
+          allowlist=.github/space-bound-accessor-allowlist.txt
+
+          matches=$(grep -rEn 'client\.[A-Za-z]+\.(GetByID|DeleteByID)\(' \
+            octopusdeploy octopusdeploy_framework \
+            --include='*.go' | grep -v '_test\.go:' || true)
+
+          violations=""
+          while IFS= read -r match; do
+            [ -z "$match" ] && continue
+            file="${match%%:*}"
+            if ! grep -qxF "$file" "$allowlist"; then
+              violations="${violations}${match}"$'\n'
+            fi
+          done <<< "$matches"
+
+          if [ -n "$violations" ]; then
+            echo "$violations"
+            echo "::error::client.<Service>.GetByID / DeleteByID resolve their path from the space the provider was configured for, so a resource with its own space_id reads and deletes in the wrong space. Use the package level helpers that take the space explicitly, for example triggers.GetById(client, spaceID, id) or projects.GetByID(client, spaceID, id). See $allowlist."
+            exit 1
+          fi
+
+          echo "::notice::No new space-bound accessor calls detected."


### PR DESCRIPTION
Fixes #265.

`client.<Service>.GetByID(id)` and `client.<Service>.DeleteByID(id)` resolve their path from the URI template of the space the provider was configured for. A resource that has its own `space_id` therefore reads and deletes in the wrong space, and the failure only shows up at refresh, after the resource has been created successfully.

That has now happened three times:

* `octopusdeploy_external_feed_create_release_trigger` (#25, fixed in #259)
* `octopusdeploy_git_trigger` (#261, fixed in #266)
* `octopusdeploy_project_deployment_target_trigger` (#262, fixed in #267)

`ProjectTriggerService.GetByID` has carried a `// Deprecated: use triggers.GetByID` comment in the SDK throughout. A comment has not been enough.

## What this adds

A grep check modelled on `prevent-new-sdk-additions.yml`, plus `.github/space-bound-accessor-allowlist.txt` listing the files that still contain these calls. Anything matching outside the allow list fails the build, with a message pointing at the package level helpers that take the space explicitly.

The allow list holds paths rather than line numbers, so it does not churn when unrelated edits move code around, and it stays correct regardless of the order the three fixes above merge in. Once a file's calls are converted it simply stops matching, and the entry can be deleted on the next pass.

`resource_team.go` is on the list as well. Teams have a different space model, so I have not touched it here.

## Verified

* Against current `main`: 11 matching call sites, all allow-listed, check passes.
* With a deliberate `client.Environments.GetByID(...)` added to a file that is not allow-listed: the check fails and prints the offending line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
