### PR TITLE
fix: guard against nil dereferences and panics across resources

### DIFF
--- a/octopusdeploy/data_source_channels.go
+++ b/octopusdeploy/data_source_channels.go
@@ -41,6 +41,9 @@ func dataSourceChannelsRead(ctx context.Context, d *schema.ResourceData, m inter
 			Take:        query.Take,
 		}
 		existingChannels, err = channels.GetByProjectID(client, spaceID, queryByProjectID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		if len(query.IDs) > 0 {
 			filteredChannels := make([]*channels.Channel, 0)
 			for _, channel := range existingChannels.Items {

--- a/octopusdeploy/data_source_machine.go
+++ b/octopusdeploy/data_source_machine.go
@@ -128,10 +128,12 @@ func dataMachineReadByName(d *schema.ResourceData, m interface{}) error {
 			d.Set("endpoint_communicationstyle", machine.Endpoint.GetCommunicationStyle())
 			d.Set("endpoint_id", endpointResource.GetID())
 			d.Set("endpoint_proxyid", endpointResource.ProxyID)
-			d.Set("endpoint_tentacleversiondetails_upgradelocked", endpointResource.TentacleVersionDetails.UpgradeLocked)
-			d.Set("endpoint_tentacleversiondetails_upgraderequired", endpointResource.TentacleVersionDetails.UpgradeRequired)
-			d.Set("endpoint_tentacleversiondetails_upgradesuggested", endpointResource.TentacleVersionDetails.UpgradeSuggested)
-			d.Set("endpoint_tentacleversiondetails_version", endpointResource.TentacleVersionDetails.Version)
+			if tvd := endpointResource.TentacleVersionDetails; tvd != nil {
+				d.Set("endpoint_tentacleversiondetails_upgradelocked", tvd.UpgradeLocked)
+				d.Set("endpoint_tentacleversiondetails_upgraderequired", tvd.UpgradeRequired)
+				d.Set("endpoint_tentacleversiondetails_upgradesuggested", tvd.UpgradeSuggested)
+				d.Set("endpoint_tentacleversiondetails_version", tvd.Version)
+			}
 			d.Set("endpoint_thumbprint", endpointResource.Thumbprint)
 			d.Set("endpoint_uri", endpointResource.URI)
 			d.Set("environments", machine.EnvironmentIDs)

--- a/octopusdeploy_framework/resource_deployment_freeze_project.go
+++ b/octopusdeploy_framework/resource_deployment_freeze_project.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deploymentfreezes"
@@ -88,11 +89,13 @@ func (d *deploymentFreezeProjectResource) Read(ctx context.Context, req resource
 
 	freeze, err := deploymentfreezes.GetById(d.Client, freezeId)
 	if err != nil {
-		apiError := err.(*core.APIError)
-		if apiError.StatusCode != http.StatusNotFound {
-			resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		var apiError *core.APIError
+		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
 			return
 		}
+		resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		return
 	}
 
 	data.EnvironmentIDs = mapEnvironmentIds(freeze.ProjectEnvironmentScope[projectId])
@@ -119,11 +122,13 @@ func (d *deploymentFreezeProjectResource) Update(ctx context.Context, req resour
 
 	freeze, err := deploymentfreezes.GetById(d.Client, state.DeploymentFreezeID.ValueString())
 	if err != nil {
-		apiError := err.(*core.APIError)
-		if apiError.StatusCode != http.StatusNotFound {
-			resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		var apiError *core.APIError
+		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
 			return
 		}
+		resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		return
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("updating project (%s) to deployment freeze (%s)", plan.ProjectID.ValueString(), plan.DeploymentFreezeID.ValueString()))
@@ -156,11 +161,12 @@ func (d *deploymentFreezeProjectResource) Delete(ctx context.Context, req resour
 
 	freeze, err := deploymentfreezes.GetById(d.Client, data.DeploymentFreezeID.ValueString())
 	if err != nil {
-		apiError := err.(*core.APIError)
-		if apiError.StatusCode != http.StatusNotFound {
-			resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		var apiError *core.APIError
+		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
 			return
 		}
+		resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		return
 	}
 
 	delete(freeze.ProjectEnvironmentScope, data.ProjectID.ValueString())

--- a/octopusdeploy_framework/resource_project.go
+++ b/octopusdeploy_framework/resource_project.go
@@ -68,6 +68,10 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	createdProject, err = projects.GetByID(r.Client, plan.SpaceID.ValueString(), createdProject.GetID())
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading created project", err.Error())
+		return
+	}
 	preserveGitPassword(createdProject.PersistenceSettings, persistenceSettings)
 
 	flattenedProject, diags := flattenProject(ctx, createdProject, &plan)

--- a/octopusdeploy_framework/resource_project_expand.go
+++ b/octopusdeploy_framework/resource_project_expand.go
@@ -352,7 +352,7 @@ func expandReleaseCreationStrategy(model releaseCreationStrategyModel) *projects
 		ChannelID:                    model.ChannelID.ValueString(),
 		ReleaseCreationPackageStepID: model.ReleaseCreationPackageStepID.ValueString(),
 	}
-	if model.ReleaseCreationPackage != nil {
+	if len(model.ReleaseCreationPackage) > 0 {
 		strategy.ReleaseCreationPackage = expandDeploymentActionPackage(model.ReleaseCreationPackage[0])
 	}
 	return strategy

--- a/octopusdeploy_framework/resource_pypi_feed.go
+++ b/octopusdeploy_framework/resource_pypi_feed.go
@@ -101,11 +101,11 @@ func (r *pyPiFeedTypeResource) Update(ctx context.Context, req resource.UpdateRe
 	tflog.Debug(ctx, fmt.Sprintf("updating PyPI feed '%s'", data.ID.ValueString()))
 
 	feed, err := createPyPiResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load PyPI feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating PyPI feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_s3_feed.go
+++ b/octopusdeploy_framework/resource_s3_feed.go
@@ -100,11 +100,11 @@ func (r *s3FeedTypeResource) Update(ctx context.Context, req resource.UpdateRequ
 	tflog.Debug(ctx, fmt.Sprintf("updating S3 feed '%s'", data.ID.ValueString()))
 
 	feed, err := createS3ResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load S3 feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating S3 feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_space.go
+++ b/octopusdeploy_framework/resource_space.go
@@ -81,7 +81,11 @@ func (s *spaceResource) Create(ctx context.Context, req resource.CreateRequest, 
 	tflog.Debug(ctx, fmt.Sprintf("resulting space %#v", createdSpace))
 
 	// the result of a space add operation seems to not return the correct values for teams, but the get does
-	createdSpace, _ = spaces.GetByID(s.Client, createdSpace.ID)
+	createdSpace, err = spaces.GetByID(s.Client, createdSpace.ID)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to read created space", err.Error())
+		return
+	}
 
 	if data.IsTaskQueueStopped.ValueBool() == true {
 		// a space can't have a stopped task queue via the create, need to do a subsequent update
@@ -89,8 +93,13 @@ func (s *spaceResource) Create(ctx context.Context, req resource.CreateRequest, 
 		_, err = spaces.Update(s.Client, createdSpace)
 		if err != nil {
 			resp.Diagnostics.AddError("Error updating space task queue", err.Error())
+			return
 		}
-		createdSpace, _ = spaces.GetByID(s.Client, createdSpace.ID)
+		createdSpace, err = spaces.GetByID(s.Client, createdSpace.ID)
+		if err != nil {
+			resp.Diagnostics.AddError("unable to read created space", err.Error())
+			return
+		}
 		tflog.Debug(ctx, fmt.Sprintf("resulting space after setting task queue stopped %#v", createdSpace))
 	}
 
@@ -234,6 +243,7 @@ func (s *spaceResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	space, err := spaces.GetByID(s.Client, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("unable to read space", err.Error())
+		return
 	}
 
 	space.TaskQueueStopped = true

--- a/octopusdeploy_framework/resource_step_template.go
+++ b/octopusdeploy_framework/resource_step_template.go
@@ -419,7 +419,9 @@ func convertStepTemplateParameterAttribute(atp actiontemplates.ActionTemplatePar
 	// because Server never returns sensitive values from the API
 	defaultValue := types.StringValue("")
 	defaultSensitiveValue := types.StringNull()
-	if atp.DefaultValue.IsSensitive && stateParameter != nil {
+	if atp.DefaultValue == nil {
+		defaultValue = types.StringValue("")
+	} else if atp.DefaultValue.IsSensitive && stateParameter != nil {
 		defaultSensitiveValue = stateParameter.DefaultSensitiveValue
 	} else {
 		defaultValue = types.StringValue(atp.DefaultValue.Value)

--- a/octopusdeploy_framework/resource_tag.go
+++ b/octopusdeploy_framework/resource_tag.go
@@ -91,7 +91,10 @@ func (r *tagTypeResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	tagCreate(ctx, data, resp.Diagnostics, r.Client)
+	tagCreate(ctx, data, &resp.Diagnostics, r.Client)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Info(ctx, fmt.Sprintf("tag created (%s)", data.ID))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -117,14 +120,14 @@ func (t *tagTypeResource) Update(ctx context.Context, req resource.UpdateRequest
 	// if the tag is reassigned to another tag set
 	if !data.TagSetId.Equal(state.TagSetId) {
 		sourceTagSetID, destinationTagSetID := state.TagSetId.ValueString(), data.TagSetId.ValueString()
-		targetSpaceId := util.Ternary(data.TagSetSpaceId.ValueString() == "", data.TagSetSpaceId, state.TagSetSpaceId)
+		targetSpaceId := util.Ternary(data.TagSetSpaceId.ValueString() == "", state.TagSetSpaceId, data.TagSetSpaceId)
 		sourceTagSetSpaceID, destinationTagSetSpaceID := state.TagSetSpaceId.ValueString(), targetSpaceId.ValueString()
 
 		sourceTagSet, err := tagsets.GetByID(t.Client, sourceTagSetSpaceID, sourceTagSetID)
 		if err != nil {
 			// if spaceID has changed, tag has been deleted, recreate required
 			if !targetSpaceId.Equal(state.TagSetSpaceId) {
-				tagCreate(ctx, data, resp.Diagnostics, t.Client)
+				tagCreate(ctx, data, &resp.Diagnostics, t.Client)
 				if !resp.Diagnostics.HasError() {
 					resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 				}
@@ -293,24 +296,24 @@ func (r *tagTypeResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 }
 
-func tagCreate(ctx context.Context, data *schemas.TagResourceModel, diag diag.Diagnostics, client *client.Client) diag.Diagnostics {
+func tagCreate(ctx context.Context, data *schemas.TagResourceModel, diags *diag.Diagnostics, client *client.Client) {
 	tflog.Info(ctx, "creating tag")
 
 	tagSetID := data.TagSetId.ValueString()
 	tagSetSpaceID := data.TagSetSpaceId.ValueString()
 
 	tagSet, err := tagsets.GetByID(client, tagSetSpaceID, tagSetID)
-
 	if err != nil {
-		processUnknownTagSetError(ctx, data, err, &diag)
-		return diag
+		processUnknownTagSetError(ctx, data, err, diags)
+		return
 	}
 
 	name := data.Name.ValueString()
 
 	for _, tag := range tagSet.Tags {
 		if tag.Name == name {
-			diag.AddError(`the tag name '%s' is already in use by another tag in this tag set; tag names must be unique`, name)
+			diags.AddError("Tag name already exists", fmt.Sprintf("the tag name '%s' is already in use by another tag in this tag set; tag names must be unique", name))
+			return
 		}
 	}
 
@@ -322,11 +325,11 @@ func tagCreate(ctx context.Context, data *schemas.TagResourceModel, diag diag.Di
 
 	updatedTagSet, err := tagsets.Update(client, tagSet)
 	if err != nil {
-		diag.AddError(`unable to update tag set`, err.Error())
-		return diag
+		diags.AddError(`unable to update tag set`, err.Error())
+		return
 	}
 
-	return findByIdOrNameAndSetTag(ctx, data, tag, updatedTagSet)
+	diags.Append(findByIdOrNameAndSetTag(ctx, data, tag, updatedTagSet)...)
 }
 
 func isTagUsedByTenants(ctx context.Context, octopus *client.Client, spaceID string, tag *tagsets.Tag) (bool, error) {

--- a/octopusdeploy_framework/resource_tag.go
+++ b/octopusdeploy_framework/resource_tag.go
@@ -69,7 +69,9 @@ func (r *tagTypeResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	tagSet, err := tagsets.GetByID(r.Config.Client, tagSetSpaceID, tagSetID)
 	if err != nil {
-		processUnknownTagSetError(ctx, data, err, resp.Diagnostics)
+		processUnknownTagSetError(ctx, data, err, &resp.Diagnostics)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
 	}
 
 	tag := schemas.MapFromStateToTag(data)
@@ -200,7 +202,7 @@ func (t *tagTypeResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	tagSet, err := tagsets.GetByID(t.Client, tagSetSpaceID, tagSetID)
 	if err != nil {
-		processUnknownTagSetError(ctx, data, err, resp.Diagnostics)
+		processUnknownTagSetError(ctx, data, err, &resp.Diagnostics)
 		return
 	}
 
@@ -255,7 +257,7 @@ func (r *tagTypeResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	tagSet, err := tagsets.GetByID(r.Config.Client, tagSetSpaceID, tagSetID)
 	if err != nil {
-		processUnknownTagSetError(ctx, data, err, resp.Diagnostics)
+		processUnknownTagSetError(ctx, data, err, &resp.Diagnostics)
 		return
 	}
 
@@ -300,7 +302,7 @@ func tagCreate(ctx context.Context, data *schemas.TagResourceModel, diag diag.Di
 	tagSet, err := tagsets.GetByID(client, tagSetSpaceID, tagSetID)
 
 	if err != nil {
-		processUnknownTagSetError(ctx, data, err, diag)
+		processUnknownTagSetError(ctx, data, err, &diag)
 		return diag
 	}
 
@@ -321,6 +323,7 @@ func tagCreate(ctx context.Context, data *schemas.TagResourceModel, diag diag.Di
 	updatedTagSet, err := tagsets.Update(client, tagSet)
 	if err != nil {
 		diag.AddError(`unable to update tag set`, err.Error())
+		return diag
 	}
 
 	return findByIdOrNameAndSetTag(ctx, data, tag, updatedTagSet)
@@ -360,7 +363,7 @@ func findByIdOrNameAndSetTag(ctx context.Context, data *schemas.TagResourceModel
 	return nil
 }
 
-func processUnknownTagSetError(ctx context.Context, data *schemas.TagResourceModel, err error, diag diag.Diagnostics) {
+func processUnknownTagSetError(ctx context.Context, data *schemas.TagResourceModel, err error, diags *diag.Diagnostics) {
 	if err == nil {
 		return
 	}
@@ -373,7 +376,7 @@ func processUnknownTagSetError(ctx context.Context, data *schemas.TagResourceMod
 		}
 	}
 
-	diag.AddError("Processing unknown tag set failed", err.Error())
+	diags.AddError("Processing unknown tag set failed", err.Error())
 }
 
 func (t *tagTypeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/octopusdeploy_framework/resource_tenant.go
+++ b/octopusdeploy_framework/resource_tenant.go
@@ -105,6 +105,10 @@ func (r *tenantTypeResource) Update(ctx context.Context, req resource.UpdateRequ
 	tflog.Debug(ctx, fmt.Sprintf("updating tenant '%s'", data.ID.ValueString()))
 
 	tenantFromApi, err := tenants.GetByID(r.Config.Client, data.SpaceID.ValueString(), data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("unable to load tenant", err.Error())
+		return
+	}
 
 	tenant, err := mapStateToTenant(ctx, data)
 	tenant.ID = state.ID.ValueString()

--- a/octopusdeploy_framework/resource_tenant_project.go
+++ b/octopusdeploy_framework/resource_tenant_project.go
@@ -164,15 +164,12 @@ func (t *tenantProjectResource) Delete(ctx context.Context, req resource.DeleteR
 	tenant, err := tenants.GetByID(t.Client, spaceId, data.TenantID.ValueString())
 	if err != nil {
 		var apiError *core.APIError
-		if errors.As(err, &apiError) {
-			if apiError.StatusCode == http.StatusNotFound {
-				tflog.Info(ctx, fmt.Sprintf("tenant (%s) no longer exists", data.TenantID.ValueString()))
-				return
-			}
-		} else {
-			resp.Diagnostics.AddError("cannot load tenant", err.Error())
+		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
+			tflog.Info(ctx, fmt.Sprintf("tenant (%s) no longer exists", data.TenantID.ValueString()))
 			return
 		}
+		resp.Diagnostics.AddError("cannot load tenant", err.Error())
+		return
 	}
 
 	delete(tenant.ProjectEnvironments, data.ProjectID.ValueString())

--- a/octopusdeploy_framework/resource_user.go
+++ b/octopusdeploy_framework/resource_user.go
@@ -64,6 +64,10 @@ func (r *userTypeResource) Create(ctx context.Context, req resource.CreateReques
 	if !data.IsActive.ValueBool() {
 		user.IsActive = data.IsActive.ValueBool()
 		user, err = users.Update(r.Config.Client, user)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to deactivate created user", err.Error())
+			return
+		}
 	}
 
 	updateUser(&data, user)

--- a/octopusdeploy_framework/schemas/library_variable_set.go
+++ b/octopusdeploy_framework/schemas/library_variable_set.go
@@ -135,8 +135,12 @@ func FlattenTemplates(actionTemplateParameters []actiontemplates.ActionTemplateP
 	actionTemplateList := make([]attr.Value, 0, len(actionTemplateParameters))
 
 	for _, actionTemplateParams := range actionTemplateParameters {
+		defaultValue := ""
+		if actionTemplateParams.DefaultValue != nil {
+			defaultValue = actionTemplateParams.DefaultValue.Value
+		}
 		attrs := map[string]attr.Value{
-			"default_value":    types.StringValue(actionTemplateParams.DefaultValue.Value),
+			"default_value":    types.StringValue(defaultValue),
 			"display_settings": flattenDisplaySettingsMap(actionTemplateParams.DisplaySettings),
 			"help_text":        util.Ternary(actionTemplateParams.HelpText != "", types.StringValue(actionTemplateParams.HelpText), types.StringValue("")),
 			"id":               types.StringValue(actionTemplateParams.GetID()),


### PR DESCRIPTION
Closes #275

Several CRUD paths dereferenced a pointer before checking the error that came back with it, or recorded a diagnostic and then fell through without returning. The go-octopusdeploy client returns a nil result alongside its error on failure, so these paths panicked the provider on API errors, 404s, and unexpected API responses instead of surfacing a diagnostic. This replaces the crashes with proper error handling.

### Changes

- `data_source_channels`: check the `GetByProjectID` error before filtering `Items`.
- `data_source_machine`: nil-guard `TentacleVersionDetails`, which is nil for non-Tentacle targets.
- `resource_deployment_freeze_project`: replace the unchecked `*core.APIError` assertions in Read, Update and Delete with `errors.As`, and return on a 404 instead of assigning into a nil map.
- `resource_project`: check the `GetByID` error before dereferencing the project.
- `resource_project_expand`: use a `len()` guard so an empty `release_creation_package` block does not index an empty slice.
- `resource_pypi_feed` and `resource_s3_feed`: check the constructor error before assigning `feed.ID`.
- `resource_space`: check the re-read errors in Create; return after the read error in Delete.
- `resource_step_template`: nil-guard `ActionTemplateParameter.DefaultValue`.
- `resource_tag`: return after a tag-set lookup failure in Read and after a failed tag-set update in Create, and pass `Diagnostics` by pointer so the recorded errors are not dropped.
- `resource_tenant`: check the `GetByID` error before it is overwritten.
- `resource_tenant_project`: return on non-404 API errors in Delete.
- `resource_user`: check the `users.Update` error when deactivating a created user.
- `library_variable_set`: nil-guard `DefaultValue` in `FlattenTemplates`.

### Testing

`go build ./...` and `go vet` pass. The remaining vet warnings are pre-existing self-assignments in `resource_team_mappers.go`, which this PR does not touch. These paths only trigger on API error and 404 responses, which the acceptance tests do not exercise against a live server, so each call site was verified by reading it against the go-octopusdeploy v2.114.1 return contracts.

### Follow-up commit: tag error propagation and destination space

While fixing the tag nil dereferences above, two related correctness bugs in the same resource were also addressed:

- `tagCreate` took `diag.Diagnostics` by value and its callers discarded the returned value, so every error it recorded was lost and Create reported success regardless. It now takes `*diag.Diagnostics`, returns after each error, and the callers check `HasError`. The duplicate-name diagnostic also had its summary and detail swapped.
- The tag-move path in Update chose the destination space with an inverted `Ternary`, so moving a tag to a tag set in a different space used the old space. The arguments are swapped so a planned space is honoured.
