### PR TITLE
fix: suppress polling URI casing differences on agent workers and polling tentacles

### DIFF
--- a/docs/resources/kubernetes_agent_deployment_target.md
+++ b/docs/resources/kubernetes_agent_deployment_target.md
@@ -52,7 +52,7 @@ resource "octopusdeploy_kubernetes_agent_deployment_target" "tenanted_agent" {
 - `name` (String) The name of this resource.
 - `roles` (List of String) A list of target roles that are associated to this Kubernetes agent.
 - `thumbprint` (String) The thumbprint of the Kubernetes agent's certificate used by server to verify the identity of the agent. This is the same thumbprint that was used when installing the agent.
-- `uri` (String) The URI of the Kubernetes agent's used by the server to queue messages. This is the same subscription uri that was used when installing the agent.
+- `uri` (String) The URI of the Kubernetes agent's used by the server to queue messages. This is the same subscription uri that was used when installing the agent. Casing is not significant; Octopus Server stores the URI with a lowercase host.
 
 ### Optional
 

--- a/docs/resources/kubernetes_agent_worker.md
+++ b/docs/resources/kubernetes_agent_worker.md
@@ -38,7 +38,7 @@ resource "octopusdeploy_kubernetes_agent_worker" "optionals" {
 
 - `name` (String) The name of this resource.
 - `thumbprint` (String) The thumbprint of the Kubernetes agent's certificate used by server to verify the identity of the agent. This is the same thumbprint that was used when installing the agent.
-- `uri` (String) The URI of the Kubernetes agent's used by the server to queue messages. This is the same subscription uri that was used when installing the agent.
+- `uri` (String) The URI of the Kubernetes agent's used by the server to queue messages. This is the same subscription uri that was used when installing the agent. Casing is not significant; Octopus Server stores the URI with a lowercase host.
 - `worker_pool_ids` (List of String) A list of worker pool Ids specifying the pools in which this worker belongs
 
 ### Optional

--- a/docs/resources/polling_tentacle_deployment_target.md
+++ b/docs/resources/polling_tentacle_deployment_target.md
@@ -31,7 +31,7 @@ resource "octopusdeploy_polling_tentacle_deployment_target" "example" {
 - `environments` (List of String) A list of environment IDs associated with this resource.
 - `name` (String) The name of this resource.
 - `roles` (List of String)
-- `tentacle_url` (String)
+- `tentacle_url` (String) The polling subscription URI that this tentacle uses to queue messages. Casing is not significant; Octopus Server stores the URI with a lowercase host.
 
 ### Optional
 

--- a/octopusdeploy/resource_kubernetes_agent_worker.go
+++ b/octopusdeploy/resource_kubernetes_agent_worker.go
@@ -16,7 +16,7 @@ func resourceKubernetesAgentWorker() *schema.Resource {
 		Description:   "This resource manages Kubernetes agent workers in Octopus Deploy.",
 		Importer:      getImporter(),
 		ReadContext:   resourceKubernetesAgentWorkerRead,
-		Schema:        getKubernetesAgentWorkerSchema(),
+		Schema:        getKubernetesAgentWorkerSchemaForResource(),
 		UpdateContext: resourceKubernetesAgentWorkerUpdate,
 	}
 }

--- a/octopusdeploy/resource_polling_tentacle_deployment_target.go
+++ b/octopusdeploy/resource_polling_tentacle_deployment_target.go
@@ -18,7 +18,7 @@ func resourcePollingTentacleDeploymentTarget() *schema.Resource {
 		Description:   "This resource manages polling tentacle deployment targets in Octopus Deploy.",
 		Importer:      getImporter(),
 		ReadContext:   resourcePollingTentacleDeploymentTargetRead,
-		Schema:        getPollingTentacleDeploymentTargetSchema(),
+		Schema:        getPollingTentacleDeploymentTargetSchemaForResource(),
 		UpdateContext: resourcePollingTentacleDeploymentTargetUpdate,
 	}
 }

--- a/octopusdeploy/schema_kubernetes_agent_deployment_target.go
+++ b/octopusdeploy/schema_kubernetes_agent_deployment_target.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/url"
-	"strings"
 )
 
 func expandKubernetesAgentDeploymentTarget(kubernetesAgent *schema.ResourceData) *machines.DeploymentTarget {
@@ -80,11 +79,7 @@ func getKubernetesAgentDeploymentTargetSchemaForDataSource() map[string]*schema.
 }
 
 func getKubernetesAgentDeploymentTargetSchemaForResource() map[string]*schema.Schema {
-	uriDiffSuppress := func(k, old, new string, d *schema.ResourceData) bool {
-		return strings.EqualFold(old, new)
-	}
-
-	return getKubernetesAgentDeploymentTargetSchema(uriDiffSuppress)
+	return getKubernetesAgentDeploymentTargetSchema(getPollingURIDiffSuppressFunc())
 }
 
 func getKubernetesAgentDeploymentTargetSchema(uriDiffSuppress schema.SchemaDiffSuppressFunc) map[string]*schema.Schema {
@@ -128,7 +123,7 @@ func getKubernetesAgentDeploymentTargetSchema(uriDiffSuppress schema.SchemaDiffS
 			Type:        schema.TypeString,
 		},
 		"uri": {
-			Description:           "The URI of the Kubernetes agent's used by the server to queue messages. This is the same subscription uri that was used when installing the agent.",
+			Description:           "The URI of the Kubernetes agent's used by the server to queue messages. This is the same subscription uri that was used when installing the agent. Casing is not significant; Octopus Server stores the URI with a lowercase host.",
 			Required:              true,
 			Type:                  schema.TypeString,
 			DiffSuppressFunc:      uriDiffSuppress,

--- a/octopusdeploy/schema_kubernetes_agent_worker.go
+++ b/octopusdeploy/schema_kubernetes_agent_worker.go
@@ -64,7 +64,15 @@ func flattenKubernetesAgentWorker(Worker *machines.Worker) map[string]interface{
 	return flattenedWorker
 }
 
-func getKubernetesAgentWorkerSchema() map[string]*schema.Schema {
+func getKubernetesAgentWorkerSchemaForDataSource() map[string]*schema.Schema {
+	return getKubernetesAgentWorkerSchema(nil)
+}
+
+func getKubernetesAgentWorkerSchemaForResource() map[string]*schema.Schema {
+	return getKubernetesAgentWorkerSchema(getPollingURIDiffSuppressFunc())
+}
+
+func getKubernetesAgentWorkerSchema(uriDiffSuppress schema.SchemaDiffSuppressFunc) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"id":       getIDSchema(),
 		"space_id": getSpaceIDSchema(),
@@ -88,9 +96,11 @@ func getKubernetesAgentWorkerSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"uri": {
-			Description: "The URI of the Kubernetes agent's used by the server to queue messages. This is the same subscription uri that was used when installing the agent.",
-			Required:    true,
-			Type:        schema.TypeString,
+			Description:           "The URI of the Kubernetes agent's used by the server to queue messages. This is the same subscription uri that was used when installing the agent. Casing is not significant; Octopus Server stores the URI with a lowercase host.",
+			Required:              true,
+			Type:                  schema.TypeString,
+			DiffSuppressFunc:      uriDiffSuppress,
+			DiffSuppressOnRefresh: uriDiffSuppress != nil,
 		},
 		"upgrade_locked": {
 			Description: "If enabled the Kubernetes agent will not automatically upgrade and will stay on the currently installed version, even if the associated machine policy is configured to automatically upgrade.",
@@ -141,7 +151,7 @@ func getKubernetesAgentWorkerSchema() map[string]*schema.Schema {
 }
 
 func getKubernetesAgentWorkerDataSchema() map[string]*schema.Schema {
-	dataSchema := getKubernetesAgentWorkerSchema()
+	dataSchema := getKubernetesAgentWorkerSchemaForDataSource()
 	setDataSchema(&dataSchema)
 
 	WorkerDataSchema := getWorkerDataSchema()

--- a/octopusdeploy/schema_polling_tentacle_deployment_target.go
+++ b/octopusdeploy/schema_polling_tentacle_deployment_target.go
@@ -42,7 +42,7 @@ func flattenPollingTentacleDeploymentTarget(deploymentTarget *machines.Deploymen
 }
 
 func getPollingTentacleDeploymentTargetDataSchema() map[string]*schema.Schema {
-	dataSchema := getPollingTentacleDeploymentTargetSchema()
+	dataSchema := getPollingTentacleDeploymentTargetSchemaForDataSource()
 	setDataSchema(&dataSchema)
 
 	deploymentTargetDataSchema := getDeploymentTargetDataSchema()
@@ -62,7 +62,15 @@ func getPollingTentacleDeploymentTargetDataSchema() map[string]*schema.Schema {
 	return deploymentTargetDataSchema
 }
 
-func getPollingTentacleDeploymentTargetSchema() map[string]*schema.Schema {
+func getPollingTentacleDeploymentTargetSchemaForDataSource() map[string]*schema.Schema {
+	return getPollingTentacleDeploymentTargetSchema(nil)
+}
+
+func getPollingTentacleDeploymentTargetSchemaForResource() map[string]*schema.Schema {
+	return getPollingTentacleDeploymentTargetSchema(getPollingURIDiffSuppressFunc())
+}
+
+func getPollingTentacleDeploymentTargetSchema(tentacleURLDiffSuppress schema.SchemaDiffSuppressFunc) map[string]*schema.Schema {
 	pollingTentacleDeploymentTargetSchema := getDeploymentTargetSchema()
 
 	pollingTentacleDeploymentTargetSchema["certificate_signature_algorithm"] = &schema.Schema{
@@ -78,8 +86,11 @@ func getPollingTentacleDeploymentTargetSchema() map[string]*schema.Schema {
 	}
 
 	pollingTentacleDeploymentTargetSchema["tentacle_url"] = &schema.Schema{
-		Required: true,
-		Type:     schema.TypeString,
+		Description:           "The polling subscription URI that this tentacle uses to queue messages. Casing is not significant; Octopus Server stores the URI with a lowercase host.",
+		Required:              true,
+		Type:                  schema.TypeString,
+		DiffSuppressFunc:      tentacleURLDiffSuppress,
+		DiffSuppressOnRefresh: tentacleURLDiffSuppress != nil,
 	}
 
 	return pollingTentacleDeploymentTargetSchema

--- a/octopusdeploy/schema_polling_uri_test.go
+++ b/octopusdeploy/schema_polling_uri_test.go
@@ -1,0 +1,85 @@
+package octopusdeploy
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Octopus Server lowercases the host of a polling URI, while
+// octopusdeploy_polling_subscription_id only ever generates uppercase subscription
+// IDs. Without diff suppression that mismatch shows up as a permanent in-place
+// update. These tests guard the wiring, which is what actually regressed: the
+// suppressor existed for kubernetes_agent_deployment_target but was never
+// attached to the worker or the polling tentacle target.
+
+func TestPollingURIDiffSuppress(t *testing.T) {
+	suppress := getPollingURIDiffSuppressFunc()
+
+	testCases := []struct {
+		name     string
+		old      string
+		new      string
+		expected bool
+	}{
+		{"identical", "poll://abcdef0123456789/", "poll://abcdef0123456789/", true},
+		{"server lowercase vs generated uppercase", "poll://abcdef0123456789/", "poll://ABCDEF0123456789/", true},
+		{"mixed casing", "poll://AbCdEf0123456789/", "poll://aBcDeF0123456789/", true},
+		{"different subscription id", "poll://abcdef0123456789/", "poll://fedcba9876543210/", false},
+		{"trailing slash removed", "poll://abcdef0123456789/", "poll://abcdef0123456789", false},
+		{"empty vs populated", "", "poll://abcdef0123456789/", false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, suppress("uri", testCase.old, testCase.new, nil))
+		})
+	}
+}
+
+func TestPollingURIAttributesSuppressCasingOnResources(t *testing.T) {
+	testCases := []struct {
+		name      string
+		resource  *schema.Resource
+		attribute string
+	}{
+		{"kubernetes agent worker", resourceKubernetesAgentWorker(), "uri"},
+		{"kubernetes agent deployment target", resourceKubernetesAgentDeploymentTarget(), "uri"},
+		{"polling tentacle deployment target", resourcePollingTentacleDeploymentTarget(), "tentacle_url"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			attribute, ok := testCase.resource.Schema[testCase.attribute]
+			require.True(t, ok, "expected a %s attribute", testCase.attribute)
+			require.NotNil(t, attribute.DiffSuppressFunc, "expected %s to suppress casing differences", testCase.attribute)
+
+			assert.True(t, attribute.DiffSuppressFunc(testCase.attribute, "poll://abcdef0123456789/", "poll://ABCDEF0123456789/", nil))
+			assert.False(t, attribute.DiffSuppressFunc(testCase.attribute, "poll://abcdef0123456789/", "poll://fedcba9876543210/", nil))
+			assert.True(t, attribute.DiffSuppressOnRefresh, "expected %s to suppress casing differences on refresh too", testCase.attribute)
+		})
+	}
+}
+
+func TestPollingURIAttributesDoNotSuppressOnDataSources(t *testing.T) {
+	testCases := []struct {
+		name      string
+		schema    map[string]*schema.Schema
+		attribute string
+	}{
+		{"kubernetes agent workers", getKubernetesAgentWorkerSchemaForDataSource(), "uri"},
+		{"kubernetes agent deployment targets", getKubernetesAgentDeploymentTargetSchemaForDataSource(), "uri"},
+		{"polling tentacle deployment targets", getPollingTentacleDeploymentTargetSchemaForDataSource(), "tentacle_url"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			attribute, ok := testCase.schema[testCase.attribute]
+			require.True(t, ok, "expected a %s attribute", testCase.attribute)
+			assert.Nil(t, attribute.DiffSuppressFunc, "data source attributes are computed and never diffed")
+			assert.False(t, attribute.DiffSuppressOnRefresh)
+		})
+	}
+}

--- a/octopusdeploy/schema_utilities.go
+++ b/octopusdeploy/schema_utilities.go
@@ -2,10 +2,22 @@ package octopusdeploy
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+// getPollingURIDiffSuppressFunc returns a diff suppressor for attributes holding a
+// polling URI. Octopus Server lowercases the host when it stores one, but
+// octopusdeploy_polling_subscription_id only generates uppercase subscription IDs,
+// so a URI fed from that resource would otherwise produce a permanent in-place
+// update. Attach this to every attribute that accepts a `poll://` URI.
+func getPollingURIDiffSuppressFunc() schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		return strings.EqualFold(old, new)
+	}
+}
 
 func getAccountTypeSchema(isRequired bool) *schema.Schema {
 	schema := &schema.Schema{

--- a/octopusdeploy_framework/resource_kubernetes_agent_worker_test.go
+++ b/octopusdeploy_framework/resource_kubernetes_agent_worker_test.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/workers"
@@ -110,6 +111,49 @@ func TestAccOctopusDeployKubernetesAgentWorkerWithUpgradeLocked(t *testing.T) {
 					resource.TestCheckResourceAttr(prefix, "upgrade_locked", "true"),
 				),
 				Config: testAccKubernetesAgentWorkerWithUpgradeLocked(localName, workerPoolLocalName, workerPoolName, name, uri, thumbprint),
+			},
+		},
+	})
+}
+
+// octopusdeploy_polling_subscription_id only ever generates uppercase subscription
+// IDs, while Octopus Server stores the URI with a lowercase host. Without diff
+// suppression on uri that mismatch surfaces as a permanent in-place update.
+// See https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/269.
+func TestAccOctopusDeployKubernetesAgentWorkerUriCasing(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	prefix := "octopusdeploy_kubernetes_agent_worker." + localName
+
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	uri := "poll://ABCDEF0123456789/"
+	thumbprint := "1234567890ABCDEF1234567890ABCDEF12345678"
+
+	workerPoolLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	workerPoolName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	config := testAccKubernetesAgentWorkerBasic(localName, workerPoolLocalName, workerPoolName, name, uri, thumbprint)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccKubernetesAgentWorkerCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccKubernetesAgentWorkerExists(prefix),
+					resource.TestCheckResourceAttrWith(prefix, "uri", func(value string) error {
+						if !strings.EqualFold(value, uri) {
+							return fmt.Errorf("expected uri to match %q ignoring case, got %q", uri, value)
+						}
+						return nil
+					}),
+				),
+				Config: config,
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/octopusdeploy_framework/resource_polling_tentacle_deployment_target_test.go
+++ b/octopusdeploy_framework/resource_polling_tentacle_deployment_target_test.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/machines"
@@ -37,6 +38,48 @@ func TestAccOctopusDeployPollingTentacleDeploymentTargetBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(prefix, "roles.0", "polling-role"),
 				),
 				Config: testAccPollingTentacleDeploymentTargetBasic(localName, environmentLocalName, environmentName, name, tentacleUrl, thumbprint),
+			},
+		},
+	})
+}
+
+// Same casing mismatch as issue #269, reached through tentacle_url instead of uri:
+// octopusdeploy_polling_subscription_id generates uppercase subscription IDs and
+// Octopus Server stores the URI with a lowercase host.
+func TestAccOctopusDeployPollingTentacleDeploymentTargetTentacleUrlCasing(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	prefix := "octopusdeploy_polling_tentacle_deployment_target." + localName
+
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	tentacleUrl := "poll://ABCDEF0123456789/"
+	thumbprint := "1234567890ABCDEF1234567890ABCDEF12345678"
+
+	environmentLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	environmentName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	config := testAccPollingTentacleDeploymentTargetBasic(localName, environmentLocalName, environmentName, name, tentacleUrl, thumbprint)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccPollingTentacleDeploymentTargetCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccPollingTentacleDeploymentTargetExists(prefix),
+					resource.TestCheckResourceAttrWith(prefix, "tentacle_url", func(value string) error {
+						if !strings.EqualFold(value, tentacleUrl) {
+							return fmt.Errorf("expected tentacle_url to match %q ignoring case, got %q", tentacleUrl, value)
+						}
+						return nil
+					}),
+				),
+				Config: config,
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #269.

## What's wrong

`octopusdeploy_polling_subscription_id` builds subscription IDs from an uppercase-only charset (`internal/random.go:10`), and Octopus Server stores a polling URI with a lowercase host. Any attribute that compares those case-sensitively shows a diff on every plan, forever:

```
~ uri = "poll://8v274unl9d8v2aqrpaks/" -> "poll://8V274UNL9D8V2AQRPAKS/"
```

91c0f675 fixed this for `octopusdeploy_kubernetes_agent_deployment_target` in January 2025. Two resources were missed:

- `octopusdeploy_kubernetes_agent_worker`, on `uri`. This is the resource reported in #269.
- `octopusdeploy_polling_tentacle_deployment_target`, on `tentacle_url`. Nobody has reported it, but the code has the same shape and is fed by the same generator.

## What changed

I pulled the closure 91c0f675 added inline out into a shared `getPollingURIDiffSuppressFunc` and attached it to all three resources. Data sources keep `nil` suppression, matching the split that already existed.

Rather than assume what the server does with casing, I checked. Posting a worker with `poll://8V274UNL9D8V2AQRPAKS/` to Octopus 2026.x reads back as `poll://8v274unl9d8v2aqrpaks/`. Only the host changes, and the scheme and trailing slash survive intact, so `strings.EqualFold` is enough.

## Impact

`DiffSuppressFunc` runs at plan time only. No state migration, no schema version bump, nothing breaking. State that is already lowercase stays valid and stops producing a diff.

One consequence is worth stating rather than leaving to be discovered. `DiffSuppressOnRefresh` keeps the prior state value when the suppressor matches, so `uri` holds config casing for resources created or refreshed after this change, and server casing for ones brought in through `terraform import`. That means downstream references to `.uri` are not guaranteed to be canonical across workspaces. The deployment target has behaved this way since 91c0f675.

## Tests

`octopusdeploy/schema_polling_uri_test.go` covers the suppressor itself and, more usefully, the wiring, since the wiring is what actually regressed. It covers all three resources and their data sources, runs without an Octopus instance, and backfills the coverage 91c0f675 never had. I checked it fails without the fix by reverting the wiring on the worker.

`TestAccOctopusDeployKubernetesAgentWorkerUriCasing` and `TestAccOctopusDeployPollingTentacleDeploymentTargetTentacleUrlCasing` apply an uppercase URI, then re-plan the identical config and assert the plan is empty.

Docs regenerated for the three affected `Description` strings.
