### PR TITLE
fix: clone tenant when cloned_from_tenant_id is set

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -18,7 +18,7 @@ This resource manages tenants in Octopus Deploy.
 
 ### Optional
 
-- `cloned_from_tenant_id` (String) The ID of the tenant from which this tenant was cloned.
+- `cloned_from_tenant_id` (String) The ID of the tenant from which this tenant was cloned. Changing this forces a new tenant to be created.
 - `description` (String) The description of this tenant.
 - `is_disabled` (Boolean) The disabled status of this tenant.
 - `space_id` (String) The space ID associated with this tenant.

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -18,7 +18,7 @@ This resource manages tenants in Octopus Deploy.
 
 ### Optional
 
-- `cloned_from_tenant_id` (String) The ID of the tenant from which this tenant was cloned. Changing this forces a new tenant to be created.
+- `cloned_from_tenant_id` (String) The ID of an existing tenant to clone this tenant from. Can only be set at creation time; changing it destroys and recreates this tenant.
 - `description` (String) The description of this tenant.
 - `is_disabled` (Boolean) The disabled status of this tenant.
 - `space_id` (String) The space ID associated with this tenant.

--- a/octopusdeploy_framework/resource_tenant.go
+++ b/octopusdeploy_framework/resource_tenant.go
@@ -55,7 +55,12 @@ func (r *tenantTypeResource) Create(ctx context.Context, req resource.CreateRequ
 
 	tflog.Info(ctx, fmt.Sprintf("creating Tenant: %s", tenant.Name))
 
-	createdTenant, err := tenants.Add(r.Config.Client, tenant)
+	var createdTenant *tenants.Tenant
+	if data.ClonedFromTenantId.ValueString() != "" {
+		createdTenant, err = r.cloneTenant(ctx, data, tenant)
+	} else {
+		createdTenant, err = tenants.Add(r.Config.Client, tenant)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("unable to create tenant", err.Error())
 		return
@@ -65,6 +70,43 @@ func (r *tenantTypeResource) Create(ctx context.Context, req resource.CreateRequ
 
 	tflog.Info(ctx, fmt.Sprintf("Tenant created (%s)", data.ID))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// cloneTenant clones an existing tenant, then applies the configured values the clone endpoint does not accept.
+func (r *tenantTypeResource) cloneTenant(ctx context.Context, data *schemas.TenantModel, tenant *tenants.Tenant) (*tenants.Tenant, error) {
+	octopus := r.Config.Client
+	if tenant.SpaceID != "" && tenant.SpaceID != octopus.GetSpaceID() {
+		spaceClient, err := getClientForSpace(r.Config, ctx, tenant.SpaceID)
+		if err != nil {
+			return nil, err
+		}
+		octopus = spaceClient
+	}
+
+	source := &tenants.Tenant{}
+	source.ID = data.ClonedFromTenantId.ValueString()
+
+	tflog.Info(ctx, fmt.Sprintf("cloning Tenant from (%s)", source.GetID()))
+
+	clonedTenant, err := octopus.Tenants.Clone(source, tenants.TenantCloneRequest{
+		Name:        tenant.Name,
+		Description: tenant.Description,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	tenant.ID = clonedTenant.GetID()
+	tenant.SpaceID = clonedTenant.SpaceID
+	tenant.ProjectEnvironments = clonedTenant.ProjectEnvironments
+	if data.TenantTags.IsUnknown() {
+		tenant.TenantTags = clonedTenant.TenantTags
+	}
+	if data.IsDisabled.IsUnknown() {
+		tenant.IsDisabled = clonedTenant.IsDisabled
+	}
+
+	return tenants.Update(r.Config.Client, tenant)
 }
 
 func (r *tenantTypeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -171,13 +213,7 @@ func mapTenantToState(ctx context.Context, data *schemas.TenantModel, tenant *te
 	data.IsDisabled = types.BoolValue(tenant.IsDisabled)
 	data.SpaceID = types.StringValue(tenant.SpaceID)
 	data.Name = types.StringValue(tenant.Name)
-
-	convertedTenantTags, diags := util.SetToStringArray(ctx, data.TenantTags)
-	if diags.HasError() {
-		tflog.Error(ctx, fmt.Sprintf("Error converting tenant tags: %v\n", diags))
-	}
-
-	data.TenantTags = basetypes.SetValue(util.FlattenStringList(convertedTenantTags))
+	data.TenantTags = basetypes.SetValue(util.FlattenStringList(tenant.TenantTags))
 }
 
 func (*tenantTypeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/octopusdeploy_framework/resource_tenant_test.go
+++ b/octopusdeploy_framework/resource_tenant_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"strconv"
 	"testing"
@@ -54,6 +55,91 @@ func TestAccTenantBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccTenantClone(t *testing.T) {
+	firstSourceLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	secondSourceLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	description := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	firstSourceResourceName := "octopusdeploy_tenant." + firstSourceLocalName
+	secondSourceResourceName := "octopusdeploy_tenant." + secondSourceLocalName
+	resourceName := "octopusdeploy_tenant." + localName
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy:             testAccTenantCheckDestroy,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testTenantExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttrPair(resourceName, "cloned_from_tenant_id", firstSourceResourceName, "id"),
+					testTenantClonedFrom(resourceName, firstSourceResourceName),
+				),
+				Config: testAccTenantClone(firstSourceLocalName, secondSourceLocalName, localName, name, description, firstSourceLocalName),
+			},
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testTenantExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "cloned_from_tenant_id", secondSourceResourceName, "id"),
+					testTenantClonedFrom(resourceName, secondSourceResourceName),
+				),
+				Config: testAccTenantClone(firstSourceLocalName, secondSourceLocalName, localName, name, description, secondSourceLocalName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccTenantClone(firstSourceLocalName string, secondSourceLocalName string, localName string, name string, description string, cloneFromLocalName string) string {
+	return fmt.Sprintf(`
+	resource "octopusdeploy_tenant" "%s" {
+		name = "%s"
+	}
+
+	resource "octopusdeploy_tenant" "%s" {
+		name = "%s"
+	}
+
+	resource "octopusdeploy_tenant" "%s" {
+		name                  = "%s"
+		description           = "%s"
+		cloned_from_tenant_id = octopusdeploy_tenant.%s.id
+	}`, firstSourceLocalName, firstSourceLocalName, secondSourceLocalName, secondSourceLocalName, localName, name, description, cloneFromLocalName)
+}
+
+func testTenantClonedFrom(prefix string, sourcePrefix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[prefix]
+		if !ok {
+			return fmt.Errorf("Not found: %s", prefix)
+		}
+
+		source, ok := s.RootModule().Resources[sourcePrefix]
+		if !ok {
+			return fmt.Errorf("Not found: %s", sourcePrefix)
+		}
+
+		tenant, err := tenants.GetByID(octoClient, octoClient.GetSpaceID(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if tenant.ClonedFromTenantID != source.Primary.ID {
+			return fmt.Errorf("tenant (%s) was cloned from %q, expected %q", tenant.GetID(), tenant.ClonedFromTenantID, source.Primary.ID)
+		}
+
+		return nil
+	}
 }
 
 func testAccTenantBasic(lifecycleLocalName string, lifecycleName string, projectGroupLocalName string, projectGroupName string, projectLocalName string, projectName string, projectDescription string, environmentLocalName string, environmentName string, localName string, name string, description string, isDisabled bool) string {

--- a/octopusdeploy_framework/schemas/tenant.go
+++ b/octopusdeploy_framework/schemas/tenant.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -138,10 +139,13 @@ func (t TenantSchema) GetResourceSchema() resourceSchema.Schema {
 		Description: "This resource manages tenants in Octopus Deploy.",
 		Attributes: map[string]resourceSchema.Attribute{
 			"cloned_from_tenant_id": resourceSchema.StringAttribute{
-				Description: "The ID of the tenant from which this tenant was cloned.",
+				Description: "The ID of the tenant from which this tenant was cloned. Changing this forces a new tenant to be created.",
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString(""),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": GetDescriptionResourceSchema("tenant"),
 			"id":          GetIdResourceSchema(),

--- a/octopusdeploy_framework/schemas/tenant.go
+++ b/octopusdeploy_framework/schemas/tenant.go
@@ -139,7 +139,7 @@ func (t TenantSchema) GetResourceSchema() resourceSchema.Schema {
 		Description: "This resource manages tenants in Octopus Deploy.",
 		Attributes: map[string]resourceSchema.Attribute{
 			"cloned_from_tenant_id": resourceSchema.StringAttribute{
-				Description: "The ID of the tenant from which this tenant was cloned. Changing this forces a new tenant to be created.",
+				Description: "The ID of an existing tenant to clone this tenant from. Can only be set at creation time; changing it destroys and recreates this tenant.",
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString(""),


### PR DESCRIPTION
Fixes cloning in `octopusdeploy_tenant`, reported against the Go SDK in [go-octopusdeploy#267](https://github.com/OctopusDeploy/go-octopusdeploy/issues/267) but actually a provider bug.

## Problem

Create sent the source tenant as a `ClonedFromTenantId` body property. Octopus expects it as a `clone` query parameter and ignores the body property, so no clone happened. Confirmed against a local server:

| POST | Result |
| --- | --- |
| body `{"ClonedFromTenantId":"Tenants-1"}` | `ClonedFromTenantId: null` |
| `?clone=Tenants-1` | `ClonedFromTenantId: "Tenants-1"` |

Today this surfaces as `Provider produced inconsistent result after apply` — the plan holds the configured ID, the applied value comes back empty.

## Change

- Create now calls the SDK's clone endpoint (`TenantService.Clone`) when `cloned_from_tenant_id` is set, then updates the new tenant with the values the clone request does not accept (`tenant_tags`, `is_disabled`). Unconfigured attributes keep whatever the clone inherited from the source.
- `cloned_from_tenant_id` now forces replacement — cloning only happens on create, so an in-place update could never apply it.
- `mapTenantToState` reads `tenant_tags` from the API response rather than echoing prior state, so tags inherited from the source land in state.

No SDK bump required; `TenantService.Clone` has existed since go-octopusdeploy#176.

## Upgrade note

Configurations that already set `cloned_from_tenant_id` (silently ignored until now) will plan a replacement on the next apply.

## Testing

`TestAccTenantClone` covers the clone linkage and the forced replacement when the source changes. It fails on `main` with the inconsistent-result error and passes here. `TestAccTenantBasic` and `TestAccDataSourceTenants` still pass.

Tag inheritance was verified separately: a clone of a tagged tenant inherits the tags, and `tenant_tags = []` overrides them.