### PR TITLE
fix: stop leaking CI secrets to logs, mutable action tags, and unreviewed code

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -38,23 +38,33 @@ jobs:
       # The first step is to generate a JWT from the GitHub App private key.
       # https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#example-using-python-to-generate-a-jwt
       - name: Generate a JWT
-        run: ./github-app-jwt.py >> "$GITHUB_ENV"
+        # Capture the script output so the JWT can be registered as a secret with
+        # ::add-mask:: before it is written to $GITHUB_ENV. The script's stdout is
+        # not redirected straight into $GITHUB_ENV, because a mask command written
+        # there would be treated as a malformed environment line.
+        run: |
+          jwt_line="$(./github-app-jwt.py)"
+          echo "::add-mask::${jwt_line#jwt=}"
+          echo "$jwt_line" >> "$GITHUB_ENV"
         env:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
       # The next step is to generate an access token from the JWT.
       # https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app#generating-an-installation-access-token
       - name: Generate an access token
+        # JWT is passed through the environment rather than interpolated into the
+        # run script, so the token is not rendered into the command echoed in logs.
         run: |
           curl \
           --silent \
           --request POST \
           --url "https://api.github.com/app/installations/${GH_APP_INSTALLATION_ID}/access_tokens" \
           --header "Accept: application/vnd.github+json" \
-          --header "Authorization: Bearer ${{ env.jwt }}" \
+          --header "Authorization: Bearer $JWT" \
           --header "X-GitHub-Api-Version: 2022-11-28" | jq -r '"GIT_CREDENTIAL=" + .token' > "$GITHUB_ENV"
         env:
           GH_APP_INSTALLATION_ID: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          JWT: ${{ env.jwt }}
       - name: Download JUnit Summary from Previous Workflow
         id: download-artifact
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,20 +7,20 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.25'
-      - uses: crazy-max/ghaction-import-gpg@v6
+      - uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           args: release --clean
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,18 @@ Once your pull request is merged, our build and test workflow will execute once 
 
 Our PR checks don't run automatically on pull requests from forks. You can approve the run from the PR, but it won't help: the checks require access to values that GitHub Actions won't expose to a workflow running in the contributor's profile rather than the Octopus organization, so they will always fail and the change can't be validated where it is. To work around this, redirect the change through a branch in this repository so the checks can run before it reaches `main`.
 
-> [!IMPORTANT]
-> Don't merge a fork PR directly into `main`. Follow the steps below to redirect it through a branch in this repository first.
+> [!WARNING]
+> Redirecting a fork PR into a branch in this repository causes the contributor's code to run in workflows that hold repository secrets, including the GitHub App private key (`GH_APP_PRIVATE_KEY`), the App ID, and the Octopus licence. `build.yml` and `docs.yml` run on `push` to any branch, and the test workflow runs on `pull_request`, so any code merged into an in-repo branch executes with those secrets and a `contents: write` token. Treat this as running untrusted code with full access to those secrets.
+>
+> Before you redirect anything, read the entire diff line by line. Pay particular attention to workflow files under `.github/`, `Makefile`, `go.mod`/`go.sum`, `github-app-jwt.py`, and anything that runs during build or test. If the change modifies how CI runs, or you are not certain it is safe, do not redirect it.
 
-1. Create a new branch in this repository with a name similar to the contributor's branch (for example, if their branch is `fix-typo-in-docs`, create `fix-typo-in-docs`).
-2. Edit the contributor's PR and change its base branch from `main` to the new branch you just created.
-3. Squash and merge the PR into the new branch.
-4. Continue as you would for any other change: open a PR from the intermediate branch to `main` and merge it.
+> [!IMPORTANT]
+> Don't merge a fork PR directly into `main`, and never redirect one you have not fully reviewed. Follow the steps below only after completing the review described above.
+
+1. Review the contributor's diff in full and confirm it is safe to execute with repository secrets (see the warning above).
+2. Create a new branch in this repository with a name similar to the contributor's branch (for example, if their branch is `fix-typo-in-docs`, create `fix-typo-in-docs`).
+3. Edit the contributor's PR and change its base branch from `main` to the new branch you just created.
+4. Squash and merge the PR into the new branch.
+5. Continue as you would for any other change: open a PR from the intermediate branch to `main` and merge it.
+
+A more robust alternative to reviewing by eye on every contribution is to move the secret-bearing jobs behind a [protected GitHub Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#required-reviewers) that requires manual approval before the job with secrets runs. That keeps the secrets from being exposed to a run until a maintainer has explicitly approved it.


### PR DESCRIPTION
Closes #279

Three CI and secret-handling weaknesses, addressed together.

### GitHub App JWT no longer printed to logs

The signed App JWT was written to `$GITHUB_ENV` unmasked and then interpolated as `${{ env.jwt }}` inside a `run:` block, so the resolved token was echoed into the job log of a public repository. The JWT is now registered with `::add-mask::` before it reaches `$GITHUB_ENV`, and the access-token step reads it from an environment variable rather than interpolating it into the rendered script.

The masking is done in the workflow rather than in `github-app-jwt.py`, because the script's stdout is redirected straight into `$GITHUB_ENV`. A `::add-mask::` line printed from the script would land in `$GITHUB_ENV` as a malformed environment entry instead of being processed as a workflow command. The step now captures the script output, masks the token, and then writes it.

### Actions pinned to commit SHAs

`release.yml` pinned the actions that receive the code-signing key to `@v6`, a mutable tag. All actions are now pinned to full commit SHAs with the version in a trailing comment, so a repointed tag cannot receive `GPG_PRIVATE_KEY` or `GITHUB_TOKEN`. The SHAs were resolved from the tags the workflow already used, so the versions are unchanged; only the pinning is added. Bumping the pinned versions can be left to Dependabot.

### Contribution procedure requires review before secrets run

`CONTRIBUTING.md` described redirecting a fork PR into an in-repo branch so the checks can run, without requiring the diff to be reviewed first. The procedure now requires a full line-by-line review before any redirect, names the secrets that become available (`GH_APP_PRIVATE_KEY`, the App ID, the Octopus licence, a `contents: write` token), and points to a protected GitHub Environment with required reviewers as a more robust alternative.

### Testing

These are workflow and documentation changes with no Go impact. The YAML edits preserve the existing step structure; the JWT step was checked to confirm the masked token still reaches `$GITHUB_ENV` as `jwt=...` and that `set -e` still fails the step if the script errors. The action SHAs were resolved from the GitHub API for the tags currently in use.
