### PR TITLE
fix: correct nil derefs, import panics, and broken validators

### DIFF
--- a/internal/random.go
+++ b/internal/random.go
@@ -28,7 +28,7 @@ func GenerateRandomCryptoString(length int) string {
 		if j%bufferSize == 0 {
 			randomBytes = generateRandomBytes(bufferSize)
 		}
-		if idx := int(randomBytes[j%length] & letterIdxMask); idx < len(letterBytes) {
+		if idx := int(randomBytes[j%bufferSize] & letterIdxMask); idx < len(letterBytes) {
 			result[i] = letterBytes[idx]
 			i++
 		}

--- a/octopusdeploy/resource_project_deployment_target_trigger.go
+++ b/octopusdeploy/resource_project_deployment_target_trigger.go
@@ -129,8 +129,14 @@ func resourceProjectDeploymentTargetTriggerRead(ctx context.Context, d *schema.R
 
 	logResource("project_trigger", m)
 
-	action := resource.Action.(*actions.AutoDeployAction)
-	filter := resource.Filter.(*filters.DeploymentTargetFilter)
+	action, ok := resource.Action.(*actions.AutoDeployAction)
+	if !ok {
+		return diag.Errorf("trigger %s is not a deployment target trigger", d.Id())
+	}
+	filter, ok := resource.Filter.(*filters.DeploymentTargetFilter)
+	if !ok {
+		return diag.Errorf("trigger %s has an unexpected filter type", d.Id())
+	}
 
 	d.Set("environment_ids", filter.Environments)
 	d.Set("event_groups", filter.EventGroups)

--- a/octopusdeploy/schema_kubernetes_cluster_deployment_target.go
+++ b/octopusdeploy/schema_kubernetes_cluster_deployment_target.go
@@ -101,6 +101,10 @@ func flattenKubernetesClusterDeploymentTarget(deploymentTarget *machines.Deploym
 		flattenedDeploymentTarget["cluster_url"] = endpointResource.ClusterURL.String()
 	}
 
+	if endpointResource.Authentication == nil {
+		return flattenedDeploymentTarget
+	}
+
 	switch endpointResource.Authentication.GetAuthenticationType() {
 	case "KubernetesAws":
 		flattenedDeploymentTarget["aws_account_authentication"] = flattenKubernetesAwsAuthentication(endpointResource.Authentication.(*machines.KubernetesAwsAuthentication))
@@ -282,6 +286,10 @@ func setKubernetesClusterDeploymentTarget(ctx context.Context, d *schema.Resourc
 
 	if endpointResource.ClusterURL != nil {
 		d.Set("cluster_url", endpointResource.ClusterURL.String())
+	}
+
+	if endpointResource.Authentication == nil {
+		return nil
 	}
 
 	switch endpointResource.Authentication.GetAuthenticationType() {

--- a/octopusdeploy/schema_listening_tentacle_deployment_target.go
+++ b/octopusdeploy/schema_listening_tentacle_deployment_target.go
@@ -39,11 +39,16 @@ func flattenListeningTentacleDeploymentTarget(deploymentTarget *machines.Deploym
 	}
 
 	flattenedDeploymentTarget := flattenDeploymentTarget(deploymentTarget)
-	endpointResource, _ := machines.ToEndpointResource(deploymentTarget.Endpoint)
+	endpointResource, err := machines.ToEndpointResource(deploymentTarget.Endpoint)
+	if err != nil || endpointResource == nil {
+		return flattenedDeploymentTarget
+	}
 	flattenedDeploymentTarget["certificate_signature_algorithm"] = endpointResource.CertificateSignatureAlgorithm
 	flattenedDeploymentTarget["proxy_id"] = endpointResource.ProxyID
 	flattenedDeploymentTarget["tentacle_version_details"] = flattenTentacleVersionDetails(endpointResource.TentacleVersionDetails)
-	flattenedDeploymentTarget["tentacle_url"] = endpointResource.URI.String()
+	if endpointResource.URI != nil {
+		flattenedDeploymentTarget["tentacle_url"] = endpointResource.URI.String()
+	}
 	return flattenedDeploymentTarget
 }
 

--- a/octopusdeploy/schema_project_scheduled_trigger.go
+++ b/octopusdeploy/schema_project_scheduled_trigger.go
@@ -35,10 +35,14 @@ func flattenProjectScheduledTrigger(projectScheduledTrigger *triggers.ProjectTri
 	} else if actionType == actions.DeployNewRelease {
 		deployNewReleaseAction := projectScheduledTrigger.Action.(*actions.DeployNewReleaseAction)
 		flattenedProjectScheduledTrigger["tenant_ids"] = deployNewReleaseAction.Tenants
+		gitReference := ""
+		if deployNewReleaseAction.VersionControlReference != nil {
+			gitReference = deployNewReleaseAction.VersionControlReference.GitRef
+		}
 		flattenedProjectScheduledTrigger["deploy_new_release_action"] = []map[string]interface{}{
 			{
 				"destination_environment_id": deployNewReleaseAction.Environment,
-				"git_reference":              deployNewReleaseAction.VersionControlReference.GitRef,
+				"git_reference":              gitReference,
 			},
 		}
 	} else if actionType == actions.RunRunbook {
@@ -79,13 +83,17 @@ func flattenProjectScheduledTrigger(projectScheduledTrigger *triggers.ProjectTri
 		flattenedProjectScheduledTrigger["timezone"] = continuousDailyScheduleFilter.TimeZone
 	} else if filterType == filters.DaysPerMonthSchedule {
 		daysPerMonthScheduleFilter := projectScheduledTrigger.Filter.(*filters.DaysPerMonthScheduledTriggerFilter)
+		dayOfWeek := ""
+		if daysPerMonthScheduleFilter.Day != nil {
+			dayOfWeek = daysPerMonthScheduleFilter.Day.String()
+		}
 		flattenedProjectScheduledTrigger["days_per_month_schedule"] = []map[string]interface{}{
 			{
 				"start_time":            daysPerMonthScheduleFilter.Start.Format(filters.RFC3339NanoNoZone),
 				"monthly_schedule_type": daysPerMonthScheduleFilter.MonthlySchedule.String(),
 				"date_of_month":         daysPerMonthScheduleFilter.DateOfMonth,
 				"day_number_of_month":   daysPerMonthScheduleFilter.DayNumberOfMonth,
-				"day_of_week":           filters.Weekday.String(*daysPerMonthScheduleFilter.Day),
+				"day_of_week":           dayOfWeek,
 			},
 		}
 		flattenedProjectScheduledTrigger["timezone"] = daysPerMonthScheduleFilter.TimeZone

--- a/octopusdeploy_framework/resource_deployment_freeze_tenant.go
+++ b/octopusdeploy_framework/resource_deployment_freeze_tenant.go
@@ -3,6 +3,7 @@ package octopusdeploy_framework
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deploymentfreezes"
@@ -150,8 +151,8 @@ func (d *deploymentFreezeTenantResource) Update(ctx context.Context, req resourc
 
 	freeze, err := deploymentfreezes.GetById(d.Client, state.DeploymentFreezeID.ValueString())
 	if err != nil {
-		apiError := err.(*core.APIError)
-		if apiError.StatusCode != http.StatusNotFound {
+		var apiError *core.APIError
+		if !errors.As(err, &apiError) || apiError.StatusCode != http.StatusNotFound {
 			resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
 			return
 		}
@@ -205,11 +206,14 @@ func (d *deploymentFreezeTenantResource) Delete(ctx context.Context, req resourc
 
 	freeze, err := deploymentfreezes.GetById(d.Client, data.DeploymentFreezeID.ValueString())
 	if err != nil {
-		apiError := err.(*core.APIError)
-		if apiError.StatusCode != http.StatusNotFound {
-			resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		var apiError *core.APIError
+		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
+			tflog.Debug(ctx, fmt.Sprintf("deployment freeze (%s) already deleted", data.DeploymentFreezeID.ValueString()))
+			util.Deleted(ctx, tenantDescription)
 			return
 		}
+		resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		return
 	}
 
 	// Remove the tenant scope

--- a/octopusdeploy_framework/resource_deployment_freeze_tenant.go
+++ b/octopusdeploy_framework/resource_deployment_freeze_tenant.go
@@ -152,10 +152,12 @@ func (d *deploymentFreezeTenantResource) Update(ctx context.Context, req resourc
 	freeze, err := deploymentfreezes.GetById(d.Client, state.DeploymentFreezeID.ValueString())
 	if err != nil {
 		var apiError *core.APIError
-		if !errors.As(err, &apiError) || apiError.StatusCode != http.StatusNotFound {
-			resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		if errors.As(err, &apiError) && apiError.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
 			return
 		}
+		resp.Diagnostics.AddError("unable to load deployment freeze", err.Error())
+		return
 	}
 
 	// Remove old scope

--- a/octopusdeploy_framework/resource_project_versioning_strategy.go
+++ b/octopusdeploy_framework/resource_project_versioning_strategy.go
@@ -211,6 +211,13 @@ func mapStateToProjectVersioningStrategy(ctx context.Context, state *schemas.Pro
 }
 
 func mapProjectVersioningStrategyToState(versioningStrategy *projects.VersioningStrategy, state *schemas.ProjectVersioningStrategyModel) {
+	if versioningStrategy == nil {
+		state.DonorPackageStepID = types.StringNull()
+		state.Template = types.StringNull()
+		state.DonorPackage = types.ObjectNull(schemas.ProjectVersioningStrategyDonorPackageAttributeTypes())
+		return
+	}
+
 	if versioningStrategy.DonorPackageStepID != nil {
 		state.DonorPackageStepID = types.StringValue(*versioningStrategy.DonorPackageStepID)
 	} else {

--- a/octopusdeploy_framework/resource_space.go
+++ b/octopusdeploy_framework/resource_space.go
@@ -195,7 +195,11 @@ func (s *spaceResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	// refresh from the api
-	updatedSpace, _ := spaces.GetByID(s.Client, state.ID.ValueString())
+	updatedSpace, err := spaces.GetByID(s.Client, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("unable to re-read space", err.Error())
+		return
+	}
 	tflog.Debug(ctx, fmt.Sprintf("Update: updatedSpace: %+v", updatedSpace))
 
 	// update the plan for the managers teams

--- a/octopusdeploy_framework/resource_tenant_project.go
+++ b/octopusdeploy_framework/resource_tenant_project.go
@@ -86,6 +86,10 @@ func (t *tenantProjectResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	bits := util.SplitCompositeId(data.ID.ValueString())
+	if len(bits) != 3 {
+		resp.Diagnostics.AddError("invalid id", "expected SpaceID:TenantID:ProjectID, got "+data.ID.ValueString())
+		return
+	}
 	spaceID := bits[0]
 	tenantID := bits[1]
 	projectID := bits[2]

--- a/octopusdeploy_framework/schemas/deployment_freeze_validation.go
+++ b/octopusdeploy_framework/schemas/deployment_freeze_validation.go
@@ -41,14 +41,15 @@ func (v daysOfWeekValidator) ValidateList(ctx context.Context, req validator.Lis
 	}
 
 	var days []string
-	req.ConfigValue.ElementsAs(ctx, &days, false)
+	resp.Diagnostics.Append(req.ConfigValue.ElementsAs(ctx, &days, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	for i := 1; i < len(days); i++ {
+	for i := 0; i < len(days); i++ {
 		currentDay := days[i]
-		previousDay := days[i-1]
 
 		currentPos, currentExists := validDays[currentDay]
-		previousPos, previousExists := validDays[previousDay]
 
 		if !currentExists {
 			resp.Diagnostics.AddError(
@@ -58,20 +59,17 @@ func (v daysOfWeekValidator) ValidateList(ctx context.Context, req validator.Lis
 			return
 		}
 
-		if !previousExists {
-			resp.Diagnostics.AddError(
-				"Invalid day of week",
-				fmt.Sprintf("'%s' is not a valid day of week. Must be one of: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday", previousDay),
-			)
-			return
-		}
+		if i > 0 {
+			previousDay := days[i-1]
+			previousPos := validDays[previousDay]
 
-		if currentPos <= previousPos {
-			resp.Diagnostics.AddError(
-				"Invalid day order",
-				fmt.Sprintf("Days of the week must be in order (Sunday through Saturday). Found '%s' after '%s'", currentDay, previousDay),
-			)
-			return
+			if currentPos <= previousPos {
+				resp.Diagnostics.AddError(
+					"Invalid day order",
+					fmt.Sprintf("Days of the week must be in order (Sunday through Saturday). Found '%s' after '%s'", currentDay, previousDay),
+				)
+				return
+			}
 		}
 	}
 }

--- a/octopusdeploy_framework/schemas/retention_policy_validators.go
+++ b/octopusdeploy_framework/schemas/retention_policy_validators.go
@@ -40,19 +40,19 @@ func (r *strategyAttributeValidator) ValidateString(ctx context.Context, req val
 		return
 	}
 
-	if strategy.Equal(types.StringValue("Count")) && (req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown()) {
+	if strategy.Equal(types.StringValue(r.strategy)) && (req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown()) {
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"Missing Required Field",
-			fmt.Sprintf("%s is required when the strategy is 'Count'.", req.Path),
+			fmt.Sprintf("Attribute %s is required when the strategy is '%s'.", req.Path, r.strategy),
 		)
 		return
 	}
-	if strategy.Equal(types.StringValue("Forever")) && !req.ConfigValue.IsNull() {
+	if !strategy.Equal(types.StringValue(r.strategy)) && !req.ConfigValue.IsNull() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"Invalid Field",
-			fmt.Sprintf("%s must not be set when the strategy is 'Forever'.", req.Path),
+			fmt.Sprintf("Attribute %s must not be set when the strategy is '%s'.", req.Path, strategy),
 		)
 		return
 	}

--- a/octopusdeploy_framework/util/util.go
+++ b/octopusdeploy_framework/util/util.go
@@ -374,14 +374,13 @@ func StringSlicesEqual(a, b []string) bool {
 		return false
 	}
 
-	counts := make(map[string]int, len(a))
+	aMap := make(map[string]bool)
 	for _, item := range a {
-		counts[item]++
+		aMap[item] = true
 	}
 
 	for _, item := range b {
-		counts[item]--
-		if counts[item] < 0 {
+		if !aMap[item] {
 			return false
 		}
 	}

--- a/octopusdeploy_framework/util/util.go
+++ b/octopusdeploy_framework/util/util.go
@@ -374,13 +374,14 @@ func StringSlicesEqual(a, b []string) bool {
 		return false
 	}
 
-	aMap := make(map[string]bool)
+	counts := make(map[string]int, len(a))
 	for _, item := range a {
-		aMap[item] = true
+		counts[item]++
 	}
 
 	for _, item := range b {
-		if !aMap[item] {
+		counts[item]--
+		if counts[item] < 0 {
 			return false
 		}
 	}


### PR DESCRIPTION
Closes #286

A review found a set of independent correctness bugs: nil dereferences on optional API fields, unchecked type assertions reachable through import, two validators that do not validate what they claim. Each is fixed in place.

### Nil dereferences on optional fields

- `schema_kubernetes_cluster_deployment_target.go`: `Authentication` is a nil interface when the server reports authentication type "None", so `GetAuthenticationType()` panicked. A nil guard is added before the switch in both the flatten and set paths.
- `schema_listening_tentacle_deployment_target.go`: the error from `ToEndpointResource` was ignored and the nil result dereferenced; `URI` was also dereferenced without a guard. Both are now checked.
- `schema_project_scheduled_trigger.go`: `VersionControlReference` (for a DeployNewRelease trigger) and `Day` (for a days-per-month filter) are optional pointers that were dereferenced unconditionally. Both are now guarded.
- `resource_project_versioning_strategy.go`: `mapProjectVersioningStrategyToState` dereferenced a nil versioning strategy, which the provider itself sets to nil for Config-as-Code projects. It now maps to null state and returns.
- `resource_space.go`: the Update path discarded the re-read error and dereferenced the nil space in `getEffectiveTeams`; the error is now checked.

### Panics reachable through import

- `resource_project_deployment_target_trigger.go`: the polymorphic `Action` and `Filter` were asserted without the comma-ok form, so importing a different trigger type panicked. Both are now guarded with a diagnostic.
- `resource_tenant_project.go`: a malformed composite import id produced a slice shorter than three and panicked on index; the length is now checked.
- `resource_deployment_freeze_tenant.go`: Update and Delete asserted `*core.APIError` without comma-ok and fell through on 404, matching the deployment-freeze-project bug fixed separately. Both now use `errors.As` and handle 404 correctly.

### Validators and helpers

- `schemas/deployment_freeze_validation.go`: the day-of-week loop started at index 1, so a single-element list was never validated, and the `ElementsAs` diagnostics were discarded. Both are fixed.
- `schemas/retention_policy_validators.go`: `ValidateString` hardcoded "Count"/"Forever" and ignored the configured strategy, unlike `ValidateInt64`. It now gates on the configured strategy.
- `internal/random.go`: the generator indexed its byte buffer modulo the string length rather than the buffer size, so high bytes were never used and low bytes were read twice, biasing output. It now indexes modulo the buffer size.

### Testing

`go build ./...`, `go vet`, and `gofmt` pass. The remaining vet warnings are pre-existing self-assignments in `resource_team_mappers.go`, untouched here. These paths trigger on optional-field-absent API responses, mismatched imports, and specific validator inputs, which the acceptance tests do not exercise against a live server, so each site was verified by reading it against the go-octopusdeploy field types and the sibling code that already handled the case.

Note: the `StringSlicesEqual` multiset fix originally included here has been removed from this PR; it is covered by a separate, test-backed change.
