### PR TITLE
fix: guard account and worker-pool type assertions on read and import

### DIFF
--- a/octopusdeploy/resource_aws_openid_connect_account.go
+++ b/octopusdeploy/resource_aws_openid_connect_account.go
@@ -67,7 +67,10 @@ func resourceAmazonWebServicesOpenIDConnectAccountRead(ctx context.Context, d *s
 		return errors.ProcessApiError(ctx, d, err, "AWS OIDC account")
 	}
 
-	awsOIDCAccount := accountResource.(*accounts.AwsOIDCAccount)
+	awsOIDCAccount, ok := accountResource.(*accounts.AwsOIDCAccount)
+	if !ok {
+		return diag.Errorf("account %s is not an AWS OIDC account", d.Id())
+	}
 	if err := setAmazonWebServicesOpenIDConnectAccount(ctx, d, awsOIDCAccount); err != nil {
 		return diag.FromErr(err)
 	}

--- a/octopusdeploy/resource_azure_oidc_account.go
+++ b/octopusdeploy/resource_azure_oidc_account.go
@@ -67,7 +67,10 @@ func resourceAzureOpenIDConnectAccountRead(ctx context.Context, d *schema.Resour
 		return errors.ProcessApiError(ctx, d, err, "Azure OpenID Connect account")
 	}
 
-	azureOIDCAccount := accountResource.(*accounts.AzureOIDCAccount)
+	azureOIDCAccount, ok := accountResource.(*accounts.AzureOIDCAccount)
+	if !ok {
+		return diag.Errorf("account %s is not an Azure OIDC account", d.Id())
+	}
 	if err := setAzureOpenIDConnectAccount(ctx, d, azureOIDCAccount); err != nil {
 		return diag.FromErr(err)
 	}

--- a/octopusdeploy/resource_azure_service_principal_account.go
+++ b/octopusdeploy/resource_azure_service_principal_account.go
@@ -67,7 +67,10 @@ func resourceAzureServicePrincipalAccountRead(ctx context.Context, d *schema.Res
 		return errors.ProcessApiError(ctx, d, err, "Azure service principal account")
 	}
 
-	azureServicePrincipalAccount := accountResource.(*accounts.AzureServicePrincipalAccount)
+	azureServicePrincipalAccount, ok := accountResource.(*accounts.AzureServicePrincipalAccount)
+	if !ok {
+		return diag.Errorf("account %s is not an Azure service principal account", d.Id())
+	}
 	if err := setAzureServicePrincipalAccount(ctx, d, azureServicePrincipalAccount); err != nil {
 		return diag.FromErr(err)
 	}

--- a/octopusdeploy/resource_azure_subscription_account.go
+++ b/octopusdeploy/resource_azure_subscription_account.go
@@ -67,7 +67,10 @@ func resourceAzureSubscriptionAccountRead(ctx context.Context, d *schema.Resourc
 		return errors.ProcessApiError(ctx, d, err, "Azure subscription account")
 	}
 
-	azureSubscriptionAccount := accountResource.(*accounts.AzureSubscriptionAccount)
+	azureSubscriptionAccount, ok := accountResource.(*accounts.AzureSubscriptionAccount)
+	if !ok {
+		return diag.Errorf("account %s is not an Azure subscription account", d.Id())
+	}
 	if err := setAzureSubscriptionAccount(ctx, d, azureSubscriptionAccount); err != nil {
 		return diag.FromErr(err)
 	}

--- a/octopusdeploy/resource_dynamic_worker_pool.go
+++ b/octopusdeploy/resource_dynamic_worker_pool.go
@@ -70,7 +70,10 @@ func resourceDynamicWorkerPoolRead(ctx context.Context, d *schema.ResourceData, 
 		return errors.ProcessApiError(ctx, d, err, "dynamic worker pool")
 	}
 
-	dynamicWorkerPool := workerPoolResource.(*workerpools.DynamicWorkerPool)
+	dynamicWorkerPool, ok := workerPoolResource.(*workerpools.DynamicWorkerPool)
+	if !ok {
+		return diag.Errorf("worker pool %s is not a dynamic worker pool", d.Id())
+	}
 	if err := setDynamicWorkerPool(ctx, d, dynamicWorkerPool); err != nil {
 		return diag.FromErr(err)
 	}

--- a/octopusdeploy/resource_gcp_account.go
+++ b/octopusdeploy/resource_gcp_account.go
@@ -67,7 +67,10 @@ func resourceGoogleCloudPlatformAccountRead(ctx context.Context, d *schema.Resou
 		return errors.ProcessApiError(ctx, d, err, "GCP account")
 	}
 
-	amazonWebServicesAccount := accountResource.(*accounts.GoogleCloudPlatformAccount)
+	amazonWebServicesAccount, ok := accountResource.(*accounts.GoogleCloudPlatformAccount)
+	if !ok {
+		return diag.Errorf("account %s is not a GCP account", d.Id())
+	}
 	if err := setGoogleCloudPlatformAccount(ctx, d, amazonWebServicesAccount); err != nil {
 		return diag.FromErr(err)
 	}

--- a/octopusdeploy/resource_sshkey_account.go
+++ b/octopusdeploy/resource_sshkey_account.go
@@ -67,7 +67,10 @@ func resourceSSHKeyAccountRead(ctx context.Context, d *schema.ResourceData, m in
 		return errors.ProcessApiError(ctx, d, err, "SSH key account")
 	}
 
-	sshKeyAccount := accountResource.(*accounts.SSHKeyAccount)
+	sshKeyAccount, ok := accountResource.(*accounts.SSHKeyAccount)
+	if !ok {
+		return diag.Errorf("account %s is not an SSH key account", d.Id())
+	}
 	if err := setSSHKeyAccount(ctx, d, sshKeyAccount); err != nil {
 		return diag.FromErr(err)
 	}

--- a/octopusdeploy/resource_static_worker_pool.go
+++ b/octopusdeploy/resource_static_worker_pool.go
@@ -70,7 +70,10 @@ func resourceStaticWorkerPoolRead(ctx context.Context, d *schema.ResourceData, m
 		return errors.ProcessApiError(ctx, d, err, "static worker pool")
 	}
 
-	staticWorkerPool := workerPoolResource.(*workerpools.StaticWorkerPool)
+	staticWorkerPool, ok := workerPoolResource.(*workerpools.StaticWorkerPool)
+	if !ok {
+		return diag.Errorf("worker pool %s is not a static worker pool", d.Id())
+	}
 	if err := setStaticWorkerPool(ctx, d, staticWorkerPool); err != nil {
 		return diag.FromErr(err)
 	}

--- a/octopusdeploy/resource_team.go
+++ b/octopusdeploy/resource_team.go
@@ -3,6 +3,7 @@ package octopusdeploy
 import (
 	"bytes"
 	"context"
+	goerrors "errors"
 	"fmt"
 	"log"
 	"sort"
@@ -175,8 +176,8 @@ func resourceTeamUpdateUserRoles(ctx context.Context, d *schema.ResourceData, m 
 					if userRole.ID != "" {
 						err := client.ScopedUserRoles.DeleteByID(userRole.ID)
 						if err != nil {
-							apiError := err.(*core.APIError)
-							if apiError.StatusCode != 404 {
+							var apiError *core.APIError
+							if !goerrors.As(err, &apiError) || apiError.StatusCode != 404 {
 								// It's already been deleted, maybe mixing with the independent resource?
 								return fmt.Errorf("error removing user role %s from team %s: %s", userRole.ID, team.ID, err)
 							}

--- a/octopusdeploy/resource_token_account.go
+++ b/octopusdeploy/resource_token_account.go
@@ -66,7 +66,11 @@ func resourceTokenAccountRead(ctx context.Context, d *schema.ResourceData, m int
 		return errors.ProcessApiError(ctx, d, err, "token account")
 	}
 
-	if err := setTokenAccount(ctx, d, accountResource.(*accounts.TokenAccount)); err != nil {
+	tokenAccount, ok := accountResource.(*accounts.TokenAccount)
+	if !ok {
+		return diag.Errorf("account %s is not a token account", d.Id())
+	}
+	if err := setTokenAccount(ctx, d, tokenAccount); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/octopusdeploy_framework/resource_amazon_web_services_account.go
+++ b/octopusdeploy_framework/resource_amazon_web_services_account.go
@@ -2,6 +2,8 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
@@ -77,7 +79,13 @@ func (r *amazonWebServicesAccountResource) Read(ctx context.Context, req resourc
 		return
 	}
 
-	newState := flattenAmazonWebServicesAccount(ctx, account.(*accounts.AmazonWebServicesAccount), state)
+	awsAccount, ok := account.(*accounts.AmazonWebServicesAccount)
+	if !ok {
+		resp.Diagnostics.AddError("unexpected account type", fmt.Sprintf("%s is not an AWS account", state.ID.ValueString()))
+		return
+	}
+
+	newState := flattenAmazonWebServicesAccount(ctx, awsAccount, state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 	return
 }

--- a/octopusdeploy_framework/resource_platform_hub_aws_account.go
+++ b/octopusdeploy_framework/resource_platform_hub_aws_account.go
@@ -2,6 +2,8 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubaccounts"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
@@ -94,7 +96,13 @@ func (a *platformHubAwsAccountResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	setPlatformHubAwsAccount(ctx, &state, account.(*platformhubaccounts.PlatformHubAwsAccount))
+	awsAccount, ok := account.(*platformhubaccounts.PlatformHubAwsAccount)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading Platform Hub AWS account", fmt.Sprintf("account %s is not an AWS account", state.ID.ValueString()))
+		return
+	}
+
+	setPlatformHubAwsAccount(ctx, &state, awsAccount)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 

--- a/octopusdeploy_framework/resource_platform_hub_gcp_account.go
+++ b/octopusdeploy_framework/resource_platform_hub_gcp_account.go
@@ -2,6 +2,8 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubaccounts"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
@@ -94,7 +96,13 @@ func (g *platformHubGcpAccountResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	setPlatformHubGcpAccount(ctx, &state, account.(*platformhubaccounts.PlatformHubGcpAccount))
+	gcpAccount, ok := account.(*platformhubaccounts.PlatformHubGcpAccount)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading Platform Hub GCP account", fmt.Sprintf("account %s is not a GCP account", state.ID.ValueString()))
+		return
+	}
+
+	setPlatformHubGcpAccount(ctx, &state, gcpAccount)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 

--- a/octopusdeploy_framework/resource_username_password_account.go
+++ b/octopusdeploy_framework/resource_username_password_account.go
@@ -73,7 +73,13 @@ func (r *usernamePasswordAccountResource) Read(ctx context.Context, req resource
 		return
 	}
 
-	newState := flattenUsernamePasswordAccount(ctx, account.(*accounts.UsernamePasswordAccount), state)
+	usernamePasswordAccount, ok := account.(*accounts.UsernamePasswordAccount)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected account type", fmt.Sprintf("Expected username password account, got: %T", account))
+		return
+	}
+
+	newState := flattenUsernamePasswordAccount(ctx, usernamePasswordAccount, state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
 


### PR DESCRIPTION
Closes #283

Account and worker-pool resources read the result of `GetByID` (or `DeleteByID` for teams) with an unchecked single-value type assertion. `GetByID` returns the interface whose concrete type follows the server's `AccountType` or `WorkerPoolType`, and every one of these resources uses a plain ID passthrough importer. Importing an ID that belongs to a different account or pool type, or refreshing a resource that was recreated as another type server-side, made the assertion panic and took down the provider instead of producing a diagnostic.

Each site is converted to the comma-ok form and returns a diagnostic naming the mismatch.

### Sites

SDKv2 resources (`return diag.Errorf(...)` on mismatch): AWS OIDC, Azure OIDC, Azure service principal, Azure subscription, GCP, SSH key and token accounts, and the dynamic and static worker pools.

Framework resources (`resp.Diagnostics.AddError(...); return`): the AWS account, the username/password account, and the Platform Hub AWS and GCP accounts.

`resource_team.go` also asserted the error from `DeleteByID` to `*core.APIError` without the comma-ok form, so a transport-level failure (connection reset, DNS or TLS error, context timeout) panicked instead of being reported. That is now an `errors.As` check that preserves the existing 404 handling and error message.

### Testing

`go build ./...` and `go vet` pass. The remaining vet warnings are pre-existing self-assignments in `resource_team_mappers.go`, untouched here. These paths trigger on a mismatched import or a non-API transport error, which the acceptance tests do not exercise, so each site was verified by reading it against the `GetByID` return contract in go-octopusdeploy.
