### PR TITLE
fix: stop dropping configured fields and swallowing state-write errors

### DIFF
--- a/octopusdeploy/resource_project_scheduled_trigger.go
+++ b/octopusdeploy/resource_project_scheduled_trigger.go
@@ -41,9 +41,8 @@ func resourceProjectScheduledTriggerRead(ctx context.Context, d *schema.Resource
 
 	flattenedScheduledTrigger := flattenProjectScheduledTrigger(scheduledTrigger)
 	for key, value := range flattenedScheduledTrigger {
-		err := d.Set(key, value)
-		if err != nil {
-			return nil
+		if err := d.Set(key, value); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/octopusdeploy/schema_azure_cloud_service.go
+++ b/octopusdeploy/schema_azure_cloud_service.go
@@ -9,6 +9,9 @@ func expandAzureCloudService(flattenedMap map[string]interface{}) *machines.Azur
 	endpoint.CloudServiceName = flattenedMap["cloud_service_name"].(string)
 	endpoint.DefaultWorkerPoolID = flattenedMap["default_worker_pool_id"].(string)
 	endpoint.UseCurrentInstanceCount = flattenedMap["use_current_instance_count"].(bool)
+	endpoint.Slot = flattenedMap["slot"].(string)
+	endpoint.StorageAccountName = flattenedMap["storage_account_name"].(string)
+	endpoint.SwapIfPossible = flattenedMap["swap_if_possible"].(bool)
 
 	return endpoint
 }

--- a/octopusdeploy/schema_azure_oidc_account.go
+++ b/octopusdeploy/schema_azure_oidc_account.go
@@ -68,6 +68,14 @@ func expandAzureOpenIDConnectAccount(d *schema.ResourceData) *accounts.AzureOIDC
 		account.AccountTestSubjectKeys = getSliceFromTerraformTypeList(v)
 	}
 
+	if v, ok := d.GetOk("audience"); ok {
+		account.Audience = v.(string)
+	}
+
+	if v, ok := d.GetOk("azure_environment"); ok {
+		account.AzureEnvironment = v.(string)
+	}
+
 	return account
 }
 

--- a/octopusdeploy/schema_azure_service_principal_account.go
+++ b/octopusdeploy/schema_azure_service_principal_account.go
@@ -42,6 +42,10 @@ func expandAzureServicePrincipalAccount(d *schema.ResourceData) *accounts.AzureS
 		account.ResourceManagerEndpoint = v.(string)
 	}
 
+	if v, ok := d.GetOk("azure_environment"); ok {
+		account.AzureEnvironment = v.(string)
+	}
+
 	if v, ok := d.GetOk("space_id"); ok {
 		account.SetSpaceID(v.(string))
 	}

--- a/octopusdeploy/schema_project_scheduled_trigger.go
+++ b/octopusdeploy/schema_project_scheduled_trigger.go
@@ -13,7 +13,9 @@ import (
 
 func flattenProjectScheduledTrigger(projectScheduledTrigger *triggers.ProjectTrigger) map[string]interface{} {
 	flattenedProjectScheduledTrigger := map[string]interface{}{}
-	flattenedProjectScheduledTrigger["id"] = projectScheduledTrigger.GetID()
+	// "id" is intentionally omitted: it is not part of getProjectScheduledTriggerSchema,
+	// and the resource ID is managed separately via d.SetId. Emitting it here made the
+	// read path fail with "Invalid address to set" once d.Set errors are propagated.
 	flattenedProjectScheduledTrigger["name"] = projectScheduledTrigger.Name
 	flattenedProjectScheduledTrigger["description"] = projectScheduledTrigger.Description
 	flattenedProjectScheduledTrigger["project_id"] = projectScheduledTrigger.ProjectID

--- a/octopusdeploy_framework/datasource_project_groups.go
+++ b/octopusdeploy_framework/datasource_project_groups.go
@@ -60,10 +60,7 @@ func (p *projectGroupsDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	var ids = make([]string, 0, len(data.IDs.Elements()))
-	for _, id := range data.IDs.Elements() {
-		ids = append(ids, id.String())
-	}
+	ids := util.GetIds(data.IDs)
 
 	skip := 0
 	if !data.Skip.IsNull() {


### PR DESCRIPTION
Closes #277

Several read and expand paths silently lost data. Expand functions omitted fields the schema exposes, so configured values were never sent to the API. A read loop returned success after a `d.Set` failure, so Terraform recorded a partially-written state as a clean refresh. In each case the practitioner saw no error and ended up with state that did not match the configuration.

### Changes

- `schema_azure_cloud_service`: `expandAzureCloudService` now copies `slot`, `storage_account_name` and `swap_if_possible`, which the schema declares and the flatten path reads back.
- `schema_azure_oidc_account`: `expandAzureOpenIDConnectAccount` now sends `audience` and `azure_environment`.
- `schema_azure_service_principal_account`: `expandAzureServicePrincipalAccount` now sends `azure_environment`.
- `resource_project_scheduled_trigger`: Read returns `diag.FromErr` on a `d.Set` failure instead of `nil`, so a partial write is no longer reported as success.
- `schema_project_scheduled_trigger`: `flattenProjectScheduledTrigger` no longer emits an `id` key that is absent from the resource schema. The ID is managed via `d.SetId`. Without this, propagating the `d.Set` error above would abort every refresh with "Invalid address to set".
- `datasource_project_groups`: the `ids` filter is built with `util.GetIds` (which calls `ValueString`) instead of `attr.Value.String()`, which returned Go-quoted values that never matched.

### Testing

`go build ./...` and `go vet` pass. The remaining vet warnings are pre-existing self-assignments in `resource_team_mappers.go`, which this PR does not touch. These paths depend on a live Octopus server and specific endpoint types, which the acceptance tests do not exercise, so each change was verified by reading the expand function against the schema and the matching flatten or set path in the same file.
