### PR TITLE
fix: preserve pinned step template package version across applies

### DIFF
--- a/docs/data-sources/community_step_template.md
+++ b/docs/data-sources/community_step_template.md
@@ -58,6 +58,7 @@ Optional:
 
 - `acquisition_location` (String) Acquisition location for the package.
 - `package_id` (String) The ID of the package to use.
+- `version` (String) The version of the package to use. Only applies when the package's `selection_mode` property is `immediate`. Leave unset to leave the package version unpinned. If a version is pinned outside of Terraform (e.g. via the web UI), the pinned value is preserved across applies unless this attribute is explicitly changed.
 
 Read-Only:
 

--- a/docs/data-sources/step_template.md
+++ b/docs/data-sources/step_template.md
@@ -67,6 +67,7 @@ Read-Only:
 - `name` (String)
 - `package_id` (String)
 - `properties` (Object) (see [below for nested schema](#nestedobjatt--step_template--packages--properties))
+- `version` (String)
 
 <a id="nestedobjatt--step_template--packages--properties"></a>
 ### Nested Schema for `step_template.packages.properties`

--- a/docs/resources/community_step_template.md
+++ b/docs/resources/community_step_template.md
@@ -45,6 +45,7 @@ Read-Only:
 - `name` (String) Package name.
 - `package_id` (String) The ID of the package to use.
 - `properties` (Attributes) Properties for the package. (see [below for nested schema](#nestedatt--packages--properties))
+- `version` (String) The version of the package to use. Only applies when the package's `selection_mode` property is `immediate`.
 
 <a id="nestedatt--packages--properties"></a>
 ### Nested Schema for `packages.properties`

--- a/docs/resources/step_template.md
+++ b/docs/resources/step_template.md
@@ -24,6 +24,7 @@ resource "octopusdeploy_step_template" "example" {
       acquisition_location = "Server"
       feed_id = module.predefined.feeds.built_in
       name = "My Scripts"
+      version = "1.0.0"
       properties = {
         extract = "True"
         purpose = ""
@@ -100,6 +101,7 @@ Optional:
 
 - `acquisition_location` (String) Acquisition location for the package.
 - `package_id` (String) The ID of the package to use.
+- `version` (String) The version of the package to use. Only applies when the package's `selection_mode` property is `immediate`. Leave unset to leave the package version unpinned. If a version is pinned outside of Terraform (e.g. via the web UI), the pinned value is preserved across applies unless this attribute is explicitly changed.
 
 Read-Only:
 

--- a/examples/resources/octopusdeploy_step_template/resource.tf
+++ b/examples/resources/octopusdeploy_step_template/resource.tf
@@ -9,6 +9,7 @@ resource "octopusdeploy_step_template" "example" {
       acquisition_location = "Server"
       feed_id = module.predefined.feeds.built_in
       name = "My Scripts"
+      version = "1.0.0"
       properties = {
         extract = "True"
         purpose = ""

--- a/octopusdeploy_framework/resource_step_template.go
+++ b/octopusdeploy_framework/resource_step_template.go
@@ -242,6 +242,7 @@ func mapStepTemplateResourceModelToActionTemplate(ctx context.Context, data sche
 				Properties:          pkgProps,
 				Name:                val.Name.ValueString(),
 				PackageID:           val.PackageID.ValueString(),
+				Version:             val.Version.ValueString(),
 			}
 			pkgRef.ID = val.ID.ValueString()
 			at.Packages[i] = pkgRef
@@ -447,6 +448,7 @@ func convertStepTemplatePackageAttribute(atp packages.PackageReference) (types.O
 		"name":                 types.StringValue(atp.Name),
 		"feed_id":              types.StringValue(atp.FeedID),
 		"package_id":           types.StringValue(atp.PackageID),
+		"version":              types.StringValue(atp.Version),
 		"properties":           props,
 	})
 }
@@ -517,12 +519,12 @@ func validateStepTemplateParameters(ctx context.Context, data *schemas.StepTempl
 	diags := diag.Diagnostics{}
 
 	if data.Parameters.IsUnknown() {
-        return diags
-    }
+		return diags
+	}
 
 	if data.Parameters.IsNull() {
-        return diags
-    }
+		return diags
+	}
 
 	parameters := make([]schemas.StepTemplateParameterType, 0, len(data.Parameters.Elements()))
 	appendDiags := data.Parameters.ElementsAs(ctx, &parameters, false)

--- a/octopusdeploy_framework/resource_step_template_mapping_test.go
+++ b/octopusdeploy_framework/resource_step_template_mapping_test.go
@@ -316,6 +316,94 @@ func TestMapStepTemplateParametersToStateSensitive(t *testing.T) {
 	assert.Equal(t, expectedState, state)
 }
 
+func TestMapStepTemplatePackagesFromStateIncludesVersion(t *testing.T) {
+	ctx := context.Background()
+
+	packageConfig := types.ObjectValueMust(
+		schemas.GetStepTemplatePackageTypeAttributes(),
+		map[string]attr.Value{
+			"id":                   types.StringValue(""),
+			"acquisition_location": types.StringValue("Server"),
+			"name":                 types.StringValue("mypackage"),
+			"feed_id":              types.StringValue("feeds-builtin"),
+			"package_id":           types.StringValue("force"),
+			"version":              types.StringValue("1.2.3"),
+			"properties": types.ObjectValueMust(
+				schemas.GetStepTemplatePackagePropertiesTypeAttributes(),
+				map[string]attr.Value{
+					"extract":                types.StringValue("True"),
+					"package_parameter_name": types.StringValue(""),
+					"purpose":                types.StringValue(""),
+					"selection_mode":         types.StringValue("immediate"),
+				},
+			),
+		},
+	)
+
+	state := schemas.StepTemplateTypeResourceModel{
+		SpaceID:         types.StringValue("Spaces-1"),
+		Name:            types.StringValue("Basic Template"),
+		ActionType:      types.StringValue("Octopus.Script"),
+		StepPackageId:   types.StringValue("Octopus.Script"),
+		Packages:        types.ListValueMust(schemas.StepTemplatePackageObjectType(), []attr.Value{packageConfig}),
+		GitDependencies: types.ListValueMust(schemas.StepTemplateGitDependencyObjectType(), []attr.Value{}),
+		Parameters:      types.ListValueMust(schemas.StepTemplateParameterObjectType(), []attr.Value{}),
+		Properties: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Octopus.Action.Script.ScriptBody": types.StringValue("Write-Host 'Test'"),
+		}),
+	}
+
+	// Act
+	template, diags := mapStepTemplateResourceModelToActionTemplate(ctx, state)
+	assert.False(t, diags.HasError(), "Expected no errors in diagnostics")
+
+	// A pinned package version must be forwarded to the API; omitting it causes
+	// the Octopus Server to clear any version pin configured outside of Terraform.
+	assert.Equal(t, 1, len(template.Packages))
+	assert.Equal(t, "1.2.3", template.Packages[0].Version)
+}
+
+func TestMapStepTemplatePackagesToStateIncludesVersion(t *testing.T) {
+	ctx := context.Background()
+
+	pkgRef := packages.PackageReference{
+		AcquisitionLocation: "Server",
+		Name:                "mypackage",
+		FeedID:              "feeds-builtin",
+		PackageID:           "force",
+		Version:             "1.2.3",
+		Properties: map[string]string{
+			"Extract":              "True",
+			"Purpose":              "",
+			"PackageParameterName": "",
+			"SelectionMode":        "immediate",
+		},
+	}
+	pkgRef.ID = "PackageReferences-1"
+
+	template := &actiontemplates.ActionTemplate{
+		SpaceID:         "Spaces-1",
+		ActionType:      "Octopus.Script",
+		Name:            "Basic Template",
+		Packages:        []packages.PackageReference{pkgRef},
+		GitDependencies: []gitdependencies.GitDependency{},
+		Parameters:      []actiontemplates.ActionTemplateParameter{},
+		Properties:      map[string]core.PropertyValue{},
+	}
+	template.SetID("StepTemplates-22")
+
+	// Act
+	state := schemas.StepTemplateTypeResourceModel{}
+	diags := mapStepTemplateToResourceModel(ctx, &state, template)
+	assert.False(t, diags.HasError(), "Expected no errors in diagnostics")
+
+	packageElements := make([]schemas.StepTemplatePackageType, 0, len(state.Packages.Elements()))
+	diags = state.Packages.ElementsAs(ctx, &packageElements, false)
+	assert.False(t, diags.HasError(), "Expected no errors converting packages from state")
+	assert.Equal(t, 1, len(packageElements))
+	assert.Equal(t, "1.2.3", packageElements[0].Version.ValueString(), "Pinned package version returned by the API must be reflected in state")
+}
+
 func TestStepTemplateParametersValidationWhenNonSensitiveDefaultValueSetForSensitiveControlType(t *testing.T) {
 	ctx := context.Background()
 

--- a/octopusdeploy_framework/resource_step_template_test.go
+++ b/octopusdeploy_framework/resource_step_template_test.go
@@ -20,6 +20,7 @@ type stepTemplatePackageTestData struct {
 	acquisitonLocation string
 	feedID             string
 	name               string
+	version            string
 	properties         stepTemplatePackagePropsTestData
 }
 
@@ -60,6 +61,7 @@ func TestAccOctopusStepTemplateBasic(t *testing.T) {
 				acquisitonLocation: "Server",
 				feedID:             "feeds-builtin",
 				name:               "mypackage",
+				version:            "1.0.0",
 				properties: stepTemplatePackagePropsTestData{
 					extract:       "True",
 					purpose:       "",
@@ -105,12 +107,16 @@ func TestAccOctopusStepTemplateBasic(t *testing.T) {
 				Config: testStepTemplateRunScriptBasic(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(prefix, "name", data.name),
+					resource.TestCheckResourceAttr(prefix, "packages.0.version", data.packages[0].version),
 				),
 			},
 			{
+				// This step changes the name only, leaving packages untouched. The pinned
+				// package version must survive this unrelated apply (see issue #290).
 				Config: testStepTemplateRunScriptUpdate(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(prefix, "name", data.name+"-updated"),
+					resource.TestCheckResourceAttr(prefix, "packages.0.version", data.packages[0].version),
 				),
 			},
 		},
@@ -130,6 +136,7 @@ func testStepTemplateRunScriptBasic(data stepTemplateTestData) string {
 					acquisition_location = "%s"
 					feed_id = "%s"
 					name = "%s"
+					version = "%s"
 					properties = {
 						extract = "%s"
 						purpose = "%s"
@@ -175,6 +182,7 @@ func testStepTemplateRunScriptBasic(data stepTemplateTestData) string {
 		data.packages[0].acquisitonLocation,
 		data.packages[0].feedID,
 		data.packages[0].name,
+		data.packages[0].version,
 		data.packages[0].properties.extract,
 		data.packages[0].properties.purpose,
 		data.packages[0].properties.selectionMode,

--- a/octopusdeploy_framework/schemas/community_step_template.go
+++ b/octopusdeploy_framework/schemas/community_step_template.go
@@ -68,6 +68,7 @@ func PackagesObjectType() map[string]attr.Type {
 		"id":                   types.StringType,
 		"name":                 types.StringType,
 		"package_id":           types.StringType,
+		"version":              types.StringType,
 		"properties": types.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"extract":                types.StringType,
@@ -294,6 +295,11 @@ func GetReadOnlyStepTemplatePackageResourceSchema() rs.ListNestedAttribute {
 					Build(),
 				"package_id": util.ResourceString().
 					Description("The ID of the package to use.").
+					Computed().
+					PlanModifiers(stringplanmodifier.UseStateForUnknown()).
+					Build(),
+				"version": util.ResourceString().
+					Description("The version of the package to use. Only applies when the package's `selection_mode` property is `immediate`.").
 					Computed().
 					PlanModifiers(stringplanmodifier.UseStateForUnknown()).
 					Build(),

--- a/octopusdeploy_framework/schemas/schema.go
+++ b/octopusdeploy_framework/schemas/schema.go
@@ -506,6 +506,15 @@ func GetStepTemplatePackageResourceSchema(resourceType string) resourceSchema.Li
 					Optional().
 					Computed().
 					Build(),
+				"version": resourceSchema.StringAttribute{
+					Description: "The version of the package to use. Only applies when the package's `selection_mode` property is `immediate`. Leave unset to leave the package version unpinned. If a version is pinned outside of Terraform (e.g. via the web UI), the pinned value is preserved across applies unless this attribute is explicitly changed.",
+					Optional:    true,
+					Computed:    true,
+					Default:     stringdefault.StaticString(""),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
 				"properties": resourceSchema.SingleNestedAttribute{
 					Description: "Properties for the package.",
 					Required:    true,

--- a/octopusdeploy_framework/schemas/step_template.go
+++ b/octopusdeploy_framework/schemas/step_template.go
@@ -45,6 +45,7 @@ type StepTemplatePackageType struct {
 	Name                types.String `tfsdk:"name"`
 	FeedID              types.String `tfsdk:"feed_id"`
 	PackageID           types.String `tfsdk:"package_id"`
+	Version             types.String `tfsdk:"version"`
 	Properties          types.Object `tfsdk:"properties"`
 }
 
@@ -210,6 +211,7 @@ func GetStepTemplatePackageTypeAttributes() map[string]attr.Type {
 		"name":                 types.StringType,
 		"feed_id":              types.StringType,
 		"package_id":           types.StringType,
+		"version":              types.StringType,
 		"properties":           types.ObjectType{AttrTypes: GetStepTemplatePackagePropertiesTypeAttributes()},
 	}
 }


### PR DESCRIPTION
octopusdeploy_step_template packages had no version attribute, so Terraform never send the API's Version field. Octopus Server treats an omitted Version as a request to clear its value, so any version pinned outside of Terraform (e.g. via the web UI) is silently wiped out on the next apply.

Adds an optional/computed version attribute that round-trips with the API and preserves the last known value when not explicitly configured, so existing pins survive, while still letting the pin be managed directly from Terraform if desired.

Fixes #290

Tested this against the resource I was having issues with in #290 and it fixed the problem.