### PR TITLE
fix: do not persist planned runbook state after a failed update

### DIFF
--- a/octopusdeploy_framework/resource_runbook.go
+++ b/octopusdeploy_framework/resource_runbook.go
@@ -236,6 +236,7 @@ func (r *runbookTypeResource) Update(ctx context.Context, req resource.UpdateReq
 	updatedRunbook, err = runbooks.Update(r.Config.Client, updatedRunbook)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to update runbook", err.Error())
+		return
 	}
 
 	resp.Diagnostics.Append(plan.RefreshFromApiResponse(ctx, updatedRunbook)...)


### PR DESCRIPTION
Closes #288

`resource_runbook.go` Update recorded a diagnostic when `runbooks.Update` failed but did not return. `RefreshFromApiResponse` returns immediately when the runbook is nil, so the unmodified plan was written to state even though the API call failed. Terraform then held the desired values in state while the server still had the old configuration, and the next plan reported no changes.

The error branch now returns before state is written, matching how the other CRUD methods in this resource handle a failed API call.

### Testing

`go build ./...` passes. This path only triggers when `runbooks.Update` returns an error, which the acceptance tests (the project's only integration harness, and one that needs a live Octopus server) cannot force deterministically, and there is no unit-test harness for framework resources in this repository. The change is a missing `return` in the error branch, matching the pattern already used by Create and by the other resources.
