### PR TITLE
fix: harden feed resources against nil derefs and swallowed errors

### DIFF
--- a/octopusdeploy_framework/resource_artifactory_generic_feed.go
+++ b/octopusdeploy_framework/resource_artifactory_generic_feed.go
@@ -48,6 +48,7 @@ func (r *artifactoryGenericFeedTypeResource) Create(ctx context.Context, req res
 
 	artifactoryGenericFeed, err := createArtifactoryGenericResourceFromData(data)
 	if err != nil {
+		resp.Diagnostics.AddError("unable to create artifactoryGeneric feed", err.Error())
 		return
 	}
 
@@ -60,7 +61,12 @@ func (r *artifactoryGenericFeedTypeResource) Create(ctx context.Context, req res
 		return
 	}
 
-	updateDataFromArtifactoryGenericFeed(data, data.SpaceID.ValueString(), createdFeed.(*feeds.ArtifactoryGenericFeed))
+	artifactoryGenericFeed, ok := createdFeed.(*feeds.ArtifactoryGenericFeed)
+	if !ok {
+		resp.Diagnostics.AddError("unexpected feed type", fmt.Sprintf("%s is not an Artifactory Generic feed", createdFeed.GetID()))
+		return
+	}
+	updateDataFromArtifactoryGenericFeed(data, data.SpaceID.ValueString(), artifactoryGenericFeed)
 
 	tflog.Info(ctx, fmt.Sprintf("ArtifactoryGeneric feed created (%s)", data.ID))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -84,7 +90,11 @@ func (r *artifactoryGenericFeedTypeResource) Read(ctx context.Context, req resou
 		return
 	}
 
-	artifactoryGenericFeed := feed.(*feeds.ArtifactoryGenericFeed)
+	artifactoryGenericFeed, ok := feed.(*feeds.ArtifactoryGenericFeed)
+	if !ok {
+		resp.Diagnostics.AddError("unexpected feed type", fmt.Sprintf("%s is not an Artifactory Generic feed", data.ID.ValueString()))
+		return
+	}
 	updateDataFromArtifactoryGenericFeed(data, data.SpaceID.ValueString(), artifactoryGenericFeed)
 
 	tflog.Info(ctx, fmt.Sprintf("ArtifactoryGeneric feed read (%s)", artifactoryGenericFeed.GetID()))
@@ -103,11 +113,11 @@ func (r *artifactoryGenericFeedTypeResource) Update(ctx context.Context, req res
 	tflog.Debug(ctx, fmt.Sprintf("updating artifactoryGeneric feed '%s'", data.ID.ValueString()))
 
 	feed, err := createArtifactoryGenericResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load artifactoryGeneric feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating ArtifactoryGeneric feed (%s)", data.ID))
 
@@ -118,7 +128,12 @@ func (r *artifactoryGenericFeedTypeResource) Update(ctx context.Context, req res
 		return
 	}
 
-	updateDataFromArtifactoryGenericFeed(data, state.SpaceID.ValueString(), updatedFeed.(*feeds.ArtifactoryGenericFeed))
+	artifactoryGenericFeed, ok := updatedFeed.(*feeds.ArtifactoryGenericFeed)
+	if !ok {
+		resp.Diagnostics.AddError("unexpected feed type", fmt.Sprintf("%s is not an Artifactory Generic feed", updatedFeed.GetID()))
+		return
+	}
+	updateDataFromArtifactoryGenericFeed(data, state.SpaceID.ValueString(), artifactoryGenericFeed)
 
 	tflog.Info(ctx, fmt.Sprintf("ArtifactoryGeneric feed updated (%s)", data.ID))
 
@@ -167,13 +182,9 @@ func updateDataFromArtifactoryGenericFeed(data *schemas.ArtifactoryGenericFeedTy
 	data.FeedUri = types.StringValue(feed.FeedURI)
 	data.Name = types.StringValue(feed.Name)
 	data.SpaceID = types.StringValue(spaceId)
-	if feed.Username != "" {
-		data.Username = types.StringValue(feed.Username)
-	}
+	data.Username = util.StringOrNull(feed.Username)
 	data.Repository = types.StringValue(feed.Repository)
-	if feed.LayoutRegex != "" {
-		data.LayoutRegex = types.StringValue(feed.LayoutRegex)
-	}
+	data.LayoutRegex = util.StringOrNull(feed.LayoutRegex)
 
 	packageAcquisitionLocationOptionsList := make([]attr.Value, len(feed.PackageAcquisitionLocationOptions))
 	for i, option := range feed.PackageAcquisitionLocationOptions {

--- a/octopusdeploy_framework/resource_aws_elastic_container_registry.go
+++ b/octopusdeploy_framework/resource_aws_elastic_container_registry.go
@@ -49,6 +49,7 @@ func (r *awsElasticContainerRegistryFeedTypeResource) Create(ctx context.Context
 
 	awsElasticContainerRegistryFeed, err := createAwsElasticContainerRegistryResourceFromData(data, ctx)
 	if err != nil {
+		resp.Diagnostics.AddError("unable to create aws elastic container registry", err.Error())
 		return
 	}
 
@@ -87,7 +88,11 @@ func (r *awsElasticContainerRegistryFeedTypeResource) Read(ctx context.Context, 
 		return
 	}
 
-	awsElasticContainerRegistryFeed := feed.(*feeds.AwsElasticContainerRegistry)
+	awsElasticContainerRegistryFeed, ok := feed.(*feeds.AwsElasticContainerRegistry)
+	if !ok {
+		resp.Diagnostics.AddError("unexpected feed type", fmt.Sprintf("%s is not an AWS Elastic Container Registry feed", data.ID.ValueString()))
+		return
+	}
 	updateDataFromAwsElasticContainerRegistryFeed(data, data.SpaceID.ValueString(), awsElasticContainerRegistryFeed)
 
 	util.Read(ctx, resourceDescription, data.GetID())
@@ -105,11 +110,11 @@ func (r *awsElasticContainerRegistryFeedTypeResource) Update(ctx context.Context
 	util.Update(ctx, resourceDescription, data)
 
 	feed, err := createAwsElasticContainerRegistryResourceFromData(data, ctx)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load aws elastic container registry feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	client := r.Config.Client
 	updatedFeed, err := feeds.Update(client, feed)
@@ -201,6 +206,8 @@ func updateDataFromAwsElasticContainerRegistryFeed(data *schemas.AwsElasticConta
 			RoleArn:         types.StringValue(feed.OidcAuthentication.RoleArn),
 			SubjectKey:      util.FlattenStringList(feed.OidcAuthentication.SubjectKeys),
 		}
+	} else {
+		data.OidcAuthentication = nil
 	}
 }
 

--- a/octopusdeploy_framework/resource_docker_container_registry.go
+++ b/octopusdeploy_framework/resource_docker_container_registry.go
@@ -47,6 +47,7 @@ func (r *dockerContainerRegistryFeedTypeResource) Create(ctx context.Context, re
 
 	dockerContainerRegistryFeed, err := createDockerContainerRegistryFeedResourceFromData(data)
 	if err != nil {
+		resp.Diagnostics.AddError("unable to create docker container registry feed", err.Error())
 		return
 	}
 
@@ -101,11 +102,11 @@ func (r *dockerContainerRegistryFeedTypeResource) Update(ctx context.Context, re
 	tflog.Debug(ctx, fmt.Sprintf("updating docker container registry feed '%s'", data.ID.ValueString()))
 
 	feed, err := createDockerContainerRegistryFeedResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load docker container registry feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating Docker Container Registry feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_gcs_storage_feed.go
+++ b/octopusdeploy_framework/resource_gcs_storage_feed.go
@@ -99,11 +99,11 @@ func (r *gcsStorageFeedTypeResource) Update(ctx context.Context, req resource.Up
 	tflog.Debug(ctx, fmt.Sprintf("updating GCS feed '%s'", data.ID.ValueString()))
 
 	feed, err := createGcsStorageResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load GCS feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating GCS feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_github_repository_feed.go
+++ b/octopusdeploy_framework/resource_github_repository_feed.go
@@ -103,11 +103,11 @@ func (r *githubRepositoryFeedTypeResource) Update(ctx context.Context, req resou
 	tflog.Debug(ctx, fmt.Sprintf("updating github repository feed '%s'", data.ID.ValueString()))
 
 	feed, err := createGitHubRepositoryResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load github repository feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating GitHub Repository feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_helm_feed.go
+++ b/octopusdeploy_framework/resource_helm_feed.go
@@ -103,11 +103,11 @@ func (r *helmFeedTypeResource) Update(ctx context.Context, req resource.UpdateRe
 	tflog.Debug(ctx, fmt.Sprintf("updating helm feed '%s'", data.ID.ValueString()))
 
 	feed, err := createHelmResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load helm feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating Helm feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_maven_feed.go
+++ b/octopusdeploy_framework/resource_maven_feed.go
@@ -47,6 +47,7 @@ func (r *mavenFeedTypeResource) Create(ctx context.Context, req resource.CreateR
 
 	mavenFeed, err := createMavenResourceFromData(data)
 	if err != nil {
+		resp.Diagnostics.AddError("unable to create maven feed", err.Error())
 		return
 	}
 
@@ -101,11 +102,11 @@ func (r *mavenFeedTypeResource) Update(ctx context.Context, req resource.UpdateR
 	tflog.Debug(ctx, fmt.Sprintf("updating maven feed '%s'", data.ID.ValueString()))
 
 	feed, err := createMavenResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load maven feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating Maven feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_npm_feed.go
+++ b/octopusdeploy_framework/resource_npm_feed.go
@@ -47,6 +47,7 @@ func (r *npmFeedTypeResource) Create(ctx context.Context, req resource.CreateReq
 
 	npmFeed, err := createNpmResourceFromData(data)
 	if err != nil {
+		resp.Diagnostics.AddError("unable to create npm feed", err.Error())
 		return
 	}
 
@@ -101,11 +102,11 @@ func (r *npmFeedTypeResource) Update(ctx context.Context, req resource.UpdateReq
 	tflog.Debug(ctx, fmt.Sprintf("updating npm feed '%s'", data.ID.ValueString()))
 
 	feed, err := createNpmResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load npm feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating NPM feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_nuget_feed.go
+++ b/octopusdeploy_framework/resource_nuget_feed.go
@@ -47,6 +47,7 @@ func (r *nugetFeedTypeResource) Create(ctx context.Context, req resource.CreateR
 
 	nugetFeed, err := createNugetResourceFromData(data)
 	if err != nil {
+		resp.Diagnostics.AddError("unable to create nuget feed", err.Error())
 		return
 	}
 
@@ -103,11 +104,11 @@ func (r *nugetFeedTypeResource) Update(ctx context.Context, req resource.UpdateR
 	tflog.Debug(ctx, fmt.Sprintf("updating nuget feed '%s'", data.ID.ValueString()))
 
 	feed, err := createNugetResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load nuget feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating Nuget feed (%s)", data.ID))
 

--- a/octopusdeploy_framework/resource_oci_registry_feed.go
+++ b/octopusdeploy_framework/resource_oci_registry_feed.go
@@ -46,6 +46,7 @@ func (r *ociRegistryFeedTypeResource) Create(ctx context.Context, req resource.C
 
 	feed, err := createOCIRegistryResourceFromData(data)
 	if err != nil {
+		resp.Diagnostics.AddError("unable to create OCI Registry feed", err.Error())
 		return
 	}
 
@@ -100,11 +101,11 @@ func (r *ociRegistryFeedTypeResource) Update(ctx context.Context, req resource.U
 	tflog.Debug(ctx, fmt.Sprintf("updating OCI Registry feed '%s'", data.ID.ValueString()))
 
 	feed, err := createOCIRegistryResourceFromData(data)
-	feed.ID = state.ID.ValueString()
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load OCI Registry feed", err.Error())
 		return
 	}
+	feed.ID = state.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating OCI Registry feed (%s)", data.ID))
 


### PR DESCRIPTION
Closes #282

The feed resources shared three defects that a review found across most feed types. This hardens them so a bad configuration or a mismatched import produces a diagnostic instead of a panic or a silent failure.

### Shapes fixed

- **Update dereferenced the feed before checking the constructor error.** `create<Feed>ResourceFromData` returns `(nil, err)` when the SDK constructor rejects the input (for example an empty name that still passes the schema validator). `feed.ID = state.ID.ValueString()` was assigned before the error was checked, so the nil pointer was dereferenced and the error branch was unreachable. The error check now runs before the assignment.
- **Create swallowed the expand error.** Several Create paths discarded the error from building the feed and returned with no diagnostic and no state, so Terraform reported a generic "missing resource state after create" internal error with no cause. Create now reports the error, matching Update.
- **Unchecked type assertion on read and import.** `ImportState` passes any ID through, and `feeds.GetByID` returns the interface for whatever feed type that ID names, so a single-value assertion panicked for a wrong ID. These are now comma-ok with a diagnostic.

Two flatten paths were also corrected so that a value removed server-side (Artifactory username and layout regex, ECR OIDC authentication) is cleared on refresh instead of keeping the stale state value.

### Testing

`go build ./...` and `go vet` pass. The remaining vet warnings are pre-existing self-assignments in `resource_team_mappers.go`, untouched here. These paths trigger on constructor rejection, wrong-type import, and server-side removal, which the acceptance tests do not exercise against a live server, so each site was verified by reading it against the constructor and flatten helpers in the same file.
